### PR TITLE
feat(scripts): create script to filter nearby gists from contract

### DIFF
--- a/contracts/package-lock.json
+++ b/contracts/package-lock.json
@@ -4,9 +4,13 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "ethers": "^6.15.0",
+        "haversine-distance": "^1.2.4"
+      },
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^6.1.0",
-        "dotenv": "^17.2.0",
+        "dotenv": "^17.2.1",
         "hardhat": "^2.26.0"
       }
     },
@@ -14,9 +18,7 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -1754,9 +1756,7 @@
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -2900,9 +2900,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
-      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -3225,7 +3225,6 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.15.0.tgz",
       "integrity": "sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3237,7 +3236,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -3255,9 +3253,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -3269,9 +3265,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -3283,9 +3277,7 @@
       "version": "22.7.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -3294,25 +3286,19 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/ethers/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ethers/node_modules/ws": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4272,6 +4258,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/haversine-distance": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/haversine-distance/-/haversine-distance-1.2.4.tgz",
+      "integrity": "sha512-8MHQBQXR7GXZJIvitCf/ux+gwLtWOxmXNNz5dReG+jJbuvaEoj6QIXlaIO3cPr433BFWM4jececJaLYpwxnZhg==",
+      "license": "MIT"
     },
     "node_modules/he": {
       "version": "1.2.0",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,11 @@
 {
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^6.1.0",
-    "dotenv": "^17.2.0",
+    "dotenv": "^17.2.1",
     "hardhat": "^2.26.0"
+  },
+  "dependencies": {
+    "ethers": "^6.15.0",
+    "haversine-distance": "^1.2.4"
   }
 }

--- a/contracts/scripts/filterGists.js
+++ b/contracts/scripts/filterGists.js
@@ -96,7 +96,13 @@ async function main() {
     console.log("---------------------------------");
 }
 
-main().catch(error => {
-    console.error(error);
-    process.exit(1);
-});
+
+
+module.exports = { filterGists, main };
+
+if (require.main === module) {
+    main().catch(error => {
+        console.error(error);
+        process.exit(1);
+    });
+}

--- a/contracts/test/filterGists.js
+++ b/contracts/test/filterGists.js
@@ -1,0 +1,102 @@
+require('dotenv').config();
+const { ethers } = require('ethers');
+const haversine = require('haversine-distance');
+
+// --- Contract Setup ---
+const GIST_CONTRACT_ABI = [
+    "function getGists() view returns (tuple(uint256 id, string message, int256 lat, int256 lon, uint256 expiration)[] memory)"
+];
+
+// Load from environment variables
+const GIST_CONTRACT_ADDRESS = process.env.CONTRACT_ADDRESS;
+const RPC_URL = process.env.RPC_URL;
+
+if (!GIST_CONTRACT_ADDRESS || !RPC_URL) {
+    console.error("Error: Please set CONTRACT_ADDRESS and RPC_URL in your .env file.");
+    process.exit(1);
+}
+
+// --- Mock Data for Testing ---
+const USE_MOCK_DATA = false;
+const MOCK_GISTS = [
+    { id: 1, message: "Gist near Abuja (active)", lat: 90678, lon: 73996, expiration: Math.floor(Date.now() / 1000) + 3600 },
+    { id: 2, message: "Gist far from Abuja", lat: 65344, lon: 33779, expiration: Math.floor(Date.now() / 1000) + 3600 },
+    { id: 3, message: "Gist near Abuja (expired)", lat: 90670, lon: 74000, expiration: Math.floor(Date.now() / 1000) - 3600 },
+    { id: 4, message: "Another Gist near Abuja", lat: 90800, lon: 74100, expiration: Math.floor(Date.now() / 1000) + 7200 },
+];
+
+async function main() {
+    console.log("🔍 Starting gist filtering script...");
+
+    // Mock user location (e.g., Abuja) and search radius
+    const userLocation = { lat: 9.0765, lng: 7.3986 };
+    const searchRadiusKm = 10;
+    console.log(`Searching within ${searchRadiusKm}km of Lat: ${userLocation.lat}, Lon: ${userLocation.lng}`);
+
+    let allGistsRaw;
+
+    if (USE_MOCK_DATA) {
+        console.log("Using mock data for demonstration.");
+        allGistsRaw = MOCK_GISTS;
+    } else {
+        try {
+            console.log("Connecting to blockchain provider...");
+            const provider = new ethers.JsonRpcProvider(RPC_URL);
+            const contract = new ethers.Contract(GIST_CONTRACT_ADDRESS, GIST_CONTRACT_ABI, provider);
+
+            console.log("Fetching all gists from the contract...");
+            allGistsRaw = await contract.getGists();
+            console.log(`Found ${allGistsRaw.length} total gists on-chain.`);
+        } catch (error) {
+            console.error("❌ Error fetching data from the contract:", error.message);
+            return;
+        }
+    }
+
+    // Convert contract data to a more usable format
+    const allGists = allGistsRaw.map(gist => ({
+        id: Number(gist.id),
+        message: gist.message,
+        lat: Number(gist.lat) / 10000, // Assuming lat/lon are stored as integers
+        lon: Number(gist.lon) / 10000,
+        expiration: Number(gist.expiration),
+    }));
+
+    // --- Filtering Logic ---
+    const nowInSeconds = Math.floor(Date.now() / 1000);
+
+    const filteredGists = allGists.filter(gist => {
+        // 1. Filter by expiration
+        if (gist.expiration < nowInSeconds) {
+            return false; // Gist is expired
+        }
+
+        // 2. Filter by location
+        const gistLocation = { lat: gist.lat, lon: gist.lon };
+        const distanceMeters = haversine(userLocation, gistLocation);
+        const distanceKm = distanceMeters / 1000;
+
+        return distanceKm <= searchRadiusKm;
+    });
+
+    console.log("\n✅ Filtering complete. Results:");
+    console.log("---------------------------------");
+
+    if (filteredGists.length > 0) {
+        filteredGists.forEach(gist => {
+            console.log(`
+  ID:      ${gist.id}
+  Message: "${gist.message}"
+  Coords:  Lat ${gist.lat.toFixed(4)}, Lon ${gist.lon.toFixed(4)}
+            `);
+        });
+    } else {
+        console.log("No active gists found within the specified radius.");
+    }
+    console.log("---------------------------------");
+}
+
+main().catch(error => {
+    console.error(error);
+    process.exit(1);
+});

--- a/contracts/test/filterGists.test.js
+++ b/contracts/test/filterGists.test.js
@@ -1,0 +1,48 @@
+const { expect } = require("chai");
+const { filterGists } = require("../scripts/filterGists");
+
+describe("Gist Filtering Script", function () {
+    const now = Math.floor(Date.now() / 1000);
+    const userLocation = { lat: 9.0765, lng: 7.3986 };
+    const searchRadiusKm = 10;
+
+    // Define mock gists for various scenarios
+    const mockGists = [
+        // #1: Nearby and active (should be included)
+        { id: 1, message: "Nearby, active", lat: 9.07, lon: 7.40, expiration: now + 3600 },
+        // #2: Nearby but expired (should be excluded)
+        { id: 2, message: "Nearby, expired", lat: 9.08, lon: 7.39, expiration: now - 3600 },
+        // #3: Active but too far (should be excluded)
+        { id: 3, message: "Far, active", lat: 6.52, lon: 3.37, expiration: now + 3600 }, // Lagos
+        // #4: Far and expired (should be excluded)
+        { id: 4, message: "Far, expired", lat: 6.53, lon: 3.38, expiration: now - 3600 },
+    ];
+
+    it("should only return gists that are active and within the radius", function () {
+        const filtered = filterGists(mockGists, userLocation, searchRadiusKm);
+
+        // Assertions
+        expect(filtered).to.have.lengthOf(1);
+        expect(filtered[0].id).to.equal(1);
+        expect(filtered[0].message).to.equal("Nearby, active");
+    });
+
+    it("should return an empty array if no gists match", function () {
+        const noMatchingGists = [mockGists[2], mockGists[3]];
+        const filtered = filterGists(noMatchingGists, userLocation, searchRadiusKm);
+
+        expect(filtered).to.be.an('array').that.is.empty;
+    });
+
+    it("should return an empty array if all nearby gists are expired", function () {
+        const allExpiredGists = [mockGists[1]]; // Only the nearby, expired gist
+        const filtered = filterGists(allExpiredGists, userLocation, searchRadiusKm);
+
+        expect(filtered).to.be.an('array').that.is.empty;
+    });
+
+    it("should handle an empty input array gracefully", function () {
+        const filtered = filterGists([], userLocation, searchRadiusKm);
+        expect(filtered).to.be.an('array').that.is.empty;
+    });
+});


### PR DESCRIPTION
This PR introduces a Node.js script that fetches all gists from the smart contract and filters them based on proximity and expiration.

**Key Changes**
- Connects to a blockchain provider using an RPC URL.
- Calls the `getGists()` view function to read all gist data.
- Filters out any gists that have already expired.
- Uses the `haversine` formula to calculate the distance from a mock user location and displays only the gists within a defined radius.

This script is essential for testing the core on-chain functionality and verifying location-based filtering logic. 