### PR TITLE
feat: add weekly comparison chart

### DIFF
--- a/analytics/components/charts/WeeklyComparisonChart.tsx
+++ b/analytics/components/charts/WeeklyComparisonChart.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import type { TooltipItem } from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+const thisWeek = [142, 158, 175, 161, 189, 110, 95];
+const lastWeek = [130, 144, 160, 155, 172, 102, 88];
+
+export default function WeeklyComparisonChart() {
+  const data = {
+    labels: days,
+    datasets: [
+      {
+        label: 'This Week',
+        data: thisWeek,
+        backgroundColor: 'rgba(99, 102, 241, 0.8)',
+        borderColor: 'rgba(99, 102, 241, 1)',
+        borderWidth: 1,
+        borderRadius: 4,
+      },
+      {
+        label: 'Last Week',
+        data: lastWeek,
+        backgroundColor: 'rgba(156, 163, 175, 0.6)',
+        borderColor: 'rgba(156, 163, 175, 1)',
+        borderWidth: 1,
+        borderRadius: 4,
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    interaction: {
+      mode: 'index' as const,
+      intersect: false,
+    },
+    scales: {
+      x: {
+        grid: { display: false },
+        ticks: { color: '#9ca3af', font: { size: 12 } },
+        border: { color: '#e5e7eb' },
+      },
+      y: {
+        beginAtZero: true,
+        grid: { color: 'rgba(0,0,0,0.05)' },
+        ticks: { color: '#9ca3af', font: { size: 12 } },
+        border: { display: false },
+      },
+    },
+    plugins: {
+      legend: {
+        position: 'top' as const,
+        labels: { usePointStyle: true, pointStyleWidth: 10, padding: 16 },
+      },
+      tooltip: {
+        backgroundColor: 'rgba(17,24,39,0.9)',
+        titleColor: '#f9fafb',
+        bodyColor: '#d1d5db',
+        padding: 12,
+        cornerRadius: 8,
+        callbacks: {
+          label: (item: TooltipItem<'bar'>) =>
+            `  ${item.dataset.label}: ${(item.raw as number).toLocaleString()} gists`,
+        },
+      },
+    },
+  };
+
+  return (
+    <div style={{ position: 'relative', width: '100%' }}>
+      <Bar data={data} options={options} />
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a grouped bar chart comparing gist activity day-by-day for the current week versus the previous week.

closes #124