### PR TITLE
feat(map): implement map component with geolocation and gist markers

### DIFF
--- a/Frontend/src/components/map/AddGistModal.tsx
+++ b/Frontend/src/components/map/AddGistModal.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+interface AddGistModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onAddGist: (content: string) => void;
+}
+
+export default function AddGistModal({
+  isOpen,
+  onClose,
+  onAddGist,
+}: AddGistModalProps) {
+  const [content, setContent] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = () => {
+    if (!content.trim()) return;
+
+    setIsLoading(true);
+    setTimeout(() => {
+      onAddGist(content);
+      setContent('');
+      setIsLoading(false);
+      onClose();
+    }, 2000);
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="absolute inset-0 z-[1000] flex items-end justify-center bg-black/60"
+          onClick={onClose}
+        >
+          <motion.div
+            initial={{ y: '100%' }}
+            animate={{ y: '0%' }}
+            exit={{ y: '100%' }}
+            transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+            className="w-full max-w-lg p-6 bg-white dark:bg-gray-800 rounded-t-2xl shadow-lg"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-xl font-bold mb-4 text-gray-900 dark:text-white">
+              Pin a New Gist
+            </h2>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="What's the gist? (max 280 characters)"
+              maxLength={280}
+              className="w-full p-3 border rounded-lg h-28 bg-gray-50 dark:bg-gray-700 dark:text-white dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <button
+              onClick={handleSubmit}
+              disabled={isLoading}
+              className="w-full mt-4 px-6 py-3 text-lg font-semibold text-white  rounded-lg   bg-gradient-to-r from-purple-600 via-blue-600 to-pink-400 
+                            bg-[size:200%_auto] 
+                            hover:bg-[position:100%_center] 
+                    transition-all duration-500 ease-in-out disabled:bg-blue-400 disabled:cursor-not-allowed"
+            >
+              {isLoading ? 'Pinning...' : 'Pin Gist'}
+            </button>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/Frontend/src/components/map/Map.tsx
+++ b/Frontend/src/components/map/Map.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import { icon } from 'leaflet';
+import { useState, useEffect } from 'react';
+import { Plus } from 'lucide-react';
+import AddGistModal from './AddGistModal';
+import { motion } from 'framer-motion';
+
+export interface Gist {
+  id: number;
+  content: string;
+  lat: number;
+  lng: number;
+}
+
+const greenIcon = icon({
+  iconUrl:
+    'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-green.png',
+  shadowUrl:
+    'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+});
+
+const blueIcon = icon({
+  iconUrl:
+    'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-blue.png',
+  shadowUrl:
+    'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+});
+
+function ChangeView({
+  center,
+  zoom,
+}: {
+  center: [number, number];
+  zoom: number;
+}) {
+  const map = useMap();
+  useEffect(() => {
+    map.flyTo(center, zoom);
+  }, [center]);
+  return null;
+}
+
+export default function Map() {
+  const [position, setPosition] = useState<[number, number]>([6.5244, 3.3792]);
+  const [gists, setGists] = useState<Gist[]>([
+    {
+      id: 1,
+      content: 'Amazing suya spot just opened here!',
+      lat: 6.52,
+      lng: 3.37,
+    },
+    {
+      id: 2,
+      content: 'Heads up, major traffic on this bridge.',
+      lat: 6.53,
+      lng: 3.38,
+    },
+  ]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  useEffect(() => {
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const { latitude, longitude } = pos.coords;
+        setPosition([latitude, longitude]);
+      },
+      (err) => {
+        console.warn(`Geolocation Error (${err.code}): ${err.message}`);
+      }
+    );
+  }, []);
+
+  const handleAddGist = (content: string) => {
+    const newGist: Gist = {
+      id: Date.now(),
+      content,
+      lat: position[0],
+      lng: position[1],
+    };
+    setGists((prevGists) => [...prevGists, newGist]);
+  };
+
+  return (
+    <div className="relative h-full w-full">
+      <MapContainer center={position} zoom={14} className="h-full w-full">
+        <ChangeView center={position} zoom={14} />
+        <TileLayer
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        />
+        <Marker position={position} icon={greenIcon}>
+          <Popup>Your Current Location</Popup>
+        </Marker>
+        {gists.map((gist) => (
+          <Marker key={gist.id} position={[gist.lat, gist.lng]} icon={blueIcon}>
+            <Popup>{gist.content}</Popup>
+          </Marker>
+        ))}
+      </MapContainer>
+
+      <motion.button
+        onClick={() => setIsModalOpen(true)}
+        // 3. Animation props for pulsing effect
+        animate={{ scale: [1, 1.1, 1] }}
+        transition={{ duration: 1.5, repeat: Infinity, ease: 'easeInOut' }}
+        className="absolute top-1/2 left-8 -translate-y-1/2 z-[1000] flex items-center justify-center w-16 h-16  bg-gradient-to-r from-purple-600 via-blue-600 to-navy-400 
+                            bg-[size:200%_auto] 
+                            hover:bg-[position:100%_center] 
+                    transition-all duration-500 ease-in-out disabled:bg-blue-400 disabled:cursor-not-allowed text-white rounded-full shadow-lg hover:bg-blue-700"
+        aria-label="Add new gist"
+      >
+        <Plus size={32} />
+      </motion.button>
+
+      <AddGistModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onAddGist={handleAddGist}
+      />
+    </div>
+  );
+}

--- a/Frontend/src/components/map/MapLoader.tsx
+++ b/Frontend/src/components/map/MapLoader.tsx
@@ -1,13 +1,12 @@
-"use client"; // This marks the component as a Client Component
+'use client'; // This marks the component as a Client Component
 
-import dynamic from "next/dynamic";
-import { useMemo } from "react";
+import dynamic from 'next/dynamic';
+import { useMemo } from 'react';
 
 export default function MapLoader() {
-  // The useMemo and dynamic import logic is now safely inside a Client Component
   const Map = useMemo(
     () =>
-      dynamic(() => import("@/components/Map"), {
+      dynamic(() => import('components/map/Map'), {
         loading: () => <p>Map is loading...</p>,
         ssr: false, // This is allowed here!
       }),


### PR DESCRIPTION
This pull request implements the interactive map page as described in the issue. It adds a new route at /map which displays a Leaflet map centered on the user's current location using the Browser Geolocation API. If geolocation is denied or fails, a fallback location is used. The map uses a free tile provider for rendering. The implementation includes a new Map.tsx component built with react-leaflet, and a MapLoader.tsx component for dynamic import. 

closes #51 