### PR TITLE
feat: add spinner, badge, avatar, and pagination components

### DIFF
--- a/analytics/components/Avatar.tsx
+++ b/analytics/components/Avatar.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+type Status = 'online' | 'offline' | 'away' | 'busy';
+
+interface AvatarProps {
+  src?: string;
+  name?: string;
+  size?: Size;
+  status?: Status;
+  alt?: string;
+}
+
+interface AvatarGroupProps {
+  avatars: AvatarProps[];
+  max?: number;
+}
+
+const sizeClasses: Record<Size, string> = {
+  xs: 'h-6 w-6 text-xs',
+  sm: 'h-8 w-8 text-sm',
+  md: 'h-10 w-10 text-sm',
+  lg: 'h-12 w-12 text-base',
+  xl: 'h-16 w-16 text-lg',
+};
+
+const statusClasses: Record<Status, string> = {
+  online: 'bg-green-400',
+  offline: 'bg-gray-400',
+  away: 'bg-yellow-400',
+  busy: 'bg-red-400',
+};
+
+const statusSizeClasses: Record<Size, string> = {
+  xs: 'h-1.5 w-1.5 border',
+  sm: 'h-2 w-2 border',
+  md: 'h-2.5 w-2.5 border-2',
+  lg: 'h-3 w-3 border-2',
+  xl: 'h-3.5 w-3.5 border-2',
+};
+
+function getInitials(name?: string) {
+  if (!name) return '?';
+  const parts = name.trim().split(/\s+/);
+  return parts.length === 1
+    ? parts[0][0].toUpperCase()
+    : (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+export function Avatar({ src, name, size = 'md', status, alt }: AvatarProps) {
+  return (
+    <div className="relative inline-flex shrink-0">
+      {src ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={src}
+          alt={alt ?? name ?? 'Avatar'}
+          className={`rounded-full object-cover ${sizeClasses[size]}`}
+        />
+      ) : (
+        <div
+          className={`inline-flex items-center justify-center rounded-full bg-brand/20 font-semibold text-brand ${sizeClasses[size]}`}
+          aria-label={name ?? 'Avatar'}
+        >
+          {getInitials(name)}
+        </div>
+      )}
+      {status && (
+        <span
+          className={`absolute bottom-0 right-0 rounded-full border-white dark:border-gray-900 ${statusClasses[status]} ${statusSizeClasses[size]}`}
+        />
+      )}
+    </div>
+  );
+}
+
+export function AvatarGroup({ avatars, max = 4 }: AvatarGroupProps) {
+  const visible = avatars.slice(0, max);
+  const overflow = avatars.length - max;
+
+  return (
+    <div className="flex -space-x-2">
+      {visible.map((a, i) => (
+        <div key={i} className="ring-2 ring-white dark:ring-gray-900 rounded-full">
+          <Avatar {...a} />
+        </div>
+      ))}
+      {overflow > 0 && (
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-200 ring-2 ring-white text-xs font-semibold text-gray-600 dark:bg-gray-700 dark:ring-gray-900 dark:text-gray-300">
+          +{overflow}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Avatar;

--- a/analytics/components/Badge.tsx
+++ b/analytics/components/Badge.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { ReactNode } from 'react';
+
+type Variant = 'gray' | 'brand' | 'green' | 'yellow' | 'red' | 'blue';
+
+interface BadgeProps {
+  children: ReactNode;
+  variant?: Variant;
+  dot?: boolean;
+  pill?: boolean;
+  count?: number;
+}
+
+const variantClasses: Record<Variant, string> = {
+  gray: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300',
+  brand: 'bg-brand/10 text-brand dark:bg-brand/20',
+  green: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  yellow: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
+  red: 'bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400',
+  blue: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+};
+
+const dotClasses: Record<Variant, string> = {
+  gray: 'bg-gray-400',
+  brand: 'bg-brand',
+  green: 'bg-green-500',
+  yellow: 'bg-yellow-500',
+  red: 'bg-red-500',
+  blue: 'bg-blue-500',
+};
+
+export default function Badge({
+  children,
+  variant = 'gray',
+  dot = false,
+  pill = true,
+  count,
+}: BadgeProps) {
+  if (count !== undefined) {
+    return (
+      <span
+        className={`inline-flex min-w-[1.25rem] items-center justify-center px-1.5 py-0.5 text-xs font-bold leading-none ${variantClasses[variant]} ${pill ? 'rounded-full' : 'rounded'}`}
+      >
+        {count > 99 ? '99+' : count}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium ${variantClasses[variant]} ${pill ? 'rounded-full' : 'rounded'}`}
+    >
+      {dot && (
+        <span className={`h-1.5 w-1.5 rounded-full ${dotClasses[variant]}`} />
+      )}
+      {children}
+    </span>
+  );
+}

--- a/analytics/components/Pagination.tsx
+++ b/analytics/components/Pagination.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+interface PaginationProps {
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  pageSize?: number;
+  onPageSizeChange?: (size: number) => void;
+  pageSizeOptions?: number[];
+}
+
+const PAGE_SIZES = [10, 25, 50, 100];
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function getPageNumbers(current: number, total: number): (number | '…')[] {
+  if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+  if (current <= 4) return [1, 2, 3, 4, 5, '…', total];
+  if (current >= total - 3) return [1, '…', total - 4, total - 3, total - 2, total - 1, total];
+  return [1, '…', current - 1, current, current + 1, '…', total];
+}
+
+export default function Pagination({
+  page,
+  totalPages,
+  onPageChange,
+  pageSize,
+  onPageSizeChange,
+  pageSizeOptions = PAGE_SIZES,
+}: PaginationProps) {
+  const pages = getPageNumbers(page, totalPages);
+
+  const btnBase =
+    'inline-flex h-8 min-w-[2rem] items-center justify-center rounded px-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-brand';
+  const btnActive = 'bg-brand text-white';
+  const btnDefault =
+    'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700';
+  const btnDisabled = 'opacity-40 cursor-not-allowed';
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      {onPageSizeChange && (
+        <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+          <span>Rows per page</span>
+          <select
+            value={pageSize}
+            onChange={(e) => onPageSizeChange(Number(e.target.value))}
+            className="rounded border border-gray-200 bg-white px-2 py-1 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-brand dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+          >
+            {pageSizeOptions.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <div className="flex items-center gap-1">
+        <button
+          onClick={() => onPageChange(clamp(page - 1, 1, totalPages))}
+          disabled={page === 1}
+          className={`${btnBase} ${page === 1 ? btnDisabled : btnDefault}`}
+          aria-label="Previous page"
+        >
+          ‹
+        </button>
+
+        {pages.map((p, i) =>
+          p === '…' ? (
+            <span key={`ellipsis-${i}`} className="px-1 text-gray-400">…</span>
+          ) : (
+            <button
+              key={p}
+              onClick={() => onPageChange(p as number)}
+              className={`${btnBase} ${p === page ? btnActive : btnDefault}`}
+              aria-current={p === page ? 'page' : undefined}
+            >
+              {p}
+            </button>
+          ),
+        )}
+
+        <button
+          onClick={() => onPageChange(clamp(page + 1, 1, totalPages))}
+          disabled={page === totalPages}
+          className={`${btnBase} ${page === totalPages ? btnDisabled : btnDefault}`}
+          aria-label="Next page"
+        >
+          ›
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/analytics/components/Spinner.tsx
+++ b/analytics/components/Spinner.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+type Size = 'sm' | 'md' | 'lg';
+type Variant = 'brand' | 'white' | 'gray';
+
+interface SpinnerProps {
+  size?: Size;
+  variant?: Variant;
+  label?: string;
+  fullscreen?: boolean;
+}
+
+const sizeClasses: Record<Size, string> = {
+  sm: 'h-4 w-4 border-2',
+  md: 'h-8 w-8 border-2',
+  lg: 'h-12 w-12 border-4',
+};
+
+const colorClasses: Record<Variant, string> = {
+  brand: 'border-brand/20 border-t-brand',
+  white: 'border-white/20 border-t-white',
+  gray: 'border-gray-200 border-t-gray-500 dark:border-gray-700 dark:border-t-gray-300',
+};
+
+export default function Spinner({
+  size = 'md',
+  variant = 'brand',
+  label,
+  fullscreen = false,
+}: SpinnerProps) {
+  const spinner = (
+    <div className="flex flex-col items-center gap-2">
+      <div
+        className={`animate-spin rounded-full ${sizeClasses[size]} ${colorClasses[variant]}`}
+        role="status"
+        aria-label={label ?? 'Loading'}
+      />
+      {label && (
+        <span className="text-sm text-gray-500 dark:text-gray-400">{label}</span>
+      )}
+    </div>
+  );
+
+  if (fullscreen) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/70 dark:bg-gray-900/70">
+        {spinner}
+      </div>
+    );
+  }
+
+  return spinner;
+}


### PR DESCRIPTION
## Summary

This PR adds four reusable UI components to the analytics component library:

- **Spinner** (nalytics/components/Spinner.tsx): Three sizes (sm, md, lg), three color variants (rand, white, gray), optional text label beneath the spinner, and a ullscreen prop that renders a centered overlay over the full viewport
- **Badge** (nalytics/components/Badge.tsx): Six color variants (gray, rand, green, yellow, ed, lue), optional leading dot indicator, numeric count mode that auto-formats 99+, and togglable pill/square shape
- **Avatar** (nalytics/components/Avatar.tsx): Renders an image or falls back to two-letter initials, five sizes (xs to xl), four status indicators (online, offline, way, usy), plus an AvatarGroup component that stacks avatars with an overflow count badge
- **Pagination** (nalytics/components/Pagination.tsx): Page number buttons with smart ellipsis for large ranges, prev/next buttons, ria-current for accessibility, and an optional items-per-page <select> dropdown

## Changes

- nalytics/components/Spinner.tsx - loading spinner with sizes, variants, label, and fullscreen mode
- nalytics/components/Badge.tsx - status badge with color variants, dot, count, and pill shape
- nalytics/components/Avatar.tsx - avatar with image/initials fallback, status dot, and group display
- nalytics/components/Pagination.tsx - pagination with page numbers, ellipsis, and page size selector

closes #292
closes #293
closes #294
closes #295