### PR TITLE
feat: add forecasting lib, query builder, share card generator, and benchmark chart

### DIFF
--- a/analytics/components/QueryBuilder.tsx
+++ b/analytics/components/QueryBuilder.tsx
@@ -1,0 +1,228 @@
+'use client';
+import { useState } from 'react';
+
+const DIMENSIONS = ['Date', 'Location', 'Category'] as const;
+const METRICS = ['Count', 'Average', 'Sum'] as const;
+const FILTER_OPS = ['Greater than', 'Less than', 'Equals'] as const;
+
+type Dimension = (typeof DIMENSIONS)[number];
+type Metric = (typeof METRICS)[number];
+type FilterOp = (typeof FILTER_OPS)[number];
+
+export interface QueryFilter {
+  id: number;
+  dimension: Dimension;
+  op: FilterOp;
+  value: string;
+}
+
+export interface SavedQuery {
+  id: number;
+  name: string;
+  dimensions: Dimension[];
+  metrics: Metric[];
+  filters: QueryFilter[];
+}
+
+export interface QueryBuilderProps {
+  onRun?: (dimensions: Dimension[], metrics: Metric[], filters: QueryFilter[]) => void;
+  onSave?: (query: SavedQuery) => void;
+  savedQueries?: SavedQuery[];
+  onLoadQuery?: (query: SavedQuery) => void;
+}
+
+let nextFilterId = 1;
+let nextQueryId = 1;
+
+export default function QueryBuilder({
+  onRun,
+  onSave,
+  savedQueries = [],
+  onLoadQuery,
+}: QueryBuilderProps) {
+  const [selectedDimensions, setSelectedDimensions] = useState<Dimension[]>(['Date']);
+  const [selectedMetrics, setSelectedMetrics] = useState<Metric[]>(['Count']);
+  const [filters, setFilters] = useState<QueryFilter[]>([]);
+  const [saveName, setSaveName] = useState('');
+
+  function toggleDimension(d: Dimension) {
+    setSelectedDimensions((prev) =>
+      prev.includes(d) ? prev.filter((x) => x !== d) : [...prev, d]
+    );
+  }
+
+  function toggleMetric(m: Metric) {
+    setSelectedMetrics((prev) =>
+      prev.includes(m) ? prev.filter((x) => x !== m) : [...prev, m]
+    );
+  }
+
+  function addFilter() {
+    setFilters((prev) => [
+      ...prev,
+      { id: nextFilterId++, dimension: 'Date', op: 'Equals', value: '' },
+    ]);
+  }
+
+  function updateFilter(id: number, patch: Partial<QueryFilter>) {
+    setFilters((prev) => prev.map((f) => (f.id === id ? { ...f, ...patch } : f)));
+  }
+
+  function removeFilter(id: number) {
+    setFilters((prev) => prev.filter((f) => f.id !== id));
+  }
+
+  function handleRun() {
+    onRun?.(selectedDimensions, selectedMetrics, filters);
+  }
+
+  function handleSave() {
+    const name = saveName.trim();
+    if (!name) return;
+    const query: SavedQuery = {
+      id: nextQueryId++,
+      name,
+      dimensions: selectedDimensions,
+      metrics: selectedMetrics,
+      filters,
+    };
+    onSave?.(query);
+    setSaveName('');
+  }
+
+  function handleLoad(q: SavedQuery) {
+    setSelectedDimensions(q.dimensions);
+    setSelectedMetrics(q.metrics);
+    setFilters(q.filters);
+    onLoadQuery?.(q);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {/* Dimensions */}
+        <div className="rounded-lg border bg-white dark:bg-gray-900 p-5 shadow-sm">
+          <h2 className="font-semibold mb-3">Dimensions</h2>
+          <div className="space-y-2">
+            {DIMENSIONS.map((d) => (
+              <label key={d} className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={selectedDimensions.includes(d)}
+                  onChange={() => toggleDimension(d)}
+                  className="accent-indigo-500"
+                />
+                {d}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {/* Metrics */}
+        <div className="rounded-lg border bg-white dark:bg-gray-900 p-5 shadow-sm">
+          <h2 className="font-semibold mb-3">Metrics</h2>
+          <div className="space-y-2">
+            {METRICS.map((m) => (
+              <label key={m} className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={selectedMetrics.includes(m)}
+                  onChange={() => toggleMetric(m)}
+                  className="accent-indigo-500"
+                />
+                {m}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {/* Filters */}
+        <div className="rounded-lg border bg-white dark:bg-gray-900 p-5 shadow-sm">
+          <h2 className="font-semibold mb-3">Filters</h2>
+          <div className="space-y-2">
+            {filters.map((f) => (
+              <div key={f.id} className="flex gap-1 items-center flex-wrap">
+                <select
+                  value={f.dimension}
+                  onChange={(e) => updateFilter(f.id, { dimension: e.target.value as Dimension })}
+                  className="border rounded px-1 py-0.5 text-sm bg-transparent"
+                >
+                  {DIMENSIONS.map((d) => (
+                    <option key={d}>{d}</option>
+                  ))}
+                </select>
+                <select
+                  value={f.op}
+                  onChange={(e) => updateFilter(f.id, { op: e.target.value as FilterOp })}
+                  className="border rounded px-1 py-0.5 text-sm bg-transparent"
+                >
+                  {FILTER_OPS.map((o) => (
+                    <option key={o}>{o}</option>
+                  ))}
+                </select>
+                <input
+                  value={f.value}
+                  onChange={(e) => updateFilter(f.id, { value: e.target.value })}
+                  placeholder="value"
+                  className="border rounded px-1 py-0.5 text-sm w-20 bg-transparent"
+                />
+                <button
+                  onClick={() => removeFilter(f.id)}
+                  className="text-red-500 text-xs"
+                  aria-label="Remove filter"
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+            <button
+              onClick={addFilter}
+              className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+            >
+              + Add filter
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex gap-3 flex-wrap items-center">
+        <button
+          onClick={handleRun}
+          className="px-5 py-2 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 transition-colors"
+        >
+          Run Query
+        </button>
+        <input
+          value={saveName}
+          onChange={(e) => setSaveName(e.target.value)}
+          placeholder="Query name…"
+          className="border rounded-lg px-3 py-2 text-sm bg-transparent"
+        />
+        <button
+          onClick={handleSave}
+          disabled={!saveName.trim()}
+          className="px-4 py-2 border border-indigo-500 text-indigo-600 dark:text-indigo-400 rounded-lg text-sm font-medium hover:bg-indigo-50 dark:hover:bg-indigo-950 disabled:opacity-40 transition-colors"
+        >
+          Save Query
+        </button>
+      </div>
+
+      {savedQueries.length > 0 && (
+        <div className="rounded-lg border bg-white dark:bg-gray-900 p-5 shadow-sm">
+          <h2 className="font-semibold mb-3">Saved Queries</h2>
+          <div className="flex flex-wrap gap-2">
+            {savedQueries.map((q) => (
+              <button
+                key={q.id}
+                onClick={() => handleLoad(q)}
+                className="px-3 py-1 rounded-full border text-sm hover:bg-indigo-50 dark:hover:bg-indigo-950 transition-colors"
+              >
+                {q.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/analytics/components/ShareCardGenerator.tsx
+++ b/analytics/components/ShareCardGenerator.tsx
@@ -1,0 +1,183 @@
+'use client';
+import { useRef, useState } from 'react';
+
+type Platform = 'twitter' | 'linkedin';
+
+const PLATFORM_SIZES: Record<Platform, { width: number; height: number; label: string }> = {
+  twitter: { width: 1200, height: 628, label: 'Twitter / X (1200×628)' },
+  linkedin: { width: 1200, height: 627, label: 'LinkedIn (1200×627)' },
+};
+
+export interface ShareCardData {
+  title: string;
+  metric: string;
+  value: string;
+  subtitle?: string;
+}
+
+interface ShareCardGeneratorProps {
+  data?: ShareCardData;
+}
+
+const DEFAULT_DATA: ShareCardData = {
+  title: 'GistPin Analytics',
+  metric: 'Total Gists',
+  value: '24,891',
+  subtitle: 'Last 30 days · gistpin.io',
+};
+
+export default function ShareCardGenerator({ data = DEFAULT_DATA }: ShareCardGeneratorProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [platform, setPlatform] = useState<Platform>('twitter');
+  const [cardData, setCardData] = useState<ShareCardData>(data);
+  const [downloading, setDownloading] = useState(false);
+
+  const { width, height } = PLATFORM_SIZES[platform];
+  const scale = 400 / width; // preview scale
+
+  function drawCard(ctx: CanvasRenderingContext2D, w: number, h: number) {
+    // Background gradient
+    const grad = ctx.createLinearGradient(0, 0, w, h);
+    grad.addColorStop(0, '#1e1b4b');
+    grad.addColorStop(1, '#312e81');
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, w, h);
+
+    // Branded header bar
+    ctx.fillStyle = '#6366f1';
+    ctx.fillRect(0, 0, w, h * 0.08);
+
+    // Logo / brand text
+    ctx.fillStyle = '#ffffff';
+    ctx.font = `bold ${h * 0.055}px Inter, sans-serif`;
+    ctx.fillText('GistPin', w * 0.05, h * 0.065);
+
+    // Main metric value
+    ctx.fillStyle = '#a5b4fc';
+    ctx.font = `${h * 0.07}px Inter, sans-serif`;
+    ctx.fillText(cardData.metric, w * 0.05, h * 0.42);
+
+    ctx.fillStyle = '#ffffff';
+    ctx.font = `bold ${h * 0.22}px Inter, sans-serif`;
+    ctx.fillText(cardData.value, w * 0.05, h * 0.72);
+
+    // Title
+    ctx.fillStyle = '#c7d2fe';
+    ctx.font = `${h * 0.055}px Inter, sans-serif`;
+    ctx.fillText(cardData.title, w * 0.05, h * 0.85);
+
+    // Subtitle
+    if (cardData.subtitle) {
+      ctx.fillStyle = '#818cf8';
+      ctx.font = `${h * 0.04}px Inter, sans-serif`;
+      ctx.fillText(cardData.subtitle, w * 0.05, h * 0.93);
+    }
+
+    // Decorative circle
+    ctx.beginPath();
+    ctx.arc(w * 0.88, h * 0.5, h * 0.3, 0, Math.PI * 2);
+    ctx.fillStyle = 'rgba(99,102,241,0.15)';
+    ctx.fill();
+  }
+
+  function renderPreview() {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    drawCard(ctx, width, height);
+  }
+
+  function handleDownload() {
+    setDownloading(true);
+    const offscreen = document.createElement('canvas');
+    offscreen.width = width;
+    offscreen.height = height;
+    const ctx = offscreen.getContext('2d');
+    if (!ctx) { setDownloading(false); return; }
+    drawCard(ctx, width, height);
+    offscreen.toBlob((blob) => {
+      if (!blob) { setDownloading(false); return; }
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `gistpin-share-${platform}.png`;
+      a.click();
+      URL.revokeObjectURL(url);
+      setDownloading(false);
+    }, 'image/png');
+  }
+
+  // Render preview on mount / change
+  if (typeof window !== 'undefined') {
+    setTimeout(renderPreview, 0);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* Controls */}
+        <div className="rounded-lg border bg-white dark:bg-gray-900 p-5 shadow-sm space-y-4">
+          <h2 className="font-semibold">Card Settings</h2>
+
+          <div>
+            <label className="block text-sm text-gray-600 dark:text-gray-400 mb-1">Platform</label>
+            <select
+              value={platform}
+              onChange={(e) => setPlatform(e.target.value as Platform)}
+              className="w-full border rounded-lg px-3 py-2 text-sm bg-transparent"
+            >
+              {(Object.keys(PLATFORM_SIZES) as Platform[]).map((p) => (
+                <option key={p} value={p}>
+                  {PLATFORM_SIZES[p].label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {(
+            [
+              { key: 'title', label: 'Title' },
+              { key: 'metric', label: 'Metric Label' },
+              { key: 'value', label: 'Value' },
+              { key: 'subtitle', label: 'Subtitle' },
+            ] as { key: keyof ShareCardData; label: string }[]
+          ).map(({ key, label }) => (
+            <div key={key}>
+              <label className="block text-sm text-gray-600 dark:text-gray-400 mb-1">{label}</label>
+              <input
+                value={cardData[key] ?? ''}
+                onChange={(e) => setCardData((prev) => ({ ...prev, [key]: e.target.value }))}
+                className="w-full border rounded-lg px-3 py-2 text-sm bg-transparent"
+              />
+            </div>
+          ))}
+
+          <button
+            onClick={handleDownload}
+            disabled={downloading}
+            className="w-full px-4 py-2 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+          >
+            {downloading ? 'Generating…' : 'Download PNG'}
+          </button>
+        </div>
+
+        {/* Preview */}
+        <div className="rounded-lg border bg-white dark:bg-gray-900 p-5 shadow-sm">
+          <h2 className="font-semibold mb-3">Preview</h2>
+          <div
+            style={{ width: 400, height: Math.round(height * scale), overflow: 'hidden', borderRadius: 8 }}
+          >
+            <canvas
+              ref={canvasRef}
+              style={{ width: 400, height: Math.round(height * scale) }}
+            />
+          </div>
+          <p className="text-xs text-gray-400 mt-2">{PLATFORM_SIZES[platform].label}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/analytics/components/charts/BenchmarkChart.tsx
+++ b/analytics/components/charts/BenchmarkChart.tsx
@@ -1,0 +1,151 @@
+'use client';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import type { TooltipItem } from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+import { memo } from 'react';
+import ChartWrapper from './ChartWrapper';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+export interface BenchmarkEntry {
+  category: string;
+  gistpin: number;
+  industry: number;
+}
+
+const DEFAULT_DATA: BenchmarkEntry[] = [
+  { category: 'Engagement Rate', gistpin: 68, industry: 45 },
+  { category: 'Daily Active Users', gistpin: 52, industry: 61 },
+  { category: 'Retention (7d)', gistpin: 74, industry: 58 },
+  { category: 'Avg. Session (min)', gistpin: 4.2, industry: 3.1 },
+  { category: 'Posts / User', gistpin: 3.8, industry: 2.9 },
+  { category: 'Response Rate', gistpin: 41, industry: 55 },
+];
+
+interface BenchmarkChartProps {
+  entries?: BenchmarkEntry[];
+}
+
+function pctDiff(a: number, b: number): string {
+  if (b === 0) return '—';
+  const diff = ((a - b) / b) * 100;
+  return `${diff >= 0 ? '+' : ''}${diff.toFixed(1)}%`;
+}
+
+function BenchmarkChart({ entries = DEFAULT_DATA }: BenchmarkChartProps) {
+  const labels = entries.map((e) => e.category);
+
+  const data = {
+    labels,
+    datasets: [
+      {
+        label: 'GistPin',
+        data: entries.map((e) => e.gistpin),
+        backgroundColor: entries.map((e) =>
+          e.gistpin >= e.industry ? 'rgba(99,102,241,0.85)' : 'rgba(99,102,241,0.45)'
+        ),
+        borderRadius: 4,
+        borderSkipped: false,
+      },
+      {
+        label: 'Industry Avg.',
+        data: entries.map((e) => e.industry),
+        backgroundColor: 'rgba(156,163,175,0.6)',
+        borderRadius: 4,
+        borderSkipped: false,
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: true,
+    interaction: { mode: 'index' as const, intersect: false },
+    scales: {
+      x: {
+        grid: { display: false },
+        ticks: { color: '#9ca3af', font: { size: 11 } },
+        border: { color: '#e5e7eb' },
+      },
+      y: {
+        beginAtZero: true,
+        grid: { color: 'rgba(0,0,0,0.05)' },
+        ticks: { color: '#9ca3af', font: { size: 11 } },
+        border: { display: false },
+      },
+    },
+    plugins: {
+      legend: {
+        position: 'top' as const,
+        labels: { color: '#6b7280', font: { size: 12 }, boxWidth: 12 },
+      },
+      tooltip: {
+        backgroundColor: 'rgba(17,24,39,0.9)',
+        titleColor: '#f9fafb',
+        bodyColor: '#c7d2fe',
+        padding: 10,
+        cornerRadius: 8,
+        callbacks: {
+          afterBody: (items: TooltipItem<'bar'>[]) => {
+            const gp = items.find((i) => i.dataset.label === 'GistPin')?.raw as number | undefined;
+            const ind = items.find((i) => i.dataset.label === 'Industry Avg.')?.raw as number | undefined;
+            if (gp !== undefined && ind !== undefined) {
+              return [`Δ vs Industry: ${pctDiff(gp, ind)}`];
+            }
+            return [];
+          },
+        },
+      },
+    },
+  };
+
+  return (
+    <ChartWrapper title="GistPin vs Industry Benchmarks">
+      <Bar data={data} options={options} />
+      {/* Percentage difference table */}
+      <div className="mt-4 overflow-x-auto">
+        <table className="w-full text-xs text-gray-500">
+          <thead>
+            <tr className="border-b">
+              <th className="text-left pb-1 pr-4">Metric</th>
+              <th className="text-right pb-1 pr-4">GistPin</th>
+              <th className="text-right pb-1 pr-4">Industry</th>
+              <th className="text-right pb-1">Δ</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((e) => {
+              const diff = pctDiff(e.gistpin, e.industry);
+              const positive = e.gistpin >= e.industry;
+              return (
+                <tr key={e.category} className="border-b last:border-0">
+                  <td className="py-1 pr-4">{e.category}</td>
+                  <td className="text-right pr-4 font-medium text-gray-700 dark:text-gray-300">
+                    {e.gistpin}
+                  </td>
+                  <td className="text-right pr-4">{e.industry}</td>
+                  <td
+                    className={`text-right font-semibold ${
+                      positive ? 'text-emerald-600' : 'text-red-500'
+                    }`}
+                  >
+                    {diff}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </ChartWrapper>
+  );
+}
+
+export default memo(BenchmarkChart);

--- a/analytics/components/charts/ForecastChart.tsx
+++ b/analytics/components/charts/ForecastChart.tsx
@@ -1,5 +1,4 @@
 'use client';
-
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -13,68 +12,31 @@ import {
 import type { TooltipItem } from 'chart.js';
 import { Line } from 'react-chartjs-2';
 import { useMemo, useState } from 'react';
+import { generateHistoricalData, generateForecast } from '@/lib/forecast';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Filler, Tooltip, Legend);
 
-interface DayPoint {
-  label: string;
-  count: number;
-}
-
-function generateHistorical(): DayPoint[] {
-  const points: DayPoint[] = [];
-  const now = Date.now();
-  for (let i = 29; i >= 0; i--) {
-    const d = new Date(now - i * 86_400_000);
-    const trend = 100 + (29 - i) * 1.5;
-    const isWeekend = d.getDay() === 0 || d.getDay() === 6;
-    const count = Math.round(Math.min(200, Math.max(50, trend + (Math.random() - 0.5) * 40 - (isWeekend ? 20 : 0))));
-    points.push({ label: d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' }), count });
-  }
-  return points;
-}
-
-function linearRegression(values: number[]): { slope: number; intercept: number; r2: number } {
-  const n = values.length;
-  const xs = values.map((_, i) => i);
-  const meanX = xs.reduce((a, b) => a + b, 0) / n;
-  const meanY = values.reduce((a, b) => a + b, 0) / n;
-  const slope = xs.reduce((acc, x, i) => acc + (x - meanX) * (values[i] - meanY), 0) /
-    xs.reduce((acc, x) => acc + (x - meanX) ** 2, 0);
-  const intercept = meanY - slope * meanX;
-  const ssTot = values.reduce((acc, y) => acc + (y - meanY) ** 2, 0);
-  const ssRes = values.reduce((acc, y, i) => acc + (y - (slope * i + intercept)) ** 2, 0);
-  const r2 = ssTot === 0 ? 1 : 1 - ssRes / ssTot;
-  return { slope, intercept, r2 };
-}
-
 export default function ForecastChart() {
   const [showForecast, setShowForecast] = useState(true);
-  const historical = useMemo(() => generateHistorical(), []);
-  const counts = historical.map((p) => p.count);
-  const { slope, intercept, r2 } = useMemo(() => linearRegression(counts), [counts]);
 
-  const forecastValues = Array.from({ length: 7 }, (_, i) => {
-    const x = counts.length + i;
-    return Math.round(slope * x + intercept);
-  });
+  const historical = useMemo(() => generateHistoricalData(30), []);
+  const { forecast, upperBound, lowerBound, r2 } = useMemo(
+    () => generateForecast(historical, 7, 0.2),
+    [historical]
+  );
 
-  const now = Date.now();
-  const forecastLabels = Array.from({ length: 7 }, (_, i) => {
-    const d = new Date(now + (i + 1) * 86_400_000);
-    return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
-  });
+  const allLabels = [...historical.map((p) => p.label), ...forecast.map((p) => p.label)];
+  const histPad = [...historical.map((p) => p.value), ...Array(7).fill(null)];
+  const lastHistVal = historical[historical.length - 1].value;
 
-  const allLabels = [...historical.map((p) => p.label), ...forecastLabels];
-  const histPad = [...counts, ...Array(7).fill(null)];
   const forecastPad = showForecast
-    ? [...Array(counts.length - 1).fill(null), counts[counts.length - 1], ...forecastValues]
+    ? [...Array(historical.length - 1).fill(null), lastHistVal, ...forecast.map((p) => p.value)]
     : [];
-  const upperBound = showForecast
-    ? [...Array(counts.length - 1).fill(null), counts[counts.length - 1], ...forecastValues.map((v) => Math.round(v * 1.2))]
+  const upperPad = showForecast
+    ? [...Array(historical.length - 1).fill(null), lastHistVal, ...upperBound.map((p) => p.value)]
     : [];
-  const lowerBound = showForecast
-    ? [...Array(counts.length - 1).fill(null), counts[counts.length - 1], ...forecastValues.map((v) => Math.round(v * 0.8))]
+  const lowerPad = showForecast
+    ? [...Array(historical.length - 1).fill(null), lastHistVal, ...lowerBound.map((p) => p.value)]
     : [];
 
   const data = {
@@ -96,7 +58,7 @@ export default function ForecastChart() {
         ? [
             {
               label: 'Upper bound',
-              data: upperBound,
+              data: upperPad,
               borderColor: 'transparent',
               backgroundColor: 'rgba(99,102,241,0.12)',
               fill: '+1',
@@ -120,7 +82,7 @@ export default function ForecastChart() {
             },
             {
               label: 'Lower bound',
-              data: lowerBound,
+              data: lowerPad,
               borderColor: 'transparent',
               backgroundColor: 'rgba(99,102,241,0.12)',
               fill: '-2',
@@ -145,7 +107,8 @@ export default function ForecastChart() {
           maxRotation: 0,
           color: '#9ca3af',
           font: { size: 11 },
-          callback: (_: unknown, i: number) => (i % 5 === 0 || i === allLabels.length - 1 ? allLabels[i] : null),
+          callback: (_: unknown, i: number) =>
+            i % 5 === 0 || i === allLabels.length - 1 ? allLabels[i] : null,
         },
         border: { color: '#e5e7eb' },
       },
@@ -165,7 +128,8 @@ export default function ForecastChart() {
         padding: 10,
         cornerRadius: 8,
         displayColors: false,
-        filter: (item: TooltipItem<'line'>) => item.dataset.label !== 'Upper bound' && item.dataset.label !== 'Lower bound',
+        filter: (item: TooltipItem<'line'>) =>
+          item.dataset.label !== 'Upper bound' && item.dataset.label !== 'Lower bound',
       },
     },
   };
@@ -199,7 +163,15 @@ export default function ForecastChart() {
         </span>
         {showForecast && (
           <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-            <span style={{ width: 20, height: 2, background: 'rgba(251,146,60,0.9)', display: 'inline-block', borderTop: '2px dashed rgba(251,146,60,0.9)' }} />
+            <span
+              style={{
+                width: 20,
+                height: 2,
+                background: 'rgba(251,146,60,0.9)',
+                display: 'inline-block',
+                borderTop: '2px dashed rgba(251,146,60,0.9)',
+              }}
+            />
             7-day forecast
           </span>
         )}

--- a/analytics/lib/forecast.ts
+++ b/analytics/lib/forecast.ts
@@ -1,0 +1,61 @@
+export interface DataPoint {
+  label: string;
+  value: number;
+}
+
+export interface ForecastResult {
+  historical: DataPoint[];
+  forecast: DataPoint[];
+  upperBound: DataPoint[];
+  lowerBound: DataPoint[];
+  slope: number;
+  intercept: number;
+  r2: number;
+}
+
+export function linearRegression(values: number[]): { slope: number; intercept: number; r2: number } {
+  const n = values.length;
+  const meanX = (n - 1) / 2;
+  const meanY = values.reduce((a, b) => a + b, 0) / n;
+  const slope =
+    values.reduce((acc, y, i) => acc + (i - meanX) * (y - meanY), 0) /
+    values.reduce((acc, _, i) => acc + (i - meanX) ** 2, 0);
+  const intercept = meanY - slope * meanX;
+  const ssTot = values.reduce((acc, y) => acc + (y - meanY) ** 2, 0);
+  const ssRes = values.reduce((acc, y, i) => acc + (y - (slope * i + intercept)) ** 2, 0);
+  const r2 = ssTot === 0 ? 1 : 1 - ssRes / ssTot;
+  return { slope, intercept, r2 };
+}
+
+export function generateForecast(historical: DataPoint[], days = 7, confidencePct = 0.2): ForecastResult {
+  const values = historical.map((p) => p.value);
+  const { slope, intercept, r2 } = linearRegression(values);
+  const now = Date.now();
+
+  const forecast: DataPoint[] = Array.from({ length: days }, (_, i) => {
+    const x = values.length + i;
+    const d = new Date(now + (i + 1) * 86_400_000);
+    return {
+      label: d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' }),
+      value: Math.round(slope * x + intercept),
+    };
+  });
+
+  const upperBound = forecast.map((p) => ({ ...p, value: Math.round(p.value * (1 + confidencePct)) }));
+  const lowerBound = forecast.map((p) => ({ ...p, value: Math.round(p.value * (1 - confidencePct)) }));
+
+  return { historical, forecast, upperBound, lowerBound, slope, intercept, r2 };
+}
+
+export function generateHistoricalData(days = 30): DataPoint[] {
+  const now = Date.now();
+  return Array.from({ length: days }, (_, i) => {
+    const d = new Date(now - (days - 1 - i) * 86_400_000);
+    const isWeekend = d.getDay() === 0 || d.getDay() === 6;
+    const trend = 100 + i * 1.5;
+    const value = Math.round(
+      Math.min(200, Math.max(50, trend + (Math.random() - 0.5) * 40 - (isWeekend ? 20 : 0)))
+    );
+    return { label: d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' }), value };
+  });
+}


### PR DESCRIPTION
## Summary

Resolves all 4 issues assigned to @nanaf6203-bit.

---

### #270 — Add forecasting chart

- Created `analytics/lib/forecast.ts` with `linearRegression`, `generateForecast`, and `generateHistoricalData` utilities
- Refactored `analytics/components/charts/ForecastChart.tsx` to consume the new lib
- Features: historical + forecast line, linear regression, 7-day forecast, ±20% confidence interval, toggle button

### #271 — Create SQL query builder

- Created `analytics/components/QueryBuilder.tsx` as a reusable component
- Features: dimension/metric checkboxes, filter builder (add/remove/update), save queries, load saved queries, callback props (`onRun`, `onSave`, `onLoadQuery`)

### #272 — Build social share card generator

- Created `analytics/components/ShareCardGenerator.tsx`
- Features: Twitter (1200×628) and LinkedIn (1200×627) templates, branded GistPin header, auto-resize canvas preview, editable fields, download as PNG

### #273 — Add benchmark comparison chart

- Created `analytics/components/charts/BenchmarkChart.tsx`
- Features: side-by-side bar chart (GistPin vs Industry Avg.), color-coded bars (indigo = at/above industry, muted = below), percentage-difference table with green/red indicators

---

Closes #270
Closes #271
Closes #272
Closes #273