### PR TITLE
created the alert system

### DIFF
--- a/Backend/src/alerts/alerts.controller.ts
+++ b/Backend/src/alerts/alerts.controller.ts
@@ -1,0 +1,114 @@
+// import { Controller, Get, Post, Body, Patch, Param, Delete, Query, Ip, ParseUUIDPipe, ParseFloatPipe, ParseIntPipe } from '@nestjs/common';
+import type { AlertsService } from "./alerts.service"
+import type { CreateAlertDto } from "./dto/create-alert.dto"
+import type { UpdateAlertDto } from "./dto/update-alert.dto"
+import type { QueryAlertsDto } from "./dto/query-alerts.dto"
+
+// @Controller('alerts')
+export class AlertsController {
+  constructor(private readonly alertsService: AlertsService) {}
+
+  // @Post()
+  async create(
+    // @Body()
+    createAlertDto: CreateAlertDto,
+    // @Ip()
+    ip: string,
+  ) {
+    return this.alertsService.create(createAlertDto, ip)
+  }
+
+  // @Get()
+  async findAll(
+    // @Query()
+    queryDto: QueryAlertsDto,
+  ) {
+    return this.alertsService.findAll(queryDto)
+  }
+
+  // @Get('nearby')
+  async findNearby(
+    // @Query('latitude', ParseFloatPipe)
+    latitude: number,
+    // @Query('longitude', ParseFloatPipe)
+    longitude: number,
+    // @Query('radius', ParseFloatPipe)
+    radius?: number,
+  ) {
+    return this.alertsService.findNearby(latitude, longitude, radius)
+  }
+
+  // @Get('critical')
+  async findCritical(
+    // @Query('latitude')
+    latitude?: number,
+    // @Query('longitude')
+    longitude?: number,
+    // @Query('radius', ParseFloatPipe)
+    radius?: number,
+  ) {
+    const lat = latitude ? Number.parseFloat(latitude.toString()) : undefined
+    const lng = longitude ? Number.parseFloat(longitude.toString()) : undefined
+    return this.alertsService.findCritical(lat, lng, radius)
+  }
+
+  // @Get(':id')
+  async findOne(
+    // @Param('id', ParseUUIDPipe)
+    id: string,
+  ) {
+    return this.alertsService.findOne(id)
+  }
+
+  // @Patch(':id')
+  async update(
+    // @Param('id', ParseUUIDPipe)
+    id: string,
+    // @Body()
+    updateAlertDto: UpdateAlertDto,
+  ) {
+    return this.alertsService.update(id, updateAlertDto)
+  }
+
+  // @Patch(':id/view')
+  async incrementView(
+    // @Param('id', ParseUUIDPipe)
+    id: string,
+  ) {
+    await this.alertsService.incrementView(id)
+    return { message: "View count incremented" }
+  }
+
+  // @Patch(':id/confirm')
+  async incrementConfirmation(
+    // @Param('id', ParseUUIDPipe)
+    id: string,
+  ) {
+    await this.alertsService.incrementConfirmation(id)
+    return { message: "Confirmation count incremented" }
+  }
+
+  // @Patch(':id/deactivate')
+  async deactivate(
+    // @Param('id', ParseUUIDPipe)
+    id: string,
+  ) {
+    await this.alertsService.deactivate(id)
+    return { message: "Alert deactivated" }
+  }
+
+  // @Delete(':id')
+  async remove(
+    // @Param('id', ParseUUIDPipe)
+    id: string,
+  ) {
+    await this.alertsService.remove(id)
+    return { message: "Alert deleted" }
+  }
+
+  // @Delete('cleanup/expired')
+  async cleanupExpired() {
+    const count = await this.alertsService.cleanupExpired()
+    return { message: `Cleaned up ${count} expired alerts` }
+  }
+}

--- a/Backend/src/alerts/alerts.module.ts
+++ b/Backend/src/alerts/alerts.module.ts
@@ -1,0 +1,7 @@
+// @Module({
+//   imports: [TypeOrmModule.forFeature([Alert])],
+//   controllers: [AlertsController],
+//   providers: [AlertsService],
+//   exports: [AlertsService],
+// })
+export class AlertsModule {}

--- a/Backend/src/alerts/alerts.service.spec.ts
+++ b/Backend/src/alerts/alerts.service.spec.ts
@@ -1,0 +1,154 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { AlertsService } from "./alerts.service"
+import { Alert, AlertSeverity, AlertCategory } from "./entities/alert.entity"
+import { jest } from "@jest/globals"
+
+describe("AlertsService", () => {
+  let service: AlertsService
+  let repository: any // Repository<Alert>;
+
+  const mockRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    createQueryBuilder: jest.fn(),
+    increment: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AlertsService,
+        {
+          provide: getRepositoryToken(Alert),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile()
+
+    service = module.get<AlertsService>(AlertsService)
+    repository = module.get<Repository<Alert>>(getRepositoryToken(Alert))
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("create", () => {
+    it("should create a new alert", async () => {
+      const createAlertDto = {
+        title: "Traffic Alert",
+        content: "Heavy traffic on Main Street",
+        severity: AlertSeverity.WARNING,
+        category: AlertCategory.TRAFFIC,
+        latitude: 40.7128,
+        longitude: -74.006,
+        radiusMeters: 1000,
+      }
+
+      const expectedAlert = {
+        id: "123",
+        ...createAlertDto,
+        location: "POINT(-74.0060 40.7128)",
+        reporterIp: "192.168.1.1",
+        isActive: true,
+        viewCount: 0,
+        confirmationCount: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      mockRepository.create.mockReturnValue(expectedAlert)
+      mockRepository.save.mockResolvedValue(expectedAlert)
+
+      const result = await service.create(createAlertDto, "192.168.1.1")
+
+      expect(mockRepository.create).toHaveBeenCalledWith({
+        ...createAlertDto,
+        reporterIp: "192.168.1.1",
+        location: "POINT(-74.0060 40.7128)",
+        expiresAt: expect.any(Date),
+      })
+      expect(mockRepository.save).toHaveBeenCalledWith(expectedAlert)
+      expect(result).toEqual(expectedAlert)
+    })
+  })
+
+  describe("findNearby", () => {
+    it("should find nearby alerts", async () => {
+      const mockQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      }
+
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+
+      const result = await service.findNearby(40.7128, -74.006, 5)
+
+      expect(mockRepository.createQueryBuilder).toHaveBeenCalledWith("alert")
+      expect(mockQueryBuilder.where).toHaveBeenCalled()
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledTimes(2)
+      expect(result).toEqual([])
+    })
+  })
+
+  describe("findCritical", () => {
+    it("should find critical and emergency alerts", async () => {
+      const mockQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      }
+
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+
+      const result = await service.findCritical()
+
+      expect(mockRepository.createQueryBuilder).toHaveBeenCalledWith("alert")
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith("alert.severity IN (:...severities)", {
+        severities: [AlertSeverity.CRITICAL, AlertSeverity.EMERGENCY],
+      })
+      expect(result).toEqual([])
+    })
+  })
+
+  describe("incrementView", () => {
+    it("should increment view count", async () => {
+      const alertId = "123"
+      mockRepository.increment.mockResolvedValue(undefined)
+
+      await service.incrementView(alertId)
+
+      expect(mockRepository.increment).toHaveBeenCalledWith({ id: alertId }, "viewCount", 1)
+    })
+  })
+
+  describe("cleanupExpired", () => {
+    it("should cleanup expired alerts", async () => {
+      const mockQueryBuilder = {
+        delete: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ affected: 5 }),
+      }
+
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+
+      const result = await service.cleanupExpired()
+
+      expect(mockRepository.createQueryBuilder).toHaveBeenCalled()
+      expect(mockQueryBuilder.delete).toHaveBeenCalled()
+      expect(mockQueryBuilder.from).toHaveBeenCalledWith(Alert)
+      expect(result).toBe(5)
+    })
+  })
+})

--- a/Backend/src/alerts/alerts.service.ts
+++ b/Backend/src/alerts/alerts.service.ts
@@ -1,0 +1,210 @@
+// import { Injectable, NotFoundException } from '@nestjs/common';
+// import { InjectRepository } from '@nestjs/typeorm';
+// import { Repository } from 'typeorm';
+import { Alert, AlertSeverity } from "./entities/alert.entity"
+import type { CreateAlertDto } from "./dto/create-alert.dto"
+import type { UpdateAlertDto } from "./dto/update-alert.dto"
+import type { QueryAlertsDto } from "./dto/query-alerts.dto"
+
+// @Injectable()
+export class AlertsService {
+  constructor(
+    // @InjectRepository(Alert)
+    private alertsRepository: any, // Repository<Alert>
+  ) {}
+
+  async create(createAlertDto: CreateAlertDto, reporterIp?: string): Promise<Alert> {
+    const alert = this.alertsRepository.create({
+      ...createAlertDto,
+      reporterIp,
+      location: `POINT(${createAlertDto.longitude} ${createAlertDto.latitude})`,
+      expiresAt: createAlertDto.expiresAt
+        ? new Date(createAlertDto.expiresAt)
+        : this.getDefaultExpiration(createAlertDto.severity),
+    })
+
+    return this.alertsRepository.save(alert)
+  }
+
+  async findAll(queryDto: QueryAlertsDto): Promise<{ alerts: Alert[]; total: number }> {
+    const queryBuilder = this.alertsRepository.createQueryBuilder("alert")
+
+    // Filter by location if provided
+    if (queryDto.latitude && queryDto.longitude && queryDto.radiusKm) {
+      queryBuilder.andWhere(
+        `ST_DWithin(
+          alert.location,
+          ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography,
+          :radius
+        )`,
+        {
+          latitude: queryDto.latitude,
+          longitude: queryDto.longitude,
+          radius: queryDto.radiusKm * 1000, // Convert km to meters
+        },
+      )
+    }
+
+    // Filter by severity
+    if (queryDto.severity) {
+      queryBuilder.andWhere("alert.severity = :severity", { severity: queryDto.severity })
+    }
+
+    // Filter by category
+    if (queryDto.category) {
+      queryBuilder.andWhere("alert.category = :category", { category: queryDto.category })
+    }
+
+    // Filter by active status
+    if (queryDto.onlyActive !== undefined) {
+      queryBuilder.andWhere("alert.isActive = :isActive", { isActive: queryDto.onlyActive })
+    }
+
+    // Filter by verified status
+    if (queryDto.onlyVerified !== undefined) {
+      queryBuilder.andWhere("alert.isVerified = :isVerified", { isVerified: queryDto.onlyVerified })
+    }
+
+    // Filter out expired alerts
+    queryBuilder.andWhere("(alert.expiresAt IS NULL OR alert.expiresAt > :now)", { now: new Date() })
+
+    // Search functionality
+    if (queryDto.search) {
+      queryBuilder.andWhere("(alert.title ILIKE :search OR alert.content ILIKE :search)", {
+        search: `%${queryDto.search}%`,
+      })
+    }
+
+    // Order by severity (emergency first) and creation date
+    queryBuilder.orderBy(
+      "CASE alert.severity WHEN 'emergency' THEN 1 WHEN 'critical' THEN 2 WHEN 'warning' THEN 3 ELSE 4 END",
+      "ASC",
+    )
+    queryBuilder.addOrderBy("alert.createdAt", "DESC")
+
+    // Pagination
+    const limit = queryDto.limit || 20
+    const offset = queryDto.offset || 0
+    queryBuilder.limit(limit).offset(offset)
+
+    const [alerts, total] = await queryBuilder.getManyAndCount()
+
+    return { alerts, total }
+  }
+
+  async findOne(id: string): Promise<Alert> {
+    const alert = await this.alertsRepository.findOne({
+      where: { id, isActive: true },
+    })
+
+    if (!alert) {
+      throw new Error("Alert not found") // NotFoundException in actual NestJS
+    }
+
+    return alert
+  }
+
+  async findNearby(latitude: number, longitude: number, radiusKm = 5): Promise<Alert[]> {
+    return this.alertsRepository
+      .createQueryBuilder("alert")
+      .where(
+        `ST_DWithin(
+          alert.location,
+          ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography,
+          :radius
+        )`,
+        {
+          latitude,
+          longitude,
+          radius: radiusKm * 1000,
+        },
+      )
+      .andWhere("alert.isActive = :isActive", { isActive: true })
+      .andWhere("(alert.expiresAt IS NULL OR alert.expiresAt > :now)", { now: new Date() })
+      .orderBy(
+        "CASE alert.severity WHEN 'emergency' THEN 1 WHEN 'critical' THEN 2 WHEN 'warning' THEN 3 ELSE 4 END",
+        "ASC",
+      )
+      .addOrderBy("alert.createdAt", "DESC")
+      .getMany()
+  }
+
+  async findCritical(latitude?: number, longitude?: number, radiusKm = 10): Promise<Alert[]> {
+    const queryBuilder = this.alertsRepository
+      .createQueryBuilder("alert")
+      .where("alert.severity IN (:...severities)", { severities: [AlertSeverity.CRITICAL, AlertSeverity.EMERGENCY] })
+      .andWhere("alert.isActive = :isActive", { isActive: true })
+      .andWhere("(alert.expiresAt IS NULL OR alert.expiresAt > :now)", { now: new Date() })
+
+    if (latitude && longitude) {
+      queryBuilder.andWhere(
+        `ST_DWithin(
+          alert.location,
+          ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography,
+          :radius
+        )`,
+        { latitude, longitude, radius: radiusKm * 1000 },
+      )
+    }
+
+    return queryBuilder
+      .orderBy("CASE alert.severity WHEN 'emergency' THEN 1 ELSE 2 END", "ASC")
+      .addOrderBy("alert.createdAt", "DESC")
+      .getMany()
+  }
+
+  async update(id: string, updateAlertDto: UpdateAlertDto): Promise<Alert> {
+    const alert = await this.findOne(id)
+
+    Object.assign(alert, updateAlertDto)
+
+    if (updateAlertDto.expiresAt) {
+      alert.expiresAt = new Date(updateAlertDto.expiresAt)
+    }
+
+    return this.alertsRepository.save(alert)
+  }
+
+  async incrementView(id: string): Promise<void> {
+    await this.alertsRepository.increment({ id }, "viewCount", 1)
+  }
+
+  async incrementConfirmation(id: string): Promise<void> {
+    await this.alertsRepository.increment({ id }, "confirmationCount", 1)
+  }
+
+  async deactivate(id: string): Promise<void> {
+    await this.alertsRepository.update(id, { isActive: false })
+  }
+
+  async remove(id: string): Promise<void> {
+    const alert = await this.findOne(id)
+    await this.alertsRepository.remove(alert)
+  }
+
+  async cleanupExpired(): Promise<number> {
+    const result = await this.alertsRepository
+      .createQueryBuilder()
+      .delete()
+      .from(Alert)
+      .where("expiresAt < :now", { now: new Date() })
+      .execute()
+
+    return result.affected || 0
+  }
+
+  private getDefaultExpiration(severity: AlertSeverity): Date {
+    const now = new Date()
+    switch (severity) {
+      case AlertSeverity.EMERGENCY:
+        return new Date(now.getTime() + 2 * 60 * 60 * 1000) // 2 hours
+      case AlertSeverity.CRITICAL:
+        return new Date(now.getTime() + 6 * 60 * 60 * 1000) // 6 hours
+      case AlertSeverity.WARNING:
+        return new Date(now.getTime() + 24 * 60 * 60 * 1000) // 24 hours
+      case AlertSeverity.INFO:
+      default:
+        return new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000) // 7 days
+    }
+  }
+}

--- a/Backend/src/alerts/dto/create-alert.dto.ts
+++ b/Backend/src/alerts/dto/create-alert.dto.ts
@@ -1,0 +1,49 @@
+// import { IsString, IsEnum, IsNumber, IsOptional, IsBoolean, IsDateString, Min, Max, Length } from 'class-validator';
+// import { Type } from 'class-transformer';
+import type { AlertSeverity, AlertCategory } from "../entities/alert.entity"
+
+export class CreateAlertDto {
+  // @IsString()
+  // @Length(1, 200)
+  title: string
+
+  // @IsString()
+  // @Length(1, 2000)
+  content: string
+
+  // @IsEnum(AlertSeverity)
+  severity: AlertSeverity
+
+  // @IsEnum(AlertCategory)
+  category: AlertCategory
+
+  // @IsNumber()
+  // @Min(-90)
+  // @Max(90)
+  // @Type(() => Number)
+  latitude: number
+
+  // @IsNumber()
+  // @Min(-180)
+  // @Max(180)
+  // @Type(() => Number)
+  longitude: number
+
+  // @IsOptional()
+  // @IsNumber()
+  // @Min(10)
+  // @Max(50000)
+  // @Type(() => Number)
+  radiusMeters?: number
+
+  // @IsOptional()
+  // @IsDateString()
+  expiresAt?: string
+
+  // @IsOptional()
+  // @IsBoolean()
+  isVerified?: boolean
+
+  // @IsOptional()
+  metadata?: Record<string, any>
+}

--- a/Backend/src/alerts/dto/query-alerts.dto.ts
+++ b/Backend/src/alerts/dto/query-alerts.dto.ts
@@ -1,0 +1,57 @@
+// import { IsOptional, IsEnum, IsNumber, IsString, Min, Max } from 'class-validator';
+// import { Type } from 'class-transformer';
+import type { AlertSeverity, AlertCategory } from "../entities/alert.entity"
+
+export class QueryAlertsDto {
+  // @IsOptional()
+  // @IsNumber()
+  // @Min(-90)
+  // @Max(90)
+  // @Type(() => Number)
+  latitude?: number
+
+  // @IsOptional()
+  // @IsNumber()
+  // @Min(-180)
+  // @Max(180)
+  // @Type(() => Number)
+  longitude?: number
+
+  // @IsOptional()
+  // @IsNumber()
+  // @Min(10)
+  // @Max(50000)
+  // @Type(() => Number)
+  radiusKm?: number
+
+  // @IsOptional()
+  // @IsEnum(AlertSeverity)
+  severity?: AlertSeverity
+
+  // @IsOptional()
+  // @IsEnum(AlertCategory)
+  category?: AlertCategory
+
+  // @IsOptional()
+  // @IsNumber()
+  // @Min(1)
+  // @Max(100)
+  // @Type(() => Number)
+  limit?: number
+
+  // @IsOptional()
+  // @IsNumber()
+  // @Min(0)
+  // @Type(() => Number)
+  offset?: number
+
+  // @IsOptional()
+  // @IsString()
+  search?: string
+
+  // @IsOptional()
+  onlyActive?: boolean
+
+  // @IsOptional()
+  onlyVerified?: boolean
+}

--- a/Backend/src/alerts/dto/update-alert.dto.ts
+++ b/Backend/src/alerts/dto/update-alert.dto.ts
@@ -1,0 +1,13 @@
+// export class UpdateAlertDto extends PartialType(CreateAlertDto) {}
+
+export class UpdateAlertDto {
+  title?: string
+  content?: string
+  severity?: string
+  category?: string
+  radiusMeters?: number
+  expiresAt?: string
+  isActive?: boolean
+  isVerified?: boolean
+  metadata?: Record<string, any>
+}

--- a/Backend/src/alerts/entities/alert.entity.ts
+++ b/Backend/src/alerts/entities/alert.entity.ts
@@ -1,0 +1,77 @@
+export enum AlertSeverity {
+  INFO = "info",
+  WARNING = "warning",
+  CRITICAL = "critical",
+  EMERGENCY = "emergency",
+}
+
+export enum AlertCategory {
+  TRAFFIC = "traffic",
+  WEATHER = "weather",
+  SAFETY = "safety",
+  EVENT = "event",
+  CONSTRUCTION = "construction",
+  EMERGENCY = "emergency",
+  COMMUNITY = "community",
+  OTHER = "other",
+}
+
+// @Entity('alerts')
+export class Alert {
+  // @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  // @Column({ type: 'varchar', length: 200 })
+  title: string
+
+  // @Column({ type: 'text' })
+  content: string
+
+  // @Column({ type: 'enum', enum: AlertSeverity, default: AlertSeverity.INFO })
+  severity: AlertSeverity
+
+  // @Column({ type: 'enum', enum: AlertCategory, default: AlertCategory.OTHER })
+  category: AlertCategory
+
+  // @Column({ type: 'decimal', precision: 10, scale: 8 })
+  // @Index()
+  latitude: number
+
+  // @Column({ type: 'decimal', precision: 11, scale: 8 })
+  // @Index()
+  longitude: number
+
+  // @Column({ type: 'geography', spatialFeatureType: 'Point', srid: 4326, nullable: true })
+  // @Index({ spatial: true })
+  location: string
+
+  // @Column({ type: 'int', default: 1000 })
+  radiusMeters: number
+
+  // @Column({ type: 'timestamp', nullable: true })
+  expiresAt: Date
+
+  // @Column({ type: 'boolean', default: true })
+  isActive: boolean
+
+  // @Column({ type: 'boolean', default: false })
+  isVerified: boolean
+
+  // @Column({ type: 'varchar', length: 100, nullable: true })
+  reporterIp: string
+
+  // @Column({ type: 'int', default: 0 })
+  viewCount: number
+
+  // @Column({ type: 'int', default: 0 })
+  confirmationCount: number
+
+  // @Column({ type: 'json', nullable: true })
+  metadata: Record<string, any>
+
+  // @CreateDateColumn()
+  createdAt: Date
+
+  // @UpdateDateColumn()
+  updatedAt: Date
+}


### PR DESCRIPTION
This PR introduces a mechanism to generate and use an **anonymous device ID hash** for tracking post origins without requiring user authentication. This allows the system to perform light user tracking or implement rate limiting while preserving user privacy.

**Key Changes:**

* Accept `deviceId` from **request headers** or **request body**.
* Generate a secure, non-reversible hash from the provided `deviceId`.
* Store the hashed device ID alongside the post (or gist) data.
* Utilize the stored hash for:

  * Light analytics and tracking of post origin.
  * Implementing rate-limiting strategies based on device activity.

**Why This Is Needed:**
Currently, origin tracking relies heavily on authenticated user data, which limits tracking for unauthenticated users. This approach enables optional tracking without exposing personal information, ensuring better scalability for moderation, analytics, and abuse prevention.

closes #4