### PR TITLE
feat: add button, input, checkbox/radio, and select component library

### DIFF
--- a/analytics/components/Button.tsx
+++ b/analytics/components/Button.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { ButtonHTMLAttributes, ReactNode } from 'react';
+
+type Variant = 'primary' | 'secondary' | 'ghost';
+type Size = 'sm' | 'md' | 'lg';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant;
+  size?: Size;
+  loading?: boolean;
+  icon?: ReactNode;
+  children: ReactNode;
+}
+
+const variantClasses: Record<Variant, string> = {
+  primary:
+    'bg-brand text-white hover:bg-brand-dark border border-brand disabled:opacity-50',
+  secondary:
+    'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-700 disabled:opacity-50',
+  ghost:
+    'bg-transparent text-gray-600 hover:bg-gray-100 border border-transparent dark:text-gray-300 dark:hover:bg-gray-800 disabled:opacity-50',
+};
+
+const sizeClasses: Record<Size, string> = {
+  sm: 'h-7 px-3 text-xs gap-1.5',
+  md: 'h-9 px-4 text-sm gap-2',
+  lg: 'h-11 px-6 text-base gap-2.5',
+};
+
+export default function Button({
+  variant = 'primary',
+  size = 'md',
+  loading = false,
+  icon,
+  children,
+  disabled,
+  className = '',
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      disabled={disabled || loading}
+      className={`inline-flex items-center justify-center rounded-lg font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2 ${variantClasses[variant]} ${sizeClasses[size]} ${className}`}
+      {...props}
+    >
+      {loading ? (
+        <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+        </svg>
+      ) : (
+        icon && <span className="shrink-0">{icon}</span>
+      )}
+      {children}
+    </button>
+  );
+}

--- a/analytics/components/Checkbox.tsx
+++ b/analytics/components/Checkbox.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { InputHTMLAttributes } from 'react';
+
+interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'size'> {
+  label?: string;
+}
+
+export function Checkbox({ label, id, disabled, className = '', ...props }: CheckboxProps) {
+  const inputId = id ?? label?.toLowerCase().replace(/\s+/g, '-');
+  return (
+    <label
+      htmlFor={inputId}
+      className={`inline-flex items-center gap-2 cursor-pointer select-none ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`}
+    >
+      <input
+        id={inputId}
+        type="checkbox"
+        disabled={disabled}
+        className="h-4 w-4 rounded border-gray-300 text-brand accent-brand focus:ring-2 focus:ring-brand dark:border-gray-600"
+        {...props}
+      />
+      {label && (
+        <span className="text-sm text-gray-700 dark:text-gray-300">{label}</span>
+      )}
+    </label>
+  );
+}
+
+interface RadioProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  label?: string;
+}
+
+export function Radio({ label, id, disabled, className = '', ...props }: RadioProps) {
+  const inputId = id ?? label?.toLowerCase().replace(/\s+/g, '-');
+  return (
+    <label
+      htmlFor={inputId}
+      className={`inline-flex items-center gap-2 cursor-pointer select-none ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`}
+    >
+      <input
+        id={inputId}
+        type="radio"
+        disabled={disabled}
+        className="h-4 w-4 border-gray-300 text-brand accent-brand focus:ring-2 focus:ring-brand dark:border-gray-600"
+        {...props}
+      />
+      {label && (
+        <span className="text-sm text-gray-700 dark:text-gray-300">{label}</span>
+      )}
+    </label>
+  );
+}

--- a/analytics/components/Input.tsx
+++ b/analytics/components/Input.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { InputHTMLAttributes, ReactNode, forwardRef } from 'react';
+
+type InputType = 'text' | 'number' | 'email' | 'password' | 'date' | 'search';
+
+interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  type?: InputType;
+  label?: string;
+  error?: string;
+  hint?: string;
+  leading?: ReactNode;
+  trailing?: ReactNode;
+}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { type = 'text', label, error, hint, leading, trailing, className = '', id, ...props },
+  ref,
+) {
+  const inputId = id ?? label?.toLowerCase().replace(/\s+/g, '-');
+
+  return (
+    <div className="flex flex-col gap-1">
+      {label && (
+        <label htmlFor={inputId} className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          {label}
+        </label>
+      )}
+      <div className="relative flex items-center">
+        {leading && (
+          <span className="absolute left-3 text-gray-400 pointer-events-none">{leading}</span>
+        )}
+        <input
+          ref={ref}
+          id={inputId}
+          type={type}
+          className={`w-full rounded-lg border px-3 py-2 text-sm bg-white text-gray-900 placeholder-gray-400 transition-colors focus:outline-none focus:ring-2 focus:ring-brand focus:border-brand dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-500 ${
+            error
+              ? 'border-red-400 focus:ring-red-400 focus:border-red-400'
+              : 'border-gray-200 dark:border-gray-700'
+          } ${leading ? 'pl-9' : ''} ${trailing ? 'pr-9' : ''} disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
+          {...props}
+        />
+        {trailing && (
+          <span className="absolute right-3 text-gray-400 pointer-events-none">{trailing}</span>
+        )}
+      </div>
+      {error && <p className="text-xs text-red-500">{error}</p>}
+      {hint && !error && <p className="text-xs text-gray-400">{hint}</p>}
+    </div>
+  );
+});
+
+export default Input;

--- a/analytics/components/Select.tsx
+++ b/analytics/components/Select.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+
+export interface SelectOption {
+  value: string;
+  label: string;
+  group?: string;
+  disabled?: boolean;
+}
+
+interface SelectProps {
+  options: SelectOption[];
+  value?: string | string[];
+  onChange?: (value: string | string[]) => void;
+  placeholder?: string;
+  multiple?: boolean;
+  searchable?: boolean;
+  disabled?: boolean;
+  label?: string;
+}
+
+export default function Select({
+  options,
+  value,
+  onChange,
+  placeholder = 'Select…',
+  multiple = false,
+  searchable = false,
+  disabled = false,
+  label,
+}: SelectProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const ref = useRef<HTMLDivElement>(null);
+
+  const selected = multiple
+    ? (Array.isArray(value) ? value : [])
+    : (typeof value === 'string' ? value : '');
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  const filtered = options.filter((o) =>
+    o.label.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const groups = Array.from(new Set(filtered.map((o) => o.group ?? ''))).filter(Boolean);
+  const ungrouped = filtered.filter((o) => !o.group);
+
+  const isSelected = (val: string) =>
+    multiple ? (selected as string[]).includes(val) : selected === val;
+
+  const toggle = (val: string) => {
+    if (multiple) {
+      const arr = selected as string[];
+      const next = arr.includes(val) ? arr.filter((v) => v !== val) : [...arr, val];
+      onChange?.(next);
+    } else {
+      onChange?.(val);
+      setOpen(false);
+    }
+  };
+
+  const displayLabel = multiple
+    ? (selected as string[]).length
+      ? (selected as string[]).map((v) => options.find((o) => o.value === v)?.label ?? v).join(', ')
+      : placeholder
+    : options.find((o) => o.value === selected)?.label ?? placeholder;
+
+  const renderOption = (opt: SelectOption) => (
+    <button
+      key={opt.value}
+      type="button"
+      disabled={opt.disabled}
+      onClick={() => !opt.disabled && toggle(opt.value)}
+      className={`w-full text-left px-3 py-1.5 text-sm rounded flex items-center gap-2 transition-colors ${
+        opt.disabled
+          ? 'opacity-40 cursor-not-allowed'
+          : isSelected(opt.value)
+          ? 'bg-brand/10 text-brand font-medium'
+          : 'hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200'
+      }`}
+    >
+      {multiple && (
+        <span className={`h-3.5 w-3.5 rounded border ${isSelected(opt.value) ? 'bg-brand border-brand' : 'border-gray-300'}`} />
+      )}
+      {opt.label}
+    </button>
+  );
+
+  return (
+    <div ref={ref} className="relative flex flex-col gap-1">
+      {label && <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{label}</span>}
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => setOpen((v) => !v)}
+        className="flex h-9 w-full items-center justify-between rounded-lg border border-gray-200 bg-white px-3 text-sm text-gray-700 transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <span className="truncate">{displayLabel}</span>
+        <svg className={`h-4 w-4 shrink-0 text-gray-400 transition-transform ${open ? 'rotate-180' : ''}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="absolute top-full z-50 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800">
+          {searchable && (
+            <div className="p-2 border-b border-gray-100 dark:border-gray-700">
+              <input
+                autoFocus
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search…"
+                className="w-full rounded border border-gray-200 px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-brand dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+              />
+            </div>
+          )}
+          <div className="max-h-52 overflow-y-auto p-1">
+            {ungrouped.map(renderOption)}
+            {groups.map((group) => (
+              <div key={group}>
+                <p className="px-3 pt-2 pb-1 text-xs font-semibold uppercase tracking-wide text-gray-400">{group}</p>
+                {filtered.filter((o) => o.group === group).map(renderOption)}
+              </div>
+            ))}
+            {filtered.length === 0 && (
+              <p className="px-3 py-2 text-xs text-gray-400">No options found</p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

This PR adds four reusable UI components to the analytics component library:

- **Button** (nalytics/components/Button.tsx): Three variants - primary, secondary, ghost - in sm, md, lg sizes with optional icon slot and loading spinner state
- **Input** (nalytics/components/Input.tsx): Supports 	ext, 
umber, date, email, password, and search types with label, error message, hint text, and leading/trailing addon slots
- **Checkbox & Radio** (nalytics/components/Checkbox.tsx): Custom-styled checkbox and radio inputs with label support and disabled states, both using ccent-brand for consistent brand colouring
- **Select** (nalytics/components/Select.tsx): Dropdown with single and multi-select modes, optional search filtering, grouped options sections, and disabled individual options

## Changes

- nalytics/components/Button.tsx - button component with variants, sizes, icon, and loading state
- nalytics/components/Input.tsx - input component with type support, error/hint states, and addons
- nalytics/components/Checkbox.tsx - checkbox and radio components with labels and disabled states
- nalytics/components/Select.tsx - select dropdown with search, groups, multi-select, and disabled options

closes #296
closes #297
closes #298
closes #299