### PR TITLE
fix: analytics charts (closes #226 #227 #228 #229)

### DIFF
--- a/analytics/components/charts/WeeklyComparisonChart.tsx
+++ b/analytics/components/charts/WeeklyComparisonChart.tsx
@@ -4,49 +4,65 @@ import {
   Chart as ChartJS,
   CategoryScale,
   LinearScale,
-  BarElement,
+  PointElement,
+  LineElement,
   Tooltip,
   Legend,
 } from 'chart.js';
 import type { TooltipItem } from 'chart.js';
-import { Bar } from 'react-chartjs-2';
+import { Line } from 'react-chartjs-2';
+import { useMemo, useState } from 'react';
 
-ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
 const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-
 const thisWeek = [142, 158, 175, 161, 189, 110, 95];
 const lastWeek = [130, 144, 160, 155, 172, 102, 88];
 
+function pctDiff(a: number, b: number) {
+  if (b === 0) return 0;
+  return ((a - b) / b) * 100;
+}
+
 export default function WeeklyComparisonChart() {
-  const data = {
+  const [hideLast, setHideLast] = useState(false);
+
+  const totalThis = thisWeek.reduce((s, v) => s + v, 0);
+  const totalLast = lastWeek.reduce((s, v) => s + v, 0);
+  const diff = pctDiff(totalThis, totalLast);
+
+  const data = useMemo(() => ({
     labels: days,
     datasets: [
       {
         label: 'This Week',
         data: thisWeek,
-        backgroundColor: 'rgba(99, 102, 241, 0.8)',
-        borderColor: 'rgba(99, 102, 241, 1)',
-        borderWidth: 1,
-        borderRadius: 4,
+        borderColor: 'rgba(99,102,241,1)',
+        borderWidth: 2.5,
+        borderDash: [],
+        pointRadius: 4,
+        pointBackgroundColor: 'rgba(99,102,241,1)',
+        tension: 0.35,
+        fill: false,
       },
       {
         label: 'Last Week',
         data: lastWeek,
-        backgroundColor: 'rgba(156, 163, 175, 0.6)',
-        borderColor: 'rgba(156, 163, 175, 1)',
-        borderWidth: 1,
-        borderRadius: 4,
+        borderColor: 'rgba(156,163,175,0.9)',
+        borderWidth: 2,
+        borderDash: [6, 4],
+        pointRadius: 3,
+        pointBackgroundColor: 'rgba(156,163,175,0.9)',
+        tension: 0.35,
+        fill: false,
+        hidden: hideLast,
       },
     ],
-  };
+  }), [hideLast]);
 
   const options = {
     responsive: true,
-    interaction: {
-      mode: 'index' as const,
-      intersect: false,
-    },
+    interaction: { mode: 'index' as const, intersect: false },
     scales: {
       x: {
         grid: { display: false },
@@ -61,10 +77,7 @@ export default function WeeklyComparisonChart() {
       },
     },
     plugins: {
-      legend: {
-        position: 'top' as const,
-        labels: { usePointStyle: true, pointStyleWidth: 10, padding: 16 },
-      },
+      legend: { display: false },
       tooltip: {
         backgroundColor: 'rgba(17,24,39,0.9)',
         titleColor: '#f9fafb',
@@ -72,16 +85,57 @@ export default function WeeklyComparisonChart() {
         padding: 12,
         cornerRadius: 8,
         callbacks: {
-          label: (item: TooltipItem<'bar'>) =>
-            `  ${item.dataset.label}: ${(item.raw as number).toLocaleString()} gists`,
+          label: (item: TooltipItem<'line'>) => {
+            const cur = item.raw as number;
+            const prev = lastWeek[item.dataIndex];
+            const pct = pctDiff(cur, prev);
+            const sign = pct >= 0 ? '+' : '';
+            return `  ${item.dataset.label}: ${cur.toLocaleString()} gists  (${sign}${pct.toFixed(1)}%)`;
+          },
         },
       },
     },
   };
 
+  const diffColor = diff >= 0 ? '#16a34a' : '#dc2626';
+  const diffSign  = diff >= 0 ? '+' : '';
+
   return (
     <div style={{ position: 'relative', width: '100%' }}>
-      <Bar data={data} options={options} />
+      {/* Header row: legend + weekly % diff */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+        {/* Manual legend with toggle */}
+        <div style={{ display: 'flex', gap: 16, fontSize: 12 }}>
+          <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+            <svg width="20" height="10"><line x1="0" y1="5" x2="20" y2="5" stroke="rgba(99,102,241,1)" strokeWidth="2.5" /></svg>
+            This Week
+          </span>
+          <button
+            onClick={() => setHideLast(h => !h)}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 5, background: 'none',
+              border: 'none', cursor: 'pointer', fontSize: 12, padding: 0,
+              opacity: hideLast ? 0.4 : 1,
+            }}
+          >
+            <svg width="20" height="10">
+              <line x1="0" y1="5" x2="20" y2="5" stroke="rgba(156,163,175,0.9)" strokeWidth="2" strokeDasharray="6 4" />
+            </svg>
+            Last Week
+          </button>
+        </div>
+
+        {/* Weekly % difference badge */}
+        <span style={{
+          fontSize: 13, fontWeight: 700, color: diffColor,
+          background: diff >= 0 ? 'rgba(22,163,74,0.1)' : 'rgba(220,38,38,0.1)',
+          padding: '3px 10px', borderRadius: 20,
+        }}>
+          {diffSign}{diff.toFixed(1)}% vs last week
+        </span>
+      </div>
+
+      <Line data={data} options={options} />
     </div>
   );
 }

--- a/analytics/components/ui/TopLocationsTable.tsx
+++ b/analytics/components/ui/TopLocationsTable.tsx
@@ -1,81 +1,156 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 
 interface LocationRow {
   location: string;
   country: string;
   gists: number;
-  engagement: number;
+  growth: number; // % change vs last period
 }
 
 const locations: LocationRow[] = [
-  { location: 'Lagos', country: 'Nigeria', gists: 1420, engagement: 87 },
-  { location: 'Abuja', country: 'Nigeria', gists: 980, engagement: 74 },
-  { location: 'Nairobi', country: 'Kenya', gists: 860, engagement: 81 },
-  { location: 'Accra', country: 'Ghana', gists: 740, engagement: 69 },
-  { location: 'Kano', country: 'Nigeria', gists: 630, engagement: 62 },
-  { location: 'Cape Town', country: 'South Africa', gists: 590, engagement: 78 },
-  { location: 'Ibadan', country: 'Nigeria', gists: 510, engagement: 55 },
-  { location: 'Dar es Salaam', country: 'Tanzania', gists: 470, engagement: 66 },
+  { location: 'Lagos',         country: 'Nigeria',      gists: 1420, growth:  12.4 },
+  { location: 'Abuja',         country: 'Nigeria',      gists:  980, growth:   8.1 },
+  { location: 'Nairobi',       country: 'Kenya',        gists:  860, growth:  15.3 },
+  { location: 'Accra',         country: 'Ghana',        gists:  740, growth:  -2.7 },
+  { location: 'Kano',          country: 'Nigeria',      gists:  630, growth:   5.9 },
+  { location: 'Cape Town',     country: 'South Africa', gists:  590, growth:  21.0 },
+  { location: 'Ibadan',        country: 'Nigeria',      gists:  510, growth:  -4.1 },
+  { location: 'Dar es Salaam', country: 'Tanzania',     gists:  470, growth:   9.8 },
+  { location: 'Kampala',       country: 'Uganda',       gists:  430, growth:  18.6 },
+  { location: 'Addis Ababa',   country: 'Ethiopia',     gists:  390, growth:   3.2 },
+  { location: 'Dakar',         country: 'Senegal',      gists:  360, growth:  -1.5 },
+  { location: 'Lusaka',        country: 'Zambia',       gists:  320, growth:   7.4 },
+  { location: 'Harare',        country: 'Zimbabwe',     gists:  290, growth:  11.2 },
+  { location: 'Kumasi',        country: 'Ghana',        gists:  260, growth:  -6.3 },
+  { location: 'Mombasa',       country: 'Kenya',        gists:  240, growth:  14.7 },
 ];
 
-type SortKey = keyof LocationRow;
+type SortKey = 'rank' | 'location' | 'gists' | 'growth';
 type SortDir = 'asc' | 'desc';
+
+const PAGE_SIZE = 10;
 
 export default function TopLocationsTable() {
   const [sortKey, setSortKey] = useState<SortKey>('gists');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [search, setSearch]   = useState('');
+  const [page, setPage]       = useState(1);
 
   function handleSort(key: SortKey) {
-    if (key === sortKey) {
-      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
-    } else {
-      setSortKey(key);
-      setSortDir('desc');
-    }
+    if (key === sortKey) setSortDir(d => d === 'asc' ? 'desc' : 'asc');
+    else { setSortKey(key); setSortDir('desc'); }
+    setPage(1);
   }
 
-  const sorted = [...locations].sort((a, b) => {
-    const aVal = a[sortKey];
-    const bVal = b[sortKey];
-    const cmp = aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
-    return sortDir === 'asc' ? cmp : -cmp;
-  });
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase();
+    return locations.filter(r =>
+      r.location.toLowerCase().includes(q) || r.country.toLowerCase().includes(q)
+    );
+  }, [search]);
+
+  const sorted = useMemo(() => {
+    return [...filtered].sort((a, b) => {
+      let cmp = 0;
+      if (sortKey === 'rank' || sortKey === 'gists') cmp = a.gists - b.gists;
+      else if (sortKey === 'growth')   cmp = a.growth - b.growth;
+      else cmp = a.location.localeCompare(b.location);
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+  }, [filtered, sortKey, sortDir]);
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+  const pageData   = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
   function arrow(key: SortKey) {
     if (key !== sortKey) return ' ↕';
     return sortDir === 'asc' ? ' ↑' : ' ↓';
   }
 
+  const th: React.CSSProperties = {
+    padding: '10px 12px', textAlign: 'left', cursor: 'pointer',
+    color: '#6b7280', userSelect: 'none', whiteSpace: 'nowrap',
+  };
+
   return (
-    <div style={{ overflowX: 'auto' }}>
-      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
-        <thead>
-          <tr style={{ borderBottom: '2px solid #e5e7eb' }}>
-            {(['location', 'country', 'gists', 'engagement'] as SortKey[]).map((key) => (
-              <th
-                key={key}
-                onClick={() => handleSort(key)}
-                style={{ padding: '10px 12px', textAlign: 'left', cursor: 'pointer', color: '#6b7280', userSelect: 'none' }}
-              >
-                {key.charAt(0).toUpperCase() + key.slice(1)}
-                {arrow(key)}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {sorted.map((row) => (
-            <tr key={row.location} style={{ borderBottom: '1px solid #f3f4f6' }}>
-              <td style={{ padding: '10px 12px', fontWeight: 500 }}>{row.location}</td>
-              <td style={{ padding: '10px 12px', color: '#6b7280' }}>{row.country}</td>
-              <td style={{ padding: '10px 12px' }}>{row.gists.toLocaleString()}</td>
-              <td style={{ padding: '10px 12px' }}>{row.engagement}%</td>
+    <div>
+      {/* Search */}
+      <input
+        type="text"
+        placeholder="Search location or country…"
+        value={search}
+        onChange={e => { setSearch(e.target.value); setPage(1); }}
+        style={{
+          width: '100%', boxSizing: 'border-box', marginBottom: 12,
+          padding: '8px 12px', borderRadius: 8, border: '1px solid #e5e7eb',
+          fontSize: 13, outline: 'none',
+        }}
+      />
+
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+          <thead>
+            <tr style={{ borderBottom: '2px solid #e5e7eb' }}>
+              {(['rank', 'location', 'gists', 'growth'] as SortKey[]).map(key => (
+                <th key={key} onClick={() => handleSort(key)} style={th}>
+                  {key.charAt(0).toUpperCase() + key.slice(1)}{arrow(key)}
+                </th>
+              ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {pageData.map((row, i) => {
+              const rank = (page - 1) * PAGE_SIZE + i + 1;
+              const growthColor = row.growth >= 0 ? '#16a34a' : '#dc2626';
+              return (
+                <tr key={row.location} style={{ borderBottom: '1px solid #f3f4f6' }}>
+                  <td style={{ padding: '10px 12px', color: '#9ca3af', fontWeight: 600 }}>{rank}</td>
+                  <td style={{ padding: '10px 12px', fontWeight: 500 }}>
+                    {row.location}
+                    <span style={{ color: '#9ca3af', fontWeight: 400, marginLeft: 6, fontSize: 12 }}>
+                      {row.country}
+                    </span>
+                  </td>
+                  <td style={{ padding: '10px 12px' }}>{row.gists.toLocaleString()}</td>
+                  <td style={{ padding: '10px 12px', color: growthColor, fontWeight: 600 }}>
+                    {row.growth >= 0 ? '+' : ''}{row.growth.toFixed(1)}%
+                  </td>
+                </tr>
+              );
+            })}
+            {pageData.length === 0 && (
+              <tr>
+                <td colSpan={4} style={{ padding: 24, textAlign: 'center', color: '#9ca3af' }}>
+                  No results found.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 8, marginTop: 12, fontSize: 13 }}>
+          <button
+            onClick={() => setPage(p => Math.max(1, p - 1))}
+            disabled={page === 1}
+            style={{ padding: '4px 10px', borderRadius: 6, border: '1px solid #e5e7eb', cursor: page === 1 ? 'default' : 'pointer', opacity: page === 1 ? 0.4 : 1 }}
+          >
+            ‹
+          </button>
+          <span style={{ color: '#6b7280' }}>Page {page} of {totalPages}</span>
+          <button
+            onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+            disabled={page === totalPages}
+            style={{ padding: '4px 10px', borderRadius: 6, border: '1px solid #e5e7eb', cursor: page === totalPages ? 'default' : 'pointer', opacity: page === totalPages ? 0.4 : 1 }}
+          >
+            ›
+          </button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

closes #226, 
closes #227, 
closes #228, 
closes #229

### Changes

**#226 – TopLocationsTable**
- Added Rank column
- Added Growth column (% change, color-coded)
- Search filter (location/country)
- Pagination at 10 rows/page
- Sort by any column

**#228 – WeeklyComparisonChart**
- Converted bar → dual-line chart
- This week: solid indigo line
- Last week: dashed gray line
- Clickable legend toggle for last week
- Weekly % difference badge in header

**#227 – LiveGistCounter** — already implemented (increment animation, 1–5/min, flash, recent 5 gists)

**#229 – UserAreaChart** — already implemented (stacked, 90-day, gradients, cumulative total)