### PR TITLE
feat: add Breadcrumbs, Tabs, Dropdown components and validation utilities

### DIFF
--- a/analytics/components/Breadcrumbs.tsx
+++ b/analytics/components/Breadcrumbs.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+interface BreadcrumbItem {
+  label: string;
+  href: string;
+}
+
+interface BreadcrumbsProps {
+  items?: BreadcrumbItem[];
+  homeLabel?: string;
+}
+
+function formatLabel(segment: string) {
+  return segment.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export default function Breadcrumbs({ items, homeLabel = 'Home' }: BreadcrumbsProps) {
+  const pathname = usePathname();
+
+  const crumbs: BreadcrumbItem[] = items ?? [
+    { label: homeLabel, href: '/' },
+    ...pathname
+      .split('/')
+      .filter(Boolean)
+      .map((segment, i, arr) => ({
+        label: formatLabel(segment),
+        href: '/' + arr.slice(0, i + 1).join('/'),
+      })),
+  ];
+
+  if (crumbs.length <= 1) return null;
+
+  return (
+    <nav aria-label="Breadcrumb">
+      <ol className="flex flex-wrap items-center gap-1 text-sm text-gray-500 dark:text-gray-400">
+        {crumbs.map((crumb, i) => {
+          const isLast = i === crumbs.length - 1;
+          return (
+            <li key={crumb.href} className="flex items-center gap-1">
+              {i > 0 && (
+                <svg className="h-3.5 w-3.5 shrink-0 text-gray-300 dark:text-gray-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                  <polyline points="9 18 15 12 9 6" />
+                </svg>
+              )}
+              {isLast ? (
+                <span className="font-medium text-gray-800 dark:text-gray-100 truncate max-w-[160px] sm:max-w-none" aria-current="page">
+                  {crumb.label}
+                </span>
+              ) : (
+                <Link
+                  href={crumb.href}
+                  className="truncate max-w-[100px] sm:max-w-none hover:text-brand transition-colors"
+                >
+                  {crumb.label}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/analytics/components/Dropdown.tsx
+++ b/analytics/components/Dropdown.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { ReactNode, useEffect, useRef, useState } from 'react';
+
+interface DropdownItem {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  danger?: boolean;
+}
+
+interface DropdownProps {
+  trigger: ReactNode;
+  items: DropdownItem[];
+  align?: 'left' | 'right';
+}
+
+export default function Dropdown({ trigger, items, align = 'left' }: DropdownProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  return (
+    <div ref={ref} className="relative inline-block">
+      <div onClick={() => setOpen((o) => !o)} className="cursor-pointer">
+        {trigger}
+      </div>
+
+      {open && (
+        <div
+          className={[
+            'absolute z-50 mt-1 min-w-[10rem] rounded-md border border-gray-200 bg-white shadow-md dark:border-gray-700 dark:bg-gray-800',
+            align === 'right' ? 'right-0' : 'left-0',
+          ].join(' ')}
+          role="menu"
+        >
+          {items.map((item, i) => (
+            <button
+              key={i}
+              role="menuitem"
+              disabled={item.disabled}
+              onClick={() => {
+                if (!item.disabled) {
+                  item.onClick();
+                  setOpen(false);
+                }
+              }}
+              className={[
+                'w-full px-4 py-2 text-left text-sm transition-colors',
+                item.danger
+                  ? 'text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20'
+                  : 'text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700',
+                item.disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer',
+              ].join(' ')}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/analytics/components/Tabs.tsx
+++ b/analytics/components/Tabs.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { ReactNode, useState } from 'react';
+
+interface Tab {
+  id: string;
+  label: string;
+  content: ReactNode;
+  disabled?: boolean;
+}
+
+interface TabsProps {
+  tabs: Tab[];
+  defaultTab?: string;
+  onChange?: (id: string) => void;
+}
+
+export default function Tabs({ tabs, defaultTab, onChange }: TabsProps) {
+  const [active, setActive] = useState(defaultTab ?? tabs[0]?.id);
+
+  function select(id: string) {
+    setActive(id);
+    onChange?.(id);
+  }
+
+  const current = tabs.find((t) => t.id === active);
+
+  return (
+    <div>
+      <div
+        role="tablist"
+        className="flex border-b border-gray-200 dark:border-gray-700"
+      >
+        {tabs.map((tab) => {
+          const isActive = tab.id === active;
+          return (
+            <button
+              key={tab.id}
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={`tabpanel-${tab.id}`}
+              disabled={tab.disabled}
+              onClick={() => !tab.disabled && select(tab.id)}
+              className={[
+                'px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors focus:outline-none',
+                isActive
+                  ? 'border-brand text-brand'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200',
+                tab.disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer',
+              ].join(' ')}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {current && (
+        <div
+          id={`tabpanel-${current.id}`}
+          role="tabpanel"
+          className="pt-4"
+        >
+          {current.content}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/analytics/lib/validation.ts
+++ b/analytics/lib/validation.ts
@@ -1,0 +1,59 @@
+export type ValidationResult = { valid: true } | { valid: false; error: string };
+
+export function validateRequired(value: string, fieldName = 'Field'): ValidationResult {
+  if (!value || value.trim().length === 0) {
+    return { valid: false, error: `${fieldName} is required` };
+  }
+  return { valid: true };
+}
+
+export function validateMinLength(value: string, min: number, fieldName = 'Field'): ValidationResult {
+  if (value.length < min) {
+    return { valid: false, error: `${fieldName} must be at least ${min} characters` };
+  }
+  return { valid: true };
+}
+
+export function validateMaxLength(value: string, max: number, fieldName = 'Field'): ValidationResult {
+  if (value.length > max) {
+    return { valid: false, error: `${fieldName} must be at most ${max} characters` };
+  }
+  return { valid: true };
+}
+
+export function validateEmail(value: string): ValidationResult {
+  const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!re.test(value)) {
+    return { valid: false, error: 'Enter a valid email address' };
+  }
+  return { valid: true };
+}
+
+export function validateUrl(value: string): ValidationResult {
+  try {
+    new URL(value);
+    return { valid: true };
+  } catch {
+    return { valid: false, error: 'Enter a valid URL' };
+  }
+}
+
+export function validateRange(
+  value: number,
+  min: number,
+  max: number,
+  fieldName = 'Value',
+): ValidationResult {
+  if (value < min || value > max) {
+    return { valid: false, error: `${fieldName} must be between ${min} and ${max}` };
+  }
+  return { valid: true };
+}
+
+export function compose(...fns: (() => ValidationResult)[]): ValidationResult {
+  for (const fn of fns) {
+    const result = fn();
+    if (!result.valid) return result;
+  }
+  return { valid: true };
+}


### PR DESCRIPTION
## Summary

Resolves 4 open issues by adding reusable analytics UI components and a shared validation utility.

- closes #288
- closes #289
- closes #290
- closes #291

### Changes

- nalytics/components/Breadcrumbs.tsx - auto-generates breadcrumb trail from usePathname(), supports manual items override, chevron separators, mobile truncation, ria-current="page" on last item
- nalytics/components/Tabs.tsx - accessible tab list with ole="tab" / ole="tabpanel", active underline indicator, disabled tab support
- nalytics/components/Dropdown.tsx - click-trigger dropdown menu, outside-click close, left/right alignment, danger and disabled item variants
- nalytics/lib/validation.ts - pure validation helpers (alidateRequired, alidateEmail, alidateUrl, alidateMinLength, alidateMaxLength, alidateRange, compose)