### PR TITLE
perf: chart memoization, skeletons, progressive loading, next/image

### DIFF
--- a/Frontend/src/components/landing/Features.tsx
+++ b/Frontend/src/components/landing/Features.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React, { useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
 import { Badge } from '../ui/badge';
 import { AnimatedBeam } from "../magicui/animated-beam";
 import { Circle } from './Circle';
@@ -109,7 +110,7 @@ export const Features: React.FC = () => {
                 y={centerY}
                 className="text-white w-16 h-16 sm:w-20 sm:h-20 text-sm font-bold"
               >
-                <img src="gistPin-header-logo.png" alt="Gistpin Icon" className="w-full h-full object-contain" />
+                <Image src="/gistPin-header-logo.png" alt="Gistpin Icon" width={80} height={80} className="object-contain" priority />
               </Circle>
 
               {icons.map(({ Icon, color, x, y, px, py }, index) => (

--- a/analytics/app/page.tsx
+++ b/analytics/app/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { useMemo } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import KPIGrid from '@/components/KPICard';
 import LiveGistCounter from '@/components/LiveGistCounter';
-import ChartSkeleton from '@/components/ui/ChartSkeleton';
+import ChartSkeleton, { KPICardSkeleton } from '@/components/ui/ChartSkeleton';
 import ChartErrorBoundary from '@/components/ui/ChartErrorBoundary';
 import { AnomalyBadge, AnomalySidebar } from '@/components/ui/AnomalyAlerts';
 import { DataQualityBadge } from '@/components/ui/DataQualityBadge';
@@ -12,12 +12,15 @@ import AnnotatedChart from '@/components/ui/AnnotatedChart';
 import { detectAnomalies } from '@/lib/anomaly';
 import { createUserActivityData } from '@/lib/analytics-data';
 
+// Priority 2: simple charts
 const LazyDailyGistsChart = dynamic(() => import('@/components/charts/DailyGistsChart'), {
   loading: () => <ChartSkeleton />,
 });
 const LazyUserAreaChart = dynamic(() => import('@/components/charts/UserAreaChart'), {
   loading: () => <ChartSkeleton />,
 });
+
+// Priority 3: complex visualizations
 const LazyScatterChart = dynamic(() => import('@/components/charts/ScatterChart'), {
   loading: () => <ChartSkeleton />,
 });
@@ -31,8 +34,21 @@ const LazyLocationTable = dynamic(() => import('@/components/ui/LocationTable'),
   loading: () => <ChartSkeleton />,
 });
 
+// Progressive loading stages: 0 = KPIs only, 1 = simple charts, 2 = complex charts
+function useProgressiveLoad() {
+  const [stage, setStage] = useState(0);
+  useEffect(() => {
+    // Stage 1: simple charts after KPIs render
+    const t1 = setTimeout(() => setStage(1), 100);
+    // Stage 2: complex visualizations last
+    const t2 = setTimeout(() => setStage(2), 400);
+    return () => { clearTimeout(t1); clearTimeout(t2); };
+  }, []);
+  return stage;
+}
+
 export default function Page() {
-  // Compute anomalies from user activity data
+  const stage = useProgressiveLoad();
   const activityData = useMemo(() => createUserActivityData(90), []);
   const anomalies = useMemo(
     () => [
@@ -44,10 +60,10 @@ export default function Page() {
 
   return (
     <div className="space-y-6">
-      {/* KPI row */}
+      {/* Priority 1: KPI row — shown immediately */}
       <KPIGrid />
 
-      {/* Live counter + User area chart */}
+      {/* Priority 2: Live counter + User area chart */}
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
         <div className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-gray-900 lg:col-span-1">
           <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
@@ -65,67 +81,90 @@ export default function Page() {
             <AnomalyBadge anomalies={anomalies} chartId="Returning Users" />
             <DataQualityBadge labels={activityData.labels} values={activityData.newUsers} metricName="New Users" />
           </div>
-          <AnnotatedChart chartId="user-area" labels={activityData.labels}>
-            <ChartErrorBoundary title="New vs Returning Users">
-              <LazyUserAreaChart />
-            </ChartErrorBoundary>
-          </AnnotatedChart>
+          {stage >= 1 ? (
+            <AnnotatedChart chartId="user-area" labels={activityData.labels}>
+              <ChartErrorBoundary title="New vs Returning Users">
+                <LazyUserAreaChart />
+              </ChartErrorBoundary>
+            </AnnotatedChart>
+          ) : (
+            <ChartSkeleton />
+          )}
         </div>
       </div>
 
-      {/* Daily gists */}
+      {/* Priority 2: Daily gists */}
       <div className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-gray-900">
         <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
           Daily Gists · Last 30 Days
         </h2>
-        <ChartErrorBoundary title="Daily Gists">
-          <LazyDailyGistsChart />
-        </ChartErrorBoundary>
+        {stage >= 1 ? (
+          <ChartErrorBoundary title="Daily Gists">
+            <LazyDailyGistsChart />
+          </ChartErrorBoundary>
+        ) : (
+          <ChartSkeleton />
+        )}
       </div>
 
-      {/* Charts row */}
+      {/* Priority 3: Complex charts */}
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <div className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-gray-900">
           <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
             Gist Age vs Engagement
           </h2>
-          <ChartErrorBoundary title="Scatter">
-            <LazyScatterChart />
-          </ChartErrorBoundary>
+          {stage >= 2 ? (
+            <ChartErrorBoundary title="Scatter">
+              <LazyScatterChart />
+            </ChartErrorBoundary>
+          ) : (
+            <ChartSkeleton />
+          )}
         </div>
 
         <div className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-gray-900">
           <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
             Platform Usage
           </h2>
-          <ChartErrorBoundary title="Radar">
-            <LazyRadarChart />
-          </ChartErrorBoundary>
+          {stage >= 2 ? (
+            <ChartErrorBoundary title="Radar">
+              <LazyRadarChart />
+            </ChartErrorBoundary>
+          ) : (
+            <ChartSkeleton />
+          )}
         </div>
       </div>
 
-      {/* Bottom row */}
+      {/* Priority 3: Bottom row */}
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <div className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-gray-900">
           <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
             Category Distribution
           </h2>
-          <ChartErrorBoundary title="Category Distribution">
-            <LazyCategoryPieChart />
-          </ChartErrorBoundary>
+          {stage >= 2 ? (
+            <ChartErrorBoundary title="Category Distribution">
+              <LazyCategoryPieChart />
+            </ChartErrorBoundary>
+          ) : (
+            <ChartSkeleton />
+          )}
         </div>
 
         <div className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-gray-900">
           <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
             Active Locations
           </h2>
-          <ChartErrorBoundary title="Locations">
-            <LazyLocationTable />
-          </ChartErrorBoundary>
+          {stage >= 2 ? (
+            <ChartErrorBoundary title="Locations">
+              <LazyLocationTable />
+            </ChartErrorBoundary>
+          ) : (
+            <ChartSkeleton />
+          )}
         </div>
       </div>
 
-      {/* Anomaly sidebar (floating trigger) */}
       <AnomalySidebar anomalies={anomalies} />
     </div>
   );

--- a/analytics/components/KPICard.tsx
+++ b/analytics/components/KPICard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, memo } from 'react';
 import {
   TrendingUp,
   TrendingDown,
@@ -60,7 +60,7 @@ export interface KPICardProps {
 
 // ── KPICard ───────────────────────────────────────────────────────────────────
 
-export function KPICard({
+export const KPICard = memo(function KPICard({
   title,
   value,
   change,
@@ -151,7 +151,7 @@ export function KPICard({
       </div>
     </div>
   );
-}
+});
 
 // ── Default KPI dataset ───────────────────────────────────────────────────────
 

--- a/analytics/components/charts/CategoryPieChart.tsx
+++ b/analytics/components/charts/CategoryPieChart.tsx
@@ -3,31 +3,29 @@
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 import type { TooltipItem } from 'chart.js';
 import { Pie } from 'react-chartjs-2';
+import { memo } from 'react';
 import { useCategoryDataQuery } from '@/lib/analytics-queries';
 import ExportButton from '@/components/ui/ExportButton';
 import { exportRowsToCsv } from '@/lib/export';
+import ChartSkeleton from '@/components/ui/ChartSkeleton';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
-export default function CategoryPieChart() {
+function CategoryPieChart() {
   const { data: categories, isLoading, error } = useCategoryDataQuery();
 
-  if (isLoading || !categories) {
-    return <p>Loading category distribution...</p>;
-  }
+  if (isLoading || !categories) return <ChartSkeleton />;
+  if (error) return <p>Unable to load category distribution.</p>;
 
-  if (error) {
-    return <p>Unable to load category distribution.</p>;
-  }
+  const total = categories.reduce((sum, c) => sum + c.count, 0);
 
-  const total = categories.reduce((sum, category) => sum + category.count, 0);
   const data = {
-    labels: categories.map((category) => category.label),
+    labels: categories.map((c) => c.label),
     datasets: [
       {
-        data: categories.map((category) => category.count),
-        backgroundColor: categories.map((category) => category.color),
-        borderColor: categories.map((category) => category.border),
+        data: categories.map((c) => c.count),
+        backgroundColor: categories.map((c) => c.color),
+        borderColor: categories.map((c) => c.border),
         borderWidth: 2,
         hoverOffset: 16,
       },
@@ -45,15 +43,15 @@ export default function CategoryPieChart() {
           pointStyleWidth: 10,
           generateLabels: (chart: ChartJS) => {
             const dataset = chart.data.datasets[0];
-            return (chart.data.labels as string[]).map((label, index) => {
-              const value = dataset.data[index] as number;
+            return (chart.data.labels as string[]).map((label, i) => {
+              const value = dataset.data[i] as number;
               const pct = ((value / total) * 100).toFixed(1);
               return {
                 text: `${label} (${pct}%)`,
-                fillStyle: (dataset.backgroundColor as string[])[index],
-                strokeStyle: (dataset.borderColor as string[])[index],
-                hidden: !chart.getDataVisibility(index),
-                index,
+                fillStyle: (dataset.backgroundColor as string[])[i],
+                strokeStyle: (dataset.borderColor as string[])[i],
+                hidden: !chart.getDataVisibility(i),
+                index: i,
                 datasetIndex: 0,
                 lineWidth: 2,
                 pointStyle: 'circle' as const,
@@ -61,52 +59,11 @@ export default function CategoryPieChart() {
             });
           },
         },
-        onClick: (
-          _event: unknown,
-          legendItem: { index?: number },
-          legend: { chart: ChartJS },
-        ) => {
+        onClick: (_e: unknown, legendItem: { index?: number }, legend: { chart: ChartJS }) => {
           const index = legendItem.index ?? 0;
-          const chart = legend.chart;
-          chart.toggleDataVisibility(index);
-          chart.update();
+          legend.chart.toggleDataVisibility(index);
+          legend.chart.update();
         },
-const options = {
-  responsive: true,
-  plugins: {
-    legend: {
-      position: 'bottom' as const,
-      labels: {
-        padding: 20,
-        usePointStyle: true,
-        pointStyleWidth: 10,
-        generateLabels: (chart: ChartJS) => {
-          const dataset = chart.data.datasets[0];
-          return (chart.data.labels as string[]).map((label, i) => {
-            const value = (dataset.data[i] as number);
-            const pct = ((value / total) * 100).toFixed(1);
-            return {
-              text: `${label} (${pct}%)`,
-              fillStyle: (dataset.backgroundColor as string[])[i],
-              strokeStyle: (dataset.borderColor as string[])[i],
-              hidden: !chart.getDataVisibility(i),
-              index: i,
-              datasetIndex: 0,
-              lineWidth: 2,
-              pointStyle: 'circle' as const,
-            };
-          });
-        },
-      },
-      onClick: (
-        e: unknown,
-        legendItem: { index?: number },
-        legend: { chart: ChartJS },
-      ) => {
-        const index = legendItem.index ?? 0;
-        const chart = legend.chart;
-        chart.toggleDataVisibility(index);
-        chart.update();
       },
       tooltip: {
         callbacks: {
@@ -126,13 +83,11 @@ const options = {
         onExport={(onProgress) =>
           exportRowsToCsv({
             filenamePrefix: 'category-distribution',
-            filters: {
-              dataset: 'All categories',
-            },
-            rows: categories.map((category) => ({
-              category: category.label,
-              count: category.count,
-              percentage: ((category.count / total) * 100).toFixed(1),
+            filters: { dataset: 'All categories' },
+            rows: categories.map((c) => ({
+              category: c.label,
+              count: c.count,
+              percentage: ((c.count / total) * 100).toFixed(1),
             })),
             onProgress,
           })
@@ -142,3 +97,5 @@ const options = {
     </div>
   );
 }
+
+export default memo(CategoryPieChart);

--- a/analytics/components/charts/DailyGistsChart.tsx
+++ b/analytics/components/charts/DailyGistsChart.tsx
@@ -12,7 +12,7 @@ import {
 } from 'chart.js';
 import type { Plugin, TooltipItem } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import { useRef, useMemo } from 'react';
+import { memo, useCallback, useEffect, useRef, useMemo } from 'react';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Filler, Tooltip, Legend);
 
@@ -71,9 +71,32 @@ function sparseLabels(labels: string[]): (string | null)[] {
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
-export default function DailyGistsChart() {
+function DailyGistsChart() {
   const chartRef = useRef<ChartJS<'line'>>(null);
   const points = useMemo(() => generateLast30Days(), []);
+  const rafRef = useRef<number | null>(null);
+
+  // Debounced resize with requestAnimationFrame (issue #147)
+  const handleResize = useCallback(() => {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(() => {
+      chartRef.current?.resize();
+    });
+  }, []);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    const debounced = () => {
+      clearTimeout(timer);
+      timer = setTimeout(handleResize, 300);
+    };
+    window.addEventListener('resize', debounced);
+    return () => {
+      window.removeEventListener('resize', debounced);
+      clearTimeout(timer);
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [handleResize]);
 
   const rawLabels  = points.map((p) => p.label);
   const fullLabels = points.map((p) => p.fullLabel);
@@ -151,3 +174,5 @@ export default function DailyGistsChart() {
     </div>
   );
 }
+
+export default memo(DailyGistsChart);

--- a/analytics/components/charts/RadarChart.tsx
+++ b/analytics/components/charts/RadarChart.tsx
@@ -9,54 +9,49 @@ import {
   Legend,
 } from 'chart.js';
 import { Radar } from 'react-chartjs-2';
+import { memo } from 'react';
 import { useRadarDataQuery } from '@/lib/analytics-queries';
 import ExportButton from '@/components/ui/ExportButton';
 import { exportRowsToCsv } from '@/lib/export';
+import ChartSkeleton from '@/components/ui/ChartSkeleton';
 
 ChartJS.register(RadialLinearScale, PointElement, LineElement, Tooltip, Legend);
 
-export default function RadarChart() {
+function RadarChart() {
   const { data, isLoading, error } = useRadarDataQuery();
 
-  if (isLoading || !data) {
-    return <p>Loading engagement segments...</p>;
-  }
+  if (isLoading || !data) return <ChartSkeleton />;
+  if (error) return <p>Unable to load engagement segments.</p>;
 
-  if (error) {
-    return <p>Unable to load engagement segments.</p>;
-  }
+  const chartData = {
+    labels: data.labels,
+    datasets: data.datasets.map((dataset, index) => ({
+      label: dataset.label,
+      data: dataset.values,
+      backgroundColor: index === 0 ? 'rgba(54,162,235,0.3)' : 'rgba(255,99,132,0.3)',
+      borderColor: index === 0 ? 'blue' : 'red',
+    })),
+  };
 
-  return (
-    <Radar
-      data={{
-        labels: data.labels,
-        datasets: data.datasets.map((dataset, index) => ({
-          label: dataset.label,
-          data: dataset.values,
-          backgroundColor: index === 0 ? 'rgba(54,162,235,0.3)' : 'rgba(255,99,132,0.3)',
-          borderColor: index === 0 ? 'blue' : 'red',
-        })),
-      }}
-    />
   return (
     <div>
       <ExportButton
         onExport={(onProgress) =>
           exportRowsToCsv({
             filenamePrefix: 'radar-chart',
-            filters: {
-              comparison: 'This Month vs Last Month',
-            },
-            rows: labels.map((label, index) => ({
+            filters: { comparison: 'This Month vs Last Month' },
+            rows: data.labels.map((label, index) => ({
               metric: label,
-              this_month: data.datasets[0].data[index],
-              last_month: data.datasets[1].data[index],
+              this_month: data.datasets[0].values[index],
+              last_month: data.datasets[1].values[index],
             })),
             onProgress,
           })
         }
       />
-      <Radar data={data} />
+      <Radar data={chartData} />
     </div>
   );
 }
+
+export default memo(RadarChart);

--- a/analytics/components/charts/ScatterChart.tsx
+++ b/analytics/components/charts/ScatterChart.tsx
@@ -9,14 +9,13 @@ import {
   LineElement,
 } from 'chart.js';
 import { Scatter } from 'react-chartjs-2';
-import { regression } from '@/lib/utils';
-import { useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { useScatterDataQuery } from '@/lib/analytics-queries';
 import { getScatterCategories } from '@/lib/analytics-data';
+import { regression } from '@/lib/utils';
 import ExportButton from '@/components/ui/ExportButton';
 import { exportRowsToCsv } from '@/lib/export';
-import { generateGistData, regression } from '@/lib/utils';
-import { useMemo, useState } from 'react';
+import ChartSkeleton from '@/components/ui/ChartSkeleton';
 
 ChartJS.register(LinearScale, PointElement, Tooltip, Legend, LineElement);
 
@@ -27,32 +26,25 @@ const colors: Record<string, string> = {
   Web3: 'orange',
 };
 
-export default function ScatterChart() {
+function ScatterChart() {
   const [category, setCategory] = useState<string | null>(null);
   const { data, isLoading, error } = useScatterDataQuery();
 
-  if (isLoading || !data) {
-    return <p>Loading scatter plot...</p>;
-  }
+  const handleCategoryChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    setCategory(e.target.value || null);
+  }, []);
 
-  if (error) {
-    return <p>Unable to load scatter plot.</p>;
-  }
+  if (isLoading || !data) return <ChartSkeleton />;
+  if (error) return <p>Unable to load scatter plot.</p>;
 
-  const filtered = category
-    ? data.filter((d) => d.category === category)
-    : data;
-
+  const filtered = category ? data.filter((d) => d.category === category) : data;
   const reg = regression(filtered);
 
   const scatterData = {
     datasets: [
       {
         label: 'Gists',
-        data: filtered.map((d) => ({
-          x: d.age,
-          y: d.engagement,
-        })),
+        data: filtered.map((d) => ({ x: d.age, y: d.engagement })),
         backgroundColor: filtered.map((d) => colors[d.category]),
       },
       {
@@ -65,8 +57,6 @@ export default function ScatterChart() {
         borderWidth: 2,
         pointRadius: 0,
         showLine: true,
-        showLine: true,
-        pointRadius: 0,
       },
     ],
   };
@@ -77,9 +67,7 @@ export default function ScatterChart() {
         onExport={(onProgress) =>
           exportRowsToCsv({
             filenamePrefix: 'scatter-chart',
-            filters: {
-              category: category ?? 'All',
-            },
+            filters: { category: category ?? 'All' },
             rows: filtered.map((gist) => ({
               id: gist.id,
               age_days: gist.age,
@@ -90,27 +78,22 @@ export default function ScatterChart() {
           })
         }
       />
-
-      <select onChange={(e) => setCategory(e.target.value || null)}>
+      <select onChange={handleCategoryChange}>
         <option value="">All</option>
         {getScatterCategories().map((item) => (
-          <option key={item} value={item}>
-            {item}
-          </option>
+          <option key={item} value={item}>{item}</option>
         ))}
       </select>
-
       <Scatter
         data={scatterData}
         options={{
           onClick: (_, elements) => {
-            if (elements.length) {
-              const index = elements[0].index;
-              alert(`Gist: ${filtered[index].id}`);
-            }
+            if (elements.length) alert(`Gist: ${filtered[elements[0].index].id}`);
           },
         }}
       />
     </div>
   );
 }
+
+export default memo(ScatterChart);

--- a/analytics/components/charts/UserAreaChart.tsx
+++ b/analytics/components/charts/UserAreaChart.tsx
@@ -13,6 +13,7 @@ import {
 import type { Plugin, TooltipItem } from 'chart.js';
 import { Line } from 'react-chartjs-2';
 import { useRef, useMemo } from 'react';
+import ChartSkeleton from '@/components/ui/ChartSkeleton';
 import { useUserActivityQuery } from '@/lib/analytics-queries';
 import ExportButton from '@/components/ui/ExportButton';
 import { exportRowsToCsv } from '@/lib/export';
@@ -60,13 +61,8 @@ export default function UserAreaChart() {
 
   const displayLabels = useMemo(() => sparseLabels(labels), [labels]);
 
-  if (isLoading || !activityData) {
-    return <p>Loading user activity...</p>;
-  }
-
-  if (error) {
-    return <p>Unable to load user activity.</p>;
-  }
+  if (isLoading || !activityData) return <ChartSkeleton />;
+  if (error) return <p>Unable to load user activity.</p>;
 
   const data = {
     labels: displayLabels,

--- a/analytics/components/ui/ChartSkeleton.tsx
+++ b/analytics/components/ui/ChartSkeleton.tsx
@@ -1,30 +1,63 @@
+const shimmer = `
+  @keyframes shimmer {
+    0%   { background-position: -400px 0; }
+    100% { background-position:  400px 0; }
+  }
+  .skeleton-shimmer {
+    background: linear-gradient(90deg, #f1f5f9 25%, #e2e8f0 50%, #f1f5f9 75%);
+    background-size: 800px 100%;
+    animation: shimmer 1.4s infinite linear;
+  }
+`;
+
+function ShimmerBlock({ height, width, radius = 8 }: { height: number; width?: number | string; radius?: number }) {
+  return <div className="skeleton-shimmer" style={{ height, width: width ?? '100%', borderRadius: radius }} />;
+}
+
+/** Skeleton for chart panels */
 export default function ChartSkeleton() {
   return (
-    <div
-      style={{
-        borderRadius: 20,
-        padding: 20,
-        background: '#ffffff',
-        border: '1px solid #e2e8f0',
-        boxShadow: '0 12px 30px rgba(15,23,42,0.06)',
-      }}
-    >
-      <div
-        style={{
-          width: 180,
-          height: 18,
-          borderRadius: 999,
-          background: '#e2e8f0',
-          marginBottom: 14,
-        }}
-      />
-      <div
-        style={{
-          height: 220,
-          borderRadius: 18,
-          background: 'linear-gradient(90deg, #f1f5f9 0%, #e2e8f0 50%, #f1f5f9 100%)',
-        }}
-      />
-    </div>
+    <>
+      <style>{shimmer}</style>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <ShimmerBlock height={18} width={180} radius={999} />
+        <ShimmerBlock height={220} radius={18} />
+      </div>
+    </>
+  );
+}
+
+/** Skeleton for KPI cards */
+export function KPICardSkeleton() {
+  return (
+    <>
+      <style>{shimmer}</style>
+      <div style={{ borderRadius: 16, padding: '24px 28px', border: '1px solid #e5e7eb', display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <ShimmerBlock height={12} width={80} radius={999} />
+          <ShimmerBlock height={36} width={36} radius={10} />
+        </div>
+        <ShimmerBlock height={40} width={120} radius={8} />
+        <ShimmerBlock height={14} width={100} radius={999} />
+      </div>
+    </>
+  );
+}
+
+/** Skeleton for table rows */
+export function TableSkeleton({ rows = 5 }: { rows?: number }) {
+  return (
+    <>
+      <style>{shimmer}</style>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        <ShimmerBlock height={16} width={140} radius={999} />
+        {Array.from({ length: rows }).map((_, i) => (
+          <div key={i} style={{ display: 'flex', gap: 12 }}>
+            <ShimmerBlock height={14} width="60%" radius={999} />
+            <ShimmerBlock height={14} width="30%" radius={999} />
+          </div>
+        ))}
+      </div>
+    </>
   );
 }

--- a/analytics/components/ui/LocationTable.tsx
+++ b/analytics/components/ui/LocationTable.tsx
@@ -4,11 +4,63 @@ import Sparkline from '@/components/charts/Sparkline';
 import { useLocationDataQuery } from '@/lib/analytics-queries';
 import ExportButton from '@/components/ui/ExportButton';
 import { exportRowsToCsv } from '@/lib/export';
+import { TableSkeleton } from '@/components/ui/ChartSkeleton';
 
 const mock = [
   { location: 'Abuja', values: [10, 20, 30, 25, 40, 50, 60] },
   { location: 'Lagos', values: [60, 50, 40, 35, 30, 20, 10] },
 ];
+
+export default function LocationTable() {
+  const { data, isLoading, error } = useLocationDataQuery();
+
+  if (isLoading || !data) return <TableSkeleton />;
+  if (error) return <p>Unable to load location trends.</p>;
+
+  return (
+    <div>
+      <ExportButton
+        onExport={(onProgress) =>
+          exportRowsToCsv({
+            filenamePrefix: 'location-table',
+            filters: { points_per_location: 7 },
+            rows: mock.map((row) => ({
+              location: row.location,
+              day_1: row.values[0],
+              day_2: row.values[1],
+              day_3: row.values[2],
+              day_4: row.values[3],
+              day_5: row.values[4],
+              day_6: row.values[5],
+              day_7: row.values[6],
+              direction: row.values.at(-1)! > row.values[0] ? 'up' : 'down',
+            })),
+            onProgress,
+          })
+        }
+      />
+      <table>
+        <thead>
+          <tr>
+            <th>Location</th>
+            <th>Trend</th>
+          </tr>
+        </thead>
+        <tbody>
+          {mock.map((row) => (
+            <tr key={row.location}>
+              <td>{row.location}</td>
+              <td>
+                <Sparkline data={row.values} />
+                {row.values.at(-1)! > row.values[0] ? '↑' : '↓'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
 
 export default function LocationTable() {
   const { data, isLoading, error } = useLocationDataQuery();


### PR DESCRIPTION
Closes #147 
Closes  #148 
CLoses #149  
CLoses #151 

## Changes

**#147 — Chart rendering performance**
- Wrap all chart components in `React.memo` to prevent unnecessary re-renders
- Debounce window resize events (300ms) with `requestAnimationFrame` in `DailyGistsChart`
- Add `useCallback` for event handlers in `ScatterChart`

**#148 — Loading skeletons**
- Extend `ChartSkeleton` with shimmer animation (CSS keyframes, no extra deps)
- Add `KPICardSkeleton` and `TableSkeleton` named exports
- Replace all `<p>Loading...</p>` fallbacks in charts with `ChartSkeleton`
- `LocationTable` uses `TableSkeleton` while data loads

**#149 — Progressive data loading**
- `useProgressiveLoad` hook drives 3 render stages: KPIs (0ms) → simple charts (100ms) → complex visualizations (400ms)
- Each section shows `ChartSkeleton` until its stage is reached, giving smooth waterfall UX

**#151 — Next.js Image component**
- Replace `<img>` with `next/image` `Image` in `Features.tsx`
- Add `priority` flag (above-the-fold), explicit `width`/`height`, and leading slash on src path