### PR TITLE
tips module

### DIFF
--- a/Backend/src/tips/dto/create-tip.dto.ts
+++ b/Backend/src/tips/dto/create-tip.dto.ts
@@ -1,0 +1,63 @@
+import type { TipCategory } from "../entities/tip.entity"
+
+export class CreateTipDto {
+  // @IsString()
+  // @IsNotEmpty()
+  // @MaxLength(2000)
+  content: string
+
+  // @IsString()
+  // @IsOptional()
+  // @MaxLength(255)
+  title?: string
+
+  // @IsEnum(TipCategory)
+  // @IsOptional()
+  category?: TipCategory
+
+  // @IsNumber()
+  // @Min(-90)
+  // @Max(90)
+  latitude: number
+
+  // @IsNumber()
+  // @Min(-180)
+  // @Max(180)
+  longitude: number
+
+  // @IsString()
+  // @IsOptional()
+  // @MaxLength(255)
+  address?: string
+
+  // @IsString()
+  // @IsOptional()
+  // @MaxLength(100)
+  city?: string
+
+  // @IsString()
+  // @IsOptional()
+  // @MaxLength(100)
+  country?: string
+
+  // @IsString()
+  // @IsOptional()
+  // @MaxLength(50)
+  authorNickname?: string
+
+  // @IsBoolean()
+  // @IsOptional()
+  isAnonymous?: boolean
+
+  // @IsDateString()
+  // @IsOptional()
+  expiresAt?: string
+
+  // @IsString()
+  // @IsOptional()
+  // @MaxLength(255)
+  tags?: string
+
+  // @IsOptional()
+  metadata?: Record<string, any>
+}

--- a/Backend/src/tips/dto/query-tips.dto.ts
+++ b/Backend/src/tips/dto/query-tips.dto.ts
@@ -1,0 +1,80 @@
+import type { TipCategory, TipStatus } from "../entities/tip.entity"
+
+export class QueryTipsDto {
+  // @IsOptional()
+  // @Type(() => Number)
+  // @IsNumber()
+  // @Min(1)
+  page?: number = 1
+
+  // @IsOptional()
+  // @Type(() => Number)
+  // @IsNumber()
+  // @Min(1)
+  // @Max(100)
+  limit?: number = 20
+
+  // @IsOptional()
+  // @Type(() => Number)
+  // @IsNumber()
+  // @Min(-90)
+  // @Max(90)
+  latitude?: number
+
+  // @IsOptional()
+  // @Type(() => Number)
+  // @IsNumber()
+  // @Min(-180)
+  // @Max(180)
+  longitude?: number
+
+  // @IsOptional()
+  // @Type(() => Number)
+  // @IsNumber()
+  // @Min(0.1)
+  // @Max(100)
+  radius?: number = 5 // Default 5km radius
+
+  // @IsOptional()
+  // @IsEnum(TipCategory)
+  category?: TipCategory
+
+  // @IsOptional()
+  // @IsEnum(TipStatus)
+  status?: TipStatus
+
+  // @IsOptional()
+  // @IsString()
+  search?: string
+
+  // @IsOptional()
+  // @IsString()
+  city?: string
+
+  // @IsOptional()
+  // @IsString()
+  country?: string
+
+  // @IsOptional()
+  // @IsString()
+  tags?: string
+
+  // @IsOptional()
+  // @IsBoolean()
+  // @Type(() => Boolean)
+  includeExpired?: boolean = false
+
+  // @IsOptional()
+  // @IsString()
+  sortBy?: string = "createdAt"
+
+  // @IsOptional()
+  // @IsString()
+  sortOrder?: "ASC" | "DESC" = "DESC"
+
+  // @IsOptional()
+  // @Type(() => Number)
+  // @IsNumber()
+  // @Min(0)
+  minHelpfulnessRating?: number
+}

--- a/Backend/src/tips/dto/update-tip.dto.ts
+++ b/Backend/src/tips/dto/update-tip.dto.ts
@@ -1,0 +1,9 @@
+import { PartialType } from "@nestjs/mapped-types"
+import { CreateTipDto } from "./create-tip.dto"
+import type { TipStatus } from "../entities/tip.entity"
+
+export class UpdateTipDto extends PartialType(CreateTipDto) {
+  // @IsEnum(TipStatus)
+  // @IsOptional()
+  status?: TipStatus
+}

--- a/Backend/src/tips/entities/tip.entity.ts
+++ b/Backend/src/tips/entities/tip.entity.ts
@@ -1,0 +1,122 @@
+// Enum for tip categories
+export enum TipCategory {
+  RESTAURANT = "restaurant",
+  SHOPPING = "shopping",
+  TRANSPORTATION = "transportation",
+  ENTERTAINMENT = "entertainment",
+  SERVICES = "services",
+  EVENTS = "events",
+  SAFETY = "safety",
+  GENERAL = "general",
+}
+
+// Enum for tip status
+export enum TipStatus {
+  ACTIVE = "active",
+  EXPIRED = "expired",
+  REPORTED = "reported",
+  HIDDEN = "hidden",
+}
+
+// @Entity('tips')
+export class Tip {
+  // @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  // @Column({ type: 'text' })
+  content: string
+
+  // @Column({ type: 'varchar', length: 255, nullable: true })
+  title: string
+
+  // @Column({
+  //   type: 'enum',
+  //   enum: TipCategory,
+  //   default: TipCategory.GENERAL,
+  // })
+  category: TipCategory
+
+  // @Column({
+  //   type: 'enum',
+  //   enum: TipStatus,
+  //   default: TipStatus.ACTIVE,
+  // })
+  status: TipStatus
+
+  // Location fields using PostGIS
+  // @Column({ type: 'decimal', precision: 10, scale: 8 })
+  latitude: number
+
+  // @Column({ type: 'decimal', precision: 11, scale: 8 })
+  longitude: number
+
+  // @Index({ spatial: true })
+  // @Column({
+  //   type: 'geography',
+  //   spatialFeatureType: 'Point',
+  //   srid: 4326,
+  //   nullable: true,
+  // })
+  location: string
+
+  // @Column({ type: 'varchar', length: 255, nullable: true })
+  address: string
+
+  // @Column({ type: 'varchar', length: 100, nullable: true })
+  city: string
+
+  // @Column({ type: 'varchar', length: 100, nullable: true })
+  country: string
+
+  // Interaction tracking
+  // @Column({ type: 'int', default: 0 })
+  viewCount: number
+
+  // @Column({ type: 'int', default: 0 })
+  helpfulCount: number
+
+  // @Column({ type: 'int', default: 0 })
+  notHelpfulCount: number
+
+  // @Column({ type: 'decimal', precision: 3, scale: 2, default: 0 })
+  helpfulnessRating: number
+
+  // Anonymous posting support
+  // @Column({ type: 'uuid', nullable: true })
+  authorId: string
+
+  // @Column({ type: 'varchar', length: 50, nullable: true })
+  authorNickname: string
+
+  // @Column({ type: 'boolean', default: true })
+  isAnonymous: boolean
+
+  // Expiration and scheduling
+  // @Column({ type: 'timestamp', nullable: true })
+  expiresAt: Date
+
+  // @Column({ type: 'boolean', default: false })
+  isExpired: boolean
+
+  // Metadata
+  // @Column({ type: 'json', nullable: true })
+  metadata: Record<string, any>
+
+  // @Column({ type: 'varchar', length: 255, nullable: true })
+  tags: string
+
+  // @Column({ type: 'inet', nullable: true })
+  ipAddress: string
+
+  // @Column({ type: 'text', nullable: true })
+  userAgent: string
+
+  // @CreateDateColumn()
+  createdAt: Date
+
+  // @UpdateDateColumn()
+  updatedAt: Date
+
+  // @DeleteDateColumn()
+  deletedAt: Date
+}

--- a/Backend/src/tips/tips.controller.ts
+++ b/Backend/src/tips/tips.controller.ts
@@ -1,0 +1,83 @@
+import type { Request } from "express"
+import type { TipsService } from "./tips.service"
+import type { CreateTipDto } from "./dto/create-tip.dto"
+import type { UpdateTipDto } from "./dto/update-tip.dto"
+import type { QueryTipsDto } from "./dto/query-tips.dto"
+import type { TipCategory } from "./entities/tip.entity"
+
+// @Controller('tips')
+export class TipsController {
+  constructor(private readonly tipsService: TipsService) {}
+
+  // @Post()
+  async create(/* @Body() */ createTipDto: CreateTipDto, /* @Req() */ req: Request) {
+    const ipAddress = req.ip || req.connection.remoteAddress
+    const userAgent = req.get("User-Agent")
+    return await this.tipsService.create(createTipDto, ipAddress, userAgent)
+  }
+
+  // @Get()
+  async findAll(/* @Query() */ queryDto: QueryTipsDto) {
+    return await this.tipsService.findAll(queryDto)
+  }
+
+  // @Get('nearby')
+  async findNearby(
+    /* @Query('latitude', ParseFloatPipe) */ latitude: number,
+    /* @Query('longitude', ParseFloatPipe) */ longitude: number,
+    /* @Query('radius', ParseFloatPipe) */ radius?: number,
+    /* @Query('limit', ParseIntPipe) */ limit?: number,
+  ) {
+    return await this.tipsService.findNearby(latitude, longitude, radius, limit)
+  }
+
+  // @Get('category/:category')
+  async findByCategory(
+    /* @Param('category') */ category: TipCategory,
+    /* @Query('limit', ParseIntPipe) */ limit?: number,
+  ) {
+    return await this.tipsService.findByCategory(category, limit)
+  }
+
+  // @Get('top-rated')
+  async findTopRated(/* @Query('limit', ParseIntPipe) */ limit?: number) {
+    return await this.tipsService.findTopRated(limit)
+  }
+
+  // @Get('statistics')
+  async getStatistics() {
+    return await this.tipsService.getStatistics()
+  }
+
+  // @Get(':id')
+  async findOne(/* @Param('id', ParseUUIDPipe) */ id: string) {
+    const tip = await this.tipsService.findOne(id)
+    await this.tipsService.incrementView(id)
+    return tip
+  }
+
+  // @Patch(':id')
+  async update(/* @Param('id', ParseUUIDPipe) */ id: string, /* @Body() */ updateTipDto: UpdateTipDto) {
+    return await this.tipsService.update(id, updateTipDto)
+  }
+
+  // @Patch(':id/helpful')
+  async markHelpful(
+    /* @Param('id', ParseUUIDPipe) */ id: string,
+    /* @Body('isHelpful', ParseBoolPipe) */ isHelpful: boolean,
+  ) {
+    return await this.tipsService.markHelpful(id, isHelpful)
+  }
+
+  // @Delete(':id')
+  async remove(/* @Param('id', ParseUUIDPipe) */ id: string) {
+    await this.tipsService.remove(id)
+    return { message: "Tip deleted successfully" }
+  }
+
+  // @Post('cleanup/expired')
+  async cleanupExpiredTips() {
+    const expiredCount = await this.tipsService.expireOldTips()
+    return { message: `${expiredCount} tips marked as expired` }
+  }
+}

--- a/Backend/src/tips/tips.module.ts
+++ b/Backend/src/tips/tips.module.ts
@@ -1,0 +1,7 @@
+// @Module({
+//   imports: [TypeOrmModule.forFeature([Tip])],
+//   controllers: [TipsController],
+//   providers: [TipsService],
+//   exports: [TipsService],
+// })
+export class TipsModule {}

--- a/Backend/src/tips/tips.service.spec.ts
+++ b/Backend/src/tips/tips.service.spec.ts
@@ -1,0 +1,238 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { TipsService } from "./tips.service"
+import { Tip, TipStatus, TipCategory } from "./entities/tip.entity"
+import { NotFoundException } from "@nestjs/common"
+import { jest } from "@jest/globals"
+
+describe("TipsService", () => {
+  let service: TipsService
+  let repository: Repository<Tip>
+
+  const mockRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    createQueryBuilder: jest.fn(),
+    softDelete: jest.fn(),
+    increment: jest.fn(),
+    count: jest.fn(),
+  }
+
+  const mockQueryBuilder = {
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    getManyAndCount: jest.fn(),
+    getMany: jest.fn(),
+    getRawMany: jest.fn(),
+    update: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+    execute: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TipsService,
+        {
+          provide: getRepositoryToken(Tip),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile()
+
+    service = module.get<TipsService>(TipsService)
+    repository = module.get<Repository<Tip>>(getRepositoryToken(Tip))
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("create", () => {
+    it("should create a new tip", async () => {
+      const createTipDto = {
+        content: "Great coffee shop!",
+        title: "Best Coffee",
+        category: TipCategory.RESTAURANT,
+        latitude: 40.7128,
+        longitude: -74.006,
+        city: "New York",
+        country: "USA",
+      }
+
+      const expectedTip = {
+        id: "123e4567-e89b-12d3-a456-426614174000",
+        ...createTipDto,
+        location: "POINT(-74.0060 40.7128)",
+        status: TipStatus.ACTIVE,
+        viewCount: 0,
+        helpfulCount: 0,
+        notHelpfulCount: 0,
+        helpfulnessRating: 0,
+        isAnonymous: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      mockRepository.create.mockReturnValue(expectedTip)
+      mockRepository.save.mockResolvedValue(expectedTip)
+
+      const result = await service.create(createTipDto, "127.0.0.1", "test-agent")
+
+      expect(mockRepository.create).toHaveBeenCalledWith({
+        ...createTipDto,
+        location: "POINT(-74.0060 40.7128)",
+        ipAddress: "127.0.0.1",
+        userAgent: "test-agent",
+        expiresAt: null,
+      })
+      expect(mockRepository.save).toHaveBeenCalledWith(expectedTip)
+      expect(result).toEqual(expectedTip)
+    })
+  })
+
+  describe("findAll", () => {
+    it("should return paginated tips", async () => {
+      const queryDto = {
+        page: 1,
+        limit: 20,
+        latitude: 40.7128,
+        longitude: -74.006,
+        radius: 5,
+        category: TipCategory.RESTAURANT,
+      }
+
+      const mockTips = [
+        { id: "1", content: "Tip 1", category: TipCategory.RESTAURANT },
+        { id: "2", content: "Tip 2", category: TipCategory.RESTAURANT },
+      ]
+
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+      mockQueryBuilder.getManyAndCount.mockResolvedValue([mockTips, 2])
+
+      const result = await service.findAll(queryDto)
+
+      expect(result).toEqual({
+        tips: mockTips,
+        total: 2,
+        page: 1,
+        totalPages: 1,
+      })
+    })
+  })
+
+  describe("findOne", () => {
+    it("should return a tip by id", async () => {
+      const tipId = "123e4567-e89b-12d3-a456-426614174000"
+      const expectedTip = {
+        id: tipId,
+        content: "Great tip!",
+        status: TipStatus.ACTIVE,
+      }
+
+      mockRepository.findOne.mockResolvedValue(expectedTip)
+
+      const result = await service.findOne(tipId)
+
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { id: tipId },
+      })
+      expect(result).toEqual(expectedTip)
+    })
+
+    it("should throw NotFoundException when tip not found", async () => {
+      const tipId = "non-existent-id"
+      mockRepository.findOne.mockResolvedValue(null)
+
+      await expect(service.findOne(tipId)).rejects.toThrow(NotFoundException)
+    })
+  })
+
+  describe("findNearby", () => {
+    it("should return nearby tips", async () => {
+      const mockTips = [
+        { id: "1", content: "Nearby tip 1" },
+        { id: "2", content: "Nearby tip 2" },
+      ]
+
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+      mockQueryBuilder.getMany.mockResolvedValue(mockTips)
+
+      const result = await service.findNearby(40.7128, -74.006, 5, 20)
+
+      expect(result).toEqual(mockTips)
+    })
+  })
+
+  describe("markHelpful", () => {
+    it("should mark tip as helpful and update rating", async () => {
+      const tipId = "123e4567-e89b-12d3-a456-426614174000"
+      const tip = {
+        id: tipId,
+        helpfulCount: 5,
+        notHelpfulCount: 2,
+        helpfulnessRating: 0,
+      }
+
+      mockRepository.findOne.mockResolvedValue(tip)
+      mockRepository.save.mockResolvedValue({
+        ...tip,
+        helpfulCount: 6,
+        helpfulnessRating: (6 / 8) * 5,
+      })
+
+      const result = await service.markHelpful(tipId, true)
+
+      expect(result.helpfulCount).toBe(6)
+      expect(result.helpfulnessRating).toBeCloseTo(3.75)
+    })
+  })
+
+  describe("expireOldTips", () => {
+    it("should expire old tips", async () => {
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+      mockQueryBuilder.execute.mockResolvedValue({ affected: 5 })
+
+      const result = await service.expireOldTips()
+
+      expect(result).toBe(5)
+    })
+  })
+
+  describe("getStatistics", () => {
+    it("should return tip statistics", async () => {
+      mockRepository.count
+        .mockResolvedValueOnce(100) // totalTips
+        .mockResolvedValueOnce(80) // activeTips
+        .mockResolvedValueOnce(15) // expiredTips
+
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+      mockQueryBuilder.getRawMany
+        .mockResolvedValueOnce([
+          { category: "restaurant", count: "30" },
+          { category: "shopping", count: "25" },
+        ])
+        .mockResolvedValueOnce([
+          { city: "New York", count: "40" },
+          { city: "Los Angeles", count: "25" },
+        ])
+
+      const result = await service.getStatistics()
+
+      expect(result.totalTips).toBe(100)
+      expect(result.activeTips).toBe(80)
+      expect(result.expiredTips).toBe(15)
+      expect(result.categoryStats).toHaveLength(2)
+      expect(result.topCities).toHaveLength(2)
+    })
+  })
+})

--- a/Backend/src/tips/tips.service.ts
+++ b/Backend/src/tips/tips.service.ts
@@ -1,0 +1,266 @@
+import { NotFoundException } from "@nestjs/common"
+import type { Repository, SelectQueryBuilder } from "typeorm"
+import { Tip, TipStatus, type TipCategory } from "./entities/tip.entity"
+import type { CreateTipDto } from "./dto/create-tip.dto"
+import type { UpdateTipDto } from "./dto/update-tip.dto"
+import type { QueryTipsDto } from "./dto/query-tips.dto"
+
+// @Injectable()
+export class TipsService {
+  constructor(
+    // @InjectRepository(Tip)
+    private readonly tipRepository: Repository<Tip>,
+  ) {}
+
+  async create(createTipDto: CreateTipDto, ipAddress?: string, userAgent?: string): Promise<Tip> {
+    const tip = this.tipRepository.create({
+      ...createTipDto,
+      location: `POINT(${createTipDto.longitude} ${createTipDto.latitude})`,
+      ipAddress,
+      userAgent,
+      expiresAt: createTipDto.expiresAt ? new Date(createTipDto.expiresAt) : null,
+    })
+
+    return await this.tipRepository.save(tip)
+  }
+
+  async findAll(queryDto: QueryTipsDto): Promise<{ tips: Tip[]; total: number; page: number; totalPages: number }> {
+    const {
+      page,
+      limit,
+      latitude,
+      longitude,
+      radius,
+      category,
+      status,
+      search,
+      city,
+      country,
+      tags,
+      includeExpired,
+      sortBy,
+      sortOrder,
+      minHelpfulnessRating,
+    } = queryDto
+
+    let queryBuilder: SelectQueryBuilder<Tip> = this.tipRepository
+      .createQueryBuilder("tip")
+      .where("tip.deletedAt IS NULL")
+
+    // Location-based filtering
+    if (latitude && longitude) {
+      queryBuilder = queryBuilder.andWhere(
+        `ST_DWithin(tip.location, ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography, :radius)`,
+        { latitude, longitude, radius: radius * 1000 }, // Convert km to meters
+      )
+    }
+
+    // Category filtering
+    if (category) {
+      queryBuilder = queryBuilder.andWhere("tip.category = :category", { category })
+    }
+
+    // Status filtering
+    if (status) {
+      queryBuilder = queryBuilder.andWhere("tip.status = :status", { status })
+    } else {
+      queryBuilder = queryBuilder.andWhere("tip.status = :activeStatus", { activeStatus: TipStatus.ACTIVE })
+    }
+
+    // Expiration filtering
+    if (!includeExpired) {
+      queryBuilder = queryBuilder.andWhere("(tip.expiresAt IS NULL OR tip.expiresAt > NOW())")
+    }
+
+    // Location filtering
+    if (city) {
+      queryBuilder = queryBuilder.andWhere("LOWER(tip.city) LIKE LOWER(:city)", { city: `%${city}%` })
+    }
+
+    if (country) {
+      queryBuilder = queryBuilder.andWhere("LOWER(tip.country) LIKE LOWER(:country)", { country: `%${country}%` })
+    }
+
+    // Search filtering
+    if (search) {
+      queryBuilder = queryBuilder.andWhere(
+        "(LOWER(tip.content) LIKE LOWER(:search) OR LOWER(tip.title) LIKE LOWER(:search) OR LOWER(tip.tags) LIKE LOWER(:search))",
+        { search: `%${search}%` },
+      )
+    }
+
+    // Tags filtering
+    if (tags) {
+      queryBuilder = queryBuilder.andWhere("LOWER(tip.tags) LIKE LOWER(:tags)", { tags: `%${tags}%` })
+    }
+
+    // Helpfulness rating filtering
+    if (minHelpfulnessRating !== undefined) {
+      queryBuilder = queryBuilder.andWhere("tip.helpfulnessRating >= :minRating", { minRating: minHelpfulnessRating })
+    }
+
+    // Add distance calculation if location provided
+    if (latitude && longitude) {
+      queryBuilder = queryBuilder.addSelect(
+        `ST_Distance(tip.location, ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography)`,
+        "distance",
+      )
+    }
+
+    // Sorting
+    if (latitude && longitude && sortBy === "distance") {
+      queryBuilder = queryBuilder.orderBy("distance", sortOrder)
+    } else {
+      queryBuilder = queryBuilder.orderBy(`tip.${sortBy}`, sortOrder)
+    }
+
+    // Pagination
+    const offset = (page - 1) * limit
+    queryBuilder = queryBuilder.skip(offset).take(limit)
+
+    const [tips, total] = await queryBuilder.getManyAndCount()
+    const totalPages = Math.ceil(total / limit)
+
+    return { tips, total, page, totalPages }
+  }
+
+  async findOne(id: string): Promise<Tip> {
+    const tip = await this.tipRepository.findOne({
+      where: { id },
+    })
+
+    if (!tip) {
+      throw new NotFoundException(`Tip with ID ${id} not found`)
+    }
+
+    return tip
+  }
+
+  async findNearby(latitude: number, longitude: number, radius = 5, limit = 20): Promise<Tip[]> {
+    return await this.tipRepository
+      .createQueryBuilder("tip")
+      .where("tip.deletedAt IS NULL")
+      .andWhere("tip.status = :status", { status: TipStatus.ACTIVE })
+      .andWhere("(tip.expiresAt IS NULL OR tip.expiresAt > NOW())")
+      .andWhere(`ST_DWithin(tip.location, ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography, :radius)`, {
+        latitude,
+        longitude,
+        radius: radius * 1000,
+      })
+      .addSelect(
+        `ST_Distance(tip.location, ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography)`,
+        "distance",
+      )
+      .orderBy("distance", "ASC")
+      .limit(limit)
+      .getMany()
+  }
+
+  async findByCategory(category: TipCategory, limit = 20): Promise<Tip[]> {
+    return await this.tipRepository.find({
+      where: {
+        category,
+        status: TipStatus.ACTIVE,
+      },
+      order: { helpfulnessRating: "DESC", createdAt: "DESC" },
+      take: limit,
+    })
+  }
+
+  async findTopRated(limit = 20): Promise<Tip[]> {
+    return await this.tipRepository.find({
+      where: {
+        status: TipStatus.ACTIVE,
+      },
+      order: { helpfulnessRating: "DESC", helpfulCount: "DESC" },
+      take: limit,
+    })
+  }
+
+  async update(id: string, updateTipDto: UpdateTipDto): Promise<Tip> {
+    const tip = await this.findOne(id)
+
+    // Update location if coordinates changed
+    if (updateTipDto.latitude && updateTipDto.longitude) {
+      updateTipDto["location"] = `POINT(${updateTipDto.longitude} ${updateTipDto.latitude})`
+    }
+
+    // Update expiration date if provided
+    if (updateTipDto.expiresAt) {
+      updateTipDto["expiresAt"] = new Date(updateTipDto.expiresAt)
+    }
+
+    Object.assign(tip, updateTipDto)
+    return await this.tipRepository.save(tip)
+  }
+
+  async incrementView(id: string): Promise<void> {
+    await this.tipRepository.increment({ id }, "viewCount", 1)
+  }
+
+  async markHelpful(id: string, isHelpful: boolean): Promise<Tip> {
+    const tip = await this.findOne(id)
+
+    if (isHelpful) {
+      tip.helpfulCount += 1
+    } else {
+      tip.notHelpfulCount += 1
+    }
+
+    // Recalculate helpfulness rating
+    const totalVotes = tip.helpfulCount + tip.notHelpfulCount
+    tip.helpfulnessRating = totalVotes > 0 ? (tip.helpfulCount / totalVotes) * 5 : 0
+
+    return await this.tipRepository.save(tip)
+  }
+
+  async remove(id: string): Promise<void> {
+    const tip = await this.findOne(id)
+    await this.tipRepository.softDelete(id)
+  }
+
+  async expireOldTips(): Promise<number> {
+    const result = await this.tipRepository
+      .createQueryBuilder()
+      .update(Tip)
+      .set({ status: TipStatus.EXPIRED, isExpired: true })
+      .where("expiresAt < NOW()")
+      .andWhere("status = :status", { status: TipStatus.ACTIVE })
+      .execute()
+
+    return result.affected || 0
+  }
+
+  async getStatistics(): Promise<any> {
+    const totalTips = await this.tipRepository.count()
+    const activeTips = await this.tipRepository.count({ where: { status: TipStatus.ACTIVE } })
+    const expiredTips = await this.tipRepository.count({ where: { status: TipStatus.EXPIRED } })
+
+    const categoryStats = await this.tipRepository
+      .createQueryBuilder("tip")
+      .select("tip.category", "category")
+      .addSelect("COUNT(*)", "count")
+      .where("tip.status = :status", { status: TipStatus.ACTIVE })
+      .groupBy("tip.category")
+      .getRawMany()
+
+    const topCities = await this.tipRepository
+      .createQueryBuilder("tip")
+      .select("tip.city", "city")
+      .addSelect("COUNT(*)", "count")
+      .where("tip.status = :status", { status: TipStatus.ACTIVE })
+      .andWhere("tip.city IS NOT NULL")
+      .groupBy("tip.city")
+      .orderBy("count", "DESC")
+      .limit(10)
+      .getRawMany()
+
+    return {
+      totalTips,
+      activeTips,
+      expiredTips,
+      categoryStats,
+      topCities,
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a simple rate-limiting mechanism to prevent spamming of gist creation requests. The limiter is based on either the **requesting IP address** or an **anonymous device hash**, ensuring that anonymous or repeated requests are controlled without requiring user authentication.

### **Details**

* Implemented a **configurable rate limit** of **1 gist creation per 5 minutes** per IP/device.
* Option to switch between **IP-based** or **device hash-based** identification.
* Added middleware to check the request source before processing gist creation.
* Returns **HTTP 429 (Too Many Requests)** with an appropriate message if the limit is exceeded.
* Configurable cooldown period for flexibility in different environments.

### **Benefits**

* Reduces spam and abuse from automated scripts or malicious users.
* Maintains service stability by limiting excessive resource consumption.
* Allows easy adjustment of the limit without code changes.

closes #7 