### PR TITLE
feat: add Toast, Modal, Tooltip components and DarkModeToggle

### DIFF
--- a/analytics/components/DarkModeToggle.tsx
+++ b/analytics/components/DarkModeToggle.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function DarkModeToggle() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const isDark = saved === 'dark' || (!saved && prefersDark);
+    setDark(isDark);
+    document.documentElement.classList.toggle('dark', isDark);
+  }, []);
+
+  function toggle() {
+    const next = !dark;
+    setDark(next);
+    document.documentElement.classList.toggle('dark', next);
+    localStorage.setItem('theme', next ? 'dark' : 'light');
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label={dark ? 'Switch to light mode' : 'Switch to dark mode'}
+      className="inline-flex items-center justify-center rounded-full p-2 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+    >
+      {dark ? (
+        <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <circle cx="12" cy="12" r="5" />
+          <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+        </svg>
+      ) : (
+        <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/analytics/components/Modal.tsx
+++ b/analytics/components/Modal.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { ReactNode, useEffect } from 'react';
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: ReactNode;
+  size?: 'sm' | 'md' | 'lg';
+  footer?: ReactNode;
+}
+
+const sizeClasses = {
+  sm: 'max-w-sm',
+  md: 'max-w-md',
+  lg: 'max-w-lg',
+};
+
+export default function Modal({ open, onClose, title, children, size = 'md', footer }: ModalProps) {
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={title ? 'modal-title' : undefined}
+    >
+      <div className={`relative w-full ${sizeClasses[size]} rounded-xl bg-white shadow-xl dark:bg-gray-900`}>
+        {title && (
+          <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4 dark:border-gray-700">
+            <h2 id="modal-title" className="text-base font-semibold text-gray-900 dark:text-gray-100">
+              {title}
+            </h2>
+            <button
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+              aria-label="Close"
+            >
+              ✕
+            </button>
+          </div>
+        )}
+
+        <div className="px-6 py-4 text-sm text-gray-700 dark:text-gray-300">
+          {children}
+        </div>
+
+        {footer && (
+          <div className="flex justify-end gap-2 border-t border-gray-200 px-6 py-3 dark:border-gray-700">
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/analytics/components/Toast.tsx
+++ b/analytics/components/Toast.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type ToastType = 'success' | 'error' | 'warning' | 'info';
+
+interface ToastProps {
+  message: string;
+  type?: ToastType;
+  duration?: number;
+  onClose?: () => void;
+}
+
+const typeClasses: Record<ToastType, string> = {
+  success: 'bg-green-50 border-green-400 text-green-800 dark:bg-green-900/30 dark:border-green-500 dark:text-green-300',
+  error: 'bg-red-50 border-red-400 text-red-800 dark:bg-red-900/30 dark:border-red-500 dark:text-red-300',
+  warning: 'bg-yellow-50 border-yellow-400 text-yellow-800 dark:bg-yellow-900/30 dark:border-yellow-500 dark:text-yellow-300',
+  info: 'bg-blue-50 border-blue-400 text-blue-800 dark:bg-blue-900/30 dark:border-blue-500 dark:text-blue-300',
+};
+
+const icons: Record<ToastType, string> = {
+  success: '✓',
+  error: '✕',
+  warning: '⚠',
+  info: 'ℹ',
+};
+
+export function Toast({ message, type = 'info', duration = 4000, onClose }: ToastProps) {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setVisible(false);
+      onClose?.();
+    }, duration);
+    return () => clearTimeout(timer);
+  }, [duration, onClose]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="alert"
+      className={`flex items-start gap-3 rounded-lg border px-4 py-3 text-sm shadow-md ${typeClasses[type]}`}
+    >
+      <span className="font-bold">{icons[type]}</span>
+      <span className="flex-1">{message}</span>
+      <button
+        onClick={() => { setVisible(false); onClose?.(); }}
+        className="ml-2 opacity-60 hover:opacity-100 transition-opacity"
+        aria-label="Dismiss"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
+
+interface ToastItem {
+  id: string;
+  message: string;
+  type?: ToastType;
+}
+
+interface ToastContainerProps {
+  toasts: ToastItem[];
+  onRemove: (id: string) => void;
+}
+
+export function ToastContainer({ toasts, onRemove }: ToastContainerProps) {
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 w-80">
+      {toasts.map((t) => (
+        <Toast key={t.id} message={t.message} type={t.type} onClose={() => onRemove(t.id)} />
+      ))}
+    </div>
+  );
+}
+
+export default Toast;

--- a/analytics/components/Tooltip.tsx
+++ b/analytics/components/Tooltip.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { ReactNode, useRef, useState } from 'react';
+
+type Placement = 'top' | 'bottom' | 'left' | 'right';
+
+interface TooltipProps {
+  content: string;
+  children: ReactNode;
+  placement?: Placement;
+  delay?: number;
+}
+
+const placementClasses: Record<Placement, string> = {
+  top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
+  bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
+  left: 'right-full top-1/2 -translate-y-1/2 mr-2',
+  right: 'left-full top-1/2 -translate-y-1/2 ml-2',
+};
+
+export default function Tooltip({ content, children, placement = 'top', delay = 300 }: TooltipProps) {
+  const [visible, setVisible] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function show() {
+    timer.current = setTimeout(() => setVisible(true), delay);
+  }
+
+  function hide() {
+    if (timer.current) clearTimeout(timer.current);
+    setVisible(false);
+  }
+
+  return (
+    <span
+      className="relative inline-flex"
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
+      {children}
+      {visible && (
+        <span
+          role="tooltip"
+          className={`pointer-events-none absolute z-50 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white dark:bg-gray-700 ${placementClasses[placement]}`}
+        >
+          {content}
+        </span>
+      )}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

Adds four reusable analytics UI components.

- closes #284
- closes #285
- closes #286
- closes #287

### Changes

- nalytics/components/DarkModeToggle.tsx - button that reads prefers-color-scheme, persists choice to localStorage, toggles the dark class on <html> with sun/moon icons
- nalytics/components/Tooltip.tsx - hover/focus tooltip with configurable placement (top/bottom/left/right), show delay, and ole="tooltip" accessibility
- nalytics/components/Modal.tsx - accessible dialog with backdrop click and Escape-key close, optional title header, size variants (sm/md/lg), and footer slot
- nalytics/components/Toast.tsx - auto-dismissing notification toast with success/error/warning/info variants, dismiss button, and a ToastContainer for stacking multiple toasts