### PR TITLE
feat: onboarding funnel, content scores, uptime & SLA dashboard

### DIFF
--- a/analytics/app/content-scores/page.tsx
+++ b/analytics/app/content-scores/page.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+import { calcEngagementScores, MOCK_CONTENT } from '@/lib/engagement-score';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+const scored = calcEngagementScores(MOCK_CONTENT);
+const top5 = scored.slice(0, 5);
+
+const FACTOR_COLORS: Record<string, string> = {
+  views:          'rgba(99,102,241,0.8)',
+  likes:          'rgba(236,72,153,0.8)',
+  comments:       'rgba(34,197,94,0.8)',
+  shares:         'rgba(234,179,8,0.8)',
+  bookmarks:      'rgba(59,130,246,0.8)',
+  avgReadSeconds: 'rgba(168,85,247,0.8)',
+};
+
+const stackedData = {
+  labels: top5.map((c) => c.title.length > 20 ? c.title.slice(0, 20) + '…' : c.title),
+  datasets: Object.keys(FACTOR_COLORS).map((factor) => ({
+    label: factor,
+    data: top5.map((c) => c.breakdown[factor as keyof typeof c.breakdown]),
+    backgroundColor: FACTOR_COLORS[factor],
+    borderRadius: 2,
+  })),
+};
+
+const stackedOpts = {
+  responsive: true,
+  scales: {
+    x: { stacked: true, grid: { display: false }, ticks: { color: '#9ca3af' } },
+    y: { stacked: true, grid: { color: 'rgba(0,0,0,0.05)' }, ticks: { color: '#9ca3af' }, border: { display: false } },
+  },
+  plugins: { legend: { position: 'bottom' as const, labels: { color: '#6b7280', boxWidth: 12 } } },
+};
+
+function exportCSV() {
+  const header = 'Title,Score,Views,Likes,Comments,Shares,Bookmarks,AvgReadSec';
+  const rows = scored.map((c) =>
+    `"${c.title}",${c.score},${c.views},${c.likes},${c.comments},${c.shares},${c.bookmarks},${c.avgReadSeconds}`
+  );
+  const blob = new Blob([[header, ...rows].join('\n')], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = 'content-scores.csv'; a.click();
+  URL.revokeObjectURL(url);
+}
+
+export default function ContentScoresPage() {
+  const avg = (scored.reduce((s, c) => s + c.score, 0) / scored.length).toFixed(1);
+  const top = scored[0];
+
+  return (
+    <main style={{ maxWidth: 1180, margin: '0 auto', padding: '40px 24px 64px' }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', flexWrap: 'wrap', gap: 12, marginBottom: 32 }}>
+        <div>
+          <h1 style={{ margin: '0 0 8px', fontSize: 36 }}>Content Engagement Scores</h1>
+          <p style={{ margin: 0, color: '#475569' }}>Weighted scoring across views, likes, comments, shares, bookmarks, and read time.</p>
+        </div>
+        <button
+          onClick={exportCSV}
+          style={{ padding: '10px 20px', borderRadius: 10, background: '#6366f1', color: '#fff', border: 'none', fontWeight: 700, cursor: 'pointer', fontSize: 14 }}
+        >
+          Export CSV
+        </button>
+      </div>
+
+      {/* KPI cards */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 20, marginBottom: 28 }}>
+        {[
+          { label: 'Total Content Items', value: scored.length.toString() },
+          { label: 'Avg Engagement Score', value: avg },
+          { label: 'Top Scorer', value: top.title.length > 18 ? top.title.slice(0, 18) + '…' : top.title },
+          { label: 'Top Score', value: top.score.toString() },
+        ].map(({ label, value }) => (
+          <div key={label} style={{ background: '#fff', borderRadius: 20, padding: '22px 24px', border: '1px solid rgba(148,163,184,0.16)', boxShadow: '0 4px 16px rgba(15,23,42,0.06)' }}>
+            <p style={{ margin: '0 0 6px', color: '#64748b', fontSize: 13, fontWeight: 600 }}>{label}</p>
+            <p style={{ margin: 0, fontSize: 28, fontWeight: 700 }}>{value}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Stacked bar chart */}
+      <div style={{ background: '#fff', borderRadius: 20, padding: '24px', border: '1px solid rgba(148,163,184,0.16)', marginBottom: 28 }}>
+        <h2 style={{ marginTop: 0, fontSize: 18 }}>Engagement Factor Breakdown — Top 5</h2>
+        <Bar data={stackedData} options={stackedOpts} />
+      </div>
+
+      {/* Leaderboard table */}
+      <div style={{ background: '#fff', borderRadius: 20, padding: '24px', border: '1px solid rgba(148,163,184,0.16)' }}>
+        <h2 style={{ marginTop: 0, fontSize: 18 }}>Full Leaderboard</h2>
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+            <thead>
+              <tr style={{ borderBottom: '2px solid #e2e8f0' }}>
+                {['#', 'Title', 'Score', 'Views', 'Likes', 'Comments', 'Shares', 'Bookmarks', 'Avg Read'].map((h) => (
+                  <th key={h} style={{ padding: '10px 12px', textAlign: 'left', color: '#64748b', fontWeight: 700, whiteSpace: 'nowrap' }}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {scored.map((c, i) => (
+                <tr key={c.id} style={{ borderBottom: '1px solid #f1f5f9', background: i % 2 === 0 ? '#fff' : '#fafafa' }}>
+                  <td style={{ padding: '10px 12px', color: '#94a3b8', fontWeight: 700 }}>{i + 1}</td>
+                  <td style={{ padding: '10px 12px', fontWeight: 600 }}>{c.title}</td>
+                  <td style={{ padding: '10px 12px' }}>
+                    <span style={{ background: '#ede9fe', color: '#6366f1', borderRadius: 6, padding: '2px 8px', fontWeight: 700 }}>{c.score}</span>
+                  </td>
+                  <td style={{ padding: '10px 12px' }}>{c.views.toLocaleString()}</td>
+                  <td style={{ padding: '10px 12px' }}>{c.likes.toLocaleString()}</td>
+                  <td style={{ padding: '10px 12px' }}>{c.comments.toLocaleString()}</td>
+                  <td style={{ padding: '10px 12px' }}>{c.shares.toLocaleString()}</td>
+                  <td style={{ padding: '10px 12px' }}>{c.bookmarks.toLocaleString()}</td>
+                  <td style={{ padding: '10px 12px' }}>{c.avgReadSeconds}s</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/analytics/app/sla/page.tsx
+++ b/analytics/app/sla/page.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Bar, Line } from 'react-chartjs-2';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, PointElement, LineElement, Tooltip, Legend);
+
+interface SLAMetric {
+  name: string;
+  target: number;   // %
+  actual: number;   // %
+  breaches: number;
+}
+
+const METRICS: SLAMetric[] = [
+  { name: 'API Availability',    target: 99.9,  actual: 99.94, breaches: 0 },
+  { name: 'Response Time P95',   target: 99.0,  actual: 98.20, breaches: 3 },
+  { name: 'Error Rate < 0.1%',   target: 99.9,  actual: 99.72, breaches: 1 },
+  { name: 'Gist Delivery',       target: 99.5,  actual: 99.61, breaches: 0 },
+  { name: 'Auth Success Rate',   target: 99.8,  actual: 99.85, breaches: 0 },
+  { name: 'Data Sync Latency',   target: 98.0,  actual: 97.40, breaches: 4 },
+];
+
+const months = ['Dec', 'Jan', 'Feb', 'Mar', 'Apr', 'May'];
+const complianceTrend = [97.2, 98.1, 98.8, 99.0, 98.5, 99.1];
+const breachTrend     = [8, 6, 4, 3, 5, 2];
+
+const trendData = {
+  labels: months,
+  datasets: [{
+    label: 'Compliance %',
+    data: complianceTrend,
+    borderColor: 'rgba(99,102,241,1)',
+    backgroundColor: 'rgba(99,102,241,0.08)',
+    tension: 0.4,
+    fill: true,
+    pointRadius: 4,
+    yAxisID: 'y',
+  }],
+};
+
+const breachData = {
+  labels: months,
+  datasets: [{
+    label: 'Breaches',
+    data: breachTrend,
+    backgroundColor: breachTrend.map((v) => v > 5 ? 'rgba(239,68,68,0.8)' : 'rgba(234,179,8,0.8)'),
+    borderRadius: 4,
+  }],
+};
+
+const lineOpts = {
+  responsive: true,
+  plugins: { legend: { display: false } },
+  scales: {
+    x: { grid: { display: false }, ticks: { color: '#9ca3af' } },
+    y: { min: 95, max: 100, grid: { color: 'rgba(0,0,0,0.05)' }, ticks: { color: '#9ca3af', callback: (v: number | string) => `${v}%` }, border: { display: false } },
+  },
+};
+
+const barOpts = {
+  responsive: true,
+  plugins: { legend: { display: false } },
+  scales: {
+    x: { grid: { display: false }, ticks: { color: '#9ca3af' } },
+    y: { beginAtZero: true, grid: { color: 'rgba(0,0,0,0.05)' }, ticks: { color: '#9ca3af' }, border: { display: false } },
+  },
+};
+
+const overallCompliance = (METRICS.filter((m) => m.actual >= m.target).length / METRICS.length * 100).toFixed(0);
+const totalBreaches = METRICS.reduce((s, m) => s + m.breaches, 0);
+const atRisk = METRICS.filter((m) => m.actual < m.target).length;
+
+export default function SLAPage() {
+  return (
+    <main style={{ maxWidth: 1180, margin: '0 auto', padding: '40px 24px 64px' }}>
+      <div style={{ marginBottom: 32 }}>
+        <h1 style={{ margin: '0 0 8px', fontSize: 36 }}>SLA Compliance Dashboard</h1>
+        <p style={{ margin: 0, color: '#475569' }}>Track SLA targets, breach alerts, and compliance trends.</p>
+      </div>
+
+      {/* KPI cards */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 20, marginBottom: 28 }}>
+        {[
+          { label: 'Overall Compliance',  value: `${overallCompliance}%`,       color: parseInt(overallCompliance) >= 80 ? '#16a34a' : '#dc2626' },
+          { label: 'Total Breaches (MTD)', value: totalBreaches.toString(),      color: totalBreaches > 0 ? '#dc2626' : '#16a34a' },
+          { label: 'SLAs At Risk',         value: atRisk.toString(),             color: atRisk > 0 ? '#ca8a04' : '#16a34a' },
+          { label: 'SLAs Met',             value: `${METRICS.length - atRisk} / ${METRICS.length}`, color: '#6366f1' },
+        ].map(({ label, value, color }) => (
+          <div key={label} style={{ background: '#fff', borderRadius: 20, padding: '22px 24px', border: '1px solid rgba(148,163,184,0.16)', boxShadow: '0 4px 16px rgba(15,23,42,0.06)' }}>
+            <p style={{ margin: '0 0 6px', color: '#64748b', fontSize: 13, fontWeight: 600 }}>{label}</p>
+            <p style={{ margin: 0, fontSize: 30, fontWeight: 700, color }}>{value}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* SLA targets vs actual table */}
+      <div style={{ background: '#fff', borderRadius: 20, padding: '24px', border: '1px solid rgba(148,163,184,0.16)', marginBottom: 24 }}>
+        <h2 style={{ marginTop: 0, fontSize: 18 }}>SLA Targets vs Actual</h2>
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+            <thead>
+              <tr style={{ borderBottom: '2px solid #e2e8f0' }}>
+                {['Metric', 'Target', 'Actual', 'Δ', 'Breaches', 'Status'].map((h) => (
+                  <th key={h} style={{ padding: '10px 14px', textAlign: 'left', color: '#64748b', fontWeight: 700 }}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {METRICS.map((m, i) => {
+                const met = m.actual >= m.target;
+                const delta = (m.actual - m.target).toFixed(2);
+                return (
+                  <tr key={m.name} style={{ borderBottom: '1px solid #f1f5f9', background: i % 2 === 0 ? '#fff' : '#fafafa' }}>
+                    <td style={{ padding: '10px 14px', fontWeight: 600 }}>{m.name}</td>
+                    <td style={{ padding: '10px 14px', color: '#64748b' }}>{m.target}%</td>
+                    <td style={{ padding: '10px 14px', fontWeight: 700, color: met ? '#16a34a' : '#dc2626' }}>{m.actual}%</td>
+                    <td style={{ padding: '10px 14px', color: met ? '#16a34a' : '#dc2626' }}>{met ? '+' : ''}{delta}%</td>
+                    <td style={{ padding: '10px 14px' }}>
+                      {m.breaches > 0
+                        ? <span style={{ background: '#fee2e2', color: '#dc2626', borderRadius: 6, padding: '2px 8px', fontWeight: 700 }}>{m.breaches}</span>
+                        : <span style={{ color: '#94a3b8' }}>0</span>}
+                    </td>
+                    <td style={{ padding: '10px 14px' }}>
+                      <span style={{ padding: '3px 10px', borderRadius: 20, fontSize: 12, fontWeight: 700, background: met ? '#dcfce7' : '#fee2e2', color: met ? '#16a34a' : '#dc2626' }}>
+                        {met ? '✓ Met' : '✗ Breached'}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Trend charts */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(480px, 1fr))', gap: 24 }}>
+        <div style={{ background: '#fff', borderRadius: 20, padding: '24px', border: '1px solid rgba(148,163,184,0.16)' }}>
+          <h2 style={{ marginTop: 0, fontSize: 18 }}>Compliance % Trend</h2>
+          <Line data={trendData} options={lineOpts} />
+        </div>
+        <div style={{ background: '#fff', borderRadius: 20, padding: '24px', border: '1px solid rgba(148,163,184,0.16)' }}>
+          <h2 style={{ marginTop: 0, fontSize: 18 }}>Monthly Breach Count</h2>
+          <Bar data={breachData} options={barOpts} />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/analytics/app/uptime/page.tsx
+++ b/analytics/app/uptime/page.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+  Filler,
+} from 'chart.js';
+import { Line } from 'react-chartjs-2';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend, Filler);
+
+const SERVICES = [
+  { name: 'API Gateway',    status: 'operational', uptime30: 99.97, uptime90: 99.94 },
+  { name: 'Auth Service',   status: 'operational', uptime30: 99.99, uptime90: 99.98 },
+  { name: 'Gist Indexer',   status: 'degraded',    uptime30: 98.72, uptime90: 99.41 },
+  { name: 'Map Tiles CDN',  status: 'operational', uptime30: 100.0, uptime90: 99.99 },
+  { name: 'Soroban Bridge', status: 'incident',    uptime30: 97.85, uptime90: 98.90 },
+  { name: 'IPFS Gateway',   status: 'operational', uptime30: 99.88, uptime90: 99.75 },
+];
+
+const STATUS_STYLE: Record<string, { bg: string; color: string; label: string }> = {
+  operational: { bg: '#dcfce7', color: '#16a34a', label: 'Operational' },
+  degraded:    { bg: '#fef9c3', color: '#ca8a04', label: 'Degraded'    },
+  incident:    { bg: '#fee2e2', color: '#dc2626', label: 'Incident'    },
+};
+
+const INCIDENTS = [
+  { date: '2026-05-24', service: 'Soroban Bridge', duration: '42 min', description: 'RPC node timeout causing transaction delays.' },
+  { date: '2026-05-18', service: 'Gist Indexer',   duration: '18 min', description: 'Database connection pool exhaustion under peak load.' },
+  { date: '2026-05-10', service: 'API Gateway',    duration: '7 min',  description: 'Deployment rollout caused brief 503 responses.' },
+];
+
+const days = Array.from({ length: 30 }, (_, i) => {
+  const d = new Date('2026-05-27');
+  d.setDate(d.getDate() - (29 - i));
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+});
+
+// Simulated response time data (ms)
+const responseTime = days.map((_, i) =>
+  Math.round(80 + Math.sin(i * 0.4) * 20 + Math.random() * 15)
+);
+
+const responseData = {
+  labels: days,
+  datasets: [{
+    label: 'Response Time (ms)',
+    data: responseTime,
+    borderColor: 'rgba(99,102,241,1)',
+    backgroundColor: 'rgba(99,102,241,0.08)',
+    tension: 0.4,
+    fill: true,
+    pointRadius: 0,
+    pointHoverRadius: 4,
+  }],
+};
+
+const lineOpts = {
+  responsive: true,
+  plugins: { legend: { display: false } },
+  scales: {
+    x: { grid: { display: false }, ticks: { color: '#9ca3af', maxTicksLimit: 8 } },
+    y: { beginAtZero: false, grid: { color: 'rgba(0,0,0,0.05)' }, ticks: { color: '#9ca3af', callback: (v: number | string) => `${v}ms` }, border: { display: false } },
+  },
+};
+
+const overallUptime30 = (SERVICES.reduce((s, svc) => s + svc.uptime30, 0) / SERVICES.length).toFixed(2);
+const overallUptime90 = (SERVICES.reduce((s, svc) => s + svc.uptime90, 0) / SERVICES.length).toFixed(2);
+const avgResponse = Math.round(responseTime.reduce((a, b) => a + b, 0) / responseTime.length);
+const activeIncidents = SERVICES.filter((s) => s.status === 'incident').length;
+
+export default function UptimePage() {
+  return (
+    <main style={{ maxWidth: 1180, margin: '0 auto', padding: '40px 24px 64px' }}>
+      <div style={{ marginBottom: 32 }}>
+        <h1 style={{ margin: '0 0 8px', fontSize: 36 }}>Server Uptime & Status</h1>
+        <p style={{ margin: 0, color: '#475569' }}>Real-time service health, uptime metrics, and incident history.</p>
+      </div>
+
+      {/* KPI cards */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 20, marginBottom: 28 }}>
+        {[
+          { label: 'Uptime (30 days)',  value: `${overallUptime30}%`, color: '#16a34a' },
+          { label: 'Uptime (90 days)',  value: `${overallUptime90}%`, color: '#16a34a' },
+          { label: 'Avg Response Time', value: `${avgResponse} ms`,   color: '#6366f1' },
+          { label: 'Active Incidents',  value: activeIncidents.toString(), color: activeIncidents > 0 ? '#dc2626' : '#16a34a' },
+        ].map(({ label, value, color }) => (
+          <div key={label} style={{ background: '#fff', borderRadius: 20, padding: '22px 24px', border: '1px solid rgba(148,163,184,0.16)', boxShadow: '0 4px 16px rgba(15,23,42,0.06)' }}>
+            <p style={{ margin: '0 0 6px', color: '#64748b', fontSize: 13, fontWeight: 600 }}>{label}</p>
+            <p style={{ margin: 0, fontSize: 30, fontWeight: 700, color }}>{value}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Service status grid */}
+      <div style={{ background: '#fff', borderRadius: 20, padding: '24px', border: '1px solid rgba(148,163,184,0.16)', marginBottom: 24 }}>
+        <h2 style={{ marginTop: 0, fontSize: 18 }}>Service Status</h2>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 12 }}>
+          {SERVICES.map((svc) => {
+            const st = STATUS_STYLE[svc.status];
+            return (
+              <div key={svc.name} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '14px 16px', borderRadius: 12, border: '1px solid #e2e8f0', background: '#fafafa' }}>
+                <div>
+                  <div style={{ fontWeight: 700, fontSize: 14 }}>{svc.name}</div>
+                  <div style={{ fontSize: 12, color: '#94a3b8', marginTop: 2 }}>
+                    30d: {svc.uptime30}% &nbsp;|&nbsp; 90d: {svc.uptime90}%
+                  </div>
+                </div>
+                <span style={{ padding: '4px 10px', borderRadius: 20, background: st.bg, color: st.color, fontSize: 12, fontWeight: 700 }}>
+                  {st.label}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Response time chart */}
+      <div style={{ background: '#fff', borderRadius: 20, padding: '24px', border: '1px solid rgba(148,163,184,0.16)', marginBottom: 24 }}>
+        <h2 style={{ marginTop: 0, fontSize: 18 }}>Response Time — Last 30 Days</h2>
+        <Line data={responseData} options={lineOpts} />
+      </div>
+
+      {/* Incident timeline */}
+      <div style={{ background: '#fff', borderRadius: 20, padding: '24px', border: '1px solid rgba(148,163,184,0.16)' }}>
+        <h2 style={{ marginTop: 0, fontSize: 18 }}>Incident Timeline</h2>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          {INCIDENTS.map((inc) => (
+            <div key={inc.date + inc.service} style={{ display: 'flex', gap: 16, padding: '14px 16px', borderRadius: 12, background: '#fef2f2', border: '1px solid #fecaca' }}>
+              <div style={{ minWidth: 90, fontSize: 12, color: '#dc2626', fontWeight: 700, paddingTop: 2 }}>{inc.date}</div>
+              <div>
+                <div style={{ fontWeight: 700, fontSize: 14 }}>{inc.service} <span style={{ color: '#94a3b8', fontWeight: 400 }}>— {inc.duration}</span></div>
+                <div style={{ fontSize: 13, color: '#475569', marginTop: 2 }}>{inc.description}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/analytics/components/charts/OnboardingFunnel.tsx
+++ b/analytics/components/charts/OnboardingFunnel.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import type { TooltipItem } from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+import { useState } from 'react';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+export interface OnboardingStep {
+  label: string;
+  users: number;
+  avgTimeSeconds: number;
+}
+
+const DEFAULT_STEPS: OnboardingStep[] = [
+  { label: 'Sign Up',         users: 10_000, avgTimeSeconds: 45  },
+  { label: 'Email Verify',    users: 8_200,  avgTimeSeconds: 120 },
+  { label: 'Profile Setup',   users: 6_500,  avgTimeSeconds: 90  },
+  { label: 'First Gist',      users: 4_800,  avgTimeSeconds: 75  },
+  { label: 'Invite Friend',   users: 2_900,  avgTimeSeconds: 60  },
+  { label: 'Completed',       users: 2_100,  avgTimeSeconds: 30  },
+];
+
+const COHORTS = ['All Users', 'Mobile', 'Desktop', 'Referral'] as const;
+type Cohort = typeof COHORTS[number];
+
+const COHORT_MULTIPLIERS: Record<Cohort, number> = {
+  'All Users': 1,
+  'Mobile':    0.55,
+  'Desktop':   0.38,
+  'Referral':  0.07,
+};
+
+function fmtTime(s: number) {
+  return s >= 60 ? `${Math.floor(s / 60)}m ${s % 60}s` : `${s}s`;
+}
+
+export default function OnboardingFunnel({ steps = DEFAULT_STEPS }: { steps?: OnboardingStep[] }) {
+  const [cohort, setCohort] = useState<Cohort>('All Users');
+  const [activeIdx, setActiveIdx] = useState<number | null>(null);
+
+  const mult = COHORT_MULTIPLIERS[cohort];
+  const scaled = steps.map((s) => ({ ...s, users: Math.round(s.users * mult) }));
+
+  const colors = scaled.map((s, i) => {
+    if (i === 0) return 'rgba(99,102,241,0.85)';
+    const rate = s.users / scaled[i - 1].users;
+    return rate < 0.6 ? 'rgba(239,68,68,0.8)' : 'rgba(99,102,241,0.85)';
+  });
+
+  const data = {
+    labels: scaled.map((s) => s.label),
+    datasets: [{
+      label: 'Users',
+      data: scaled.map((s) => s.users),
+      backgroundColor: colors,
+      borderRadius: 6,
+      borderSkipped: false,
+    }],
+  };
+
+  const options = {
+    responsive: true,
+    onClick: (_: unknown, elements: { index: number }[]) => {
+      if (elements.length > 0) setActiveIdx(elements[0].index);
+    },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        backgroundColor: 'rgba(17,24,39,0.9)',
+        titleColor: '#f9fafb',
+        bodyColor: '#c7d2fe',
+        padding: 12,
+        cornerRadius: 8,
+        displayColors: false,
+        callbacks: {
+          label: (item: TooltipItem<'bar'>) => {
+            const idx = item.dataIndex;
+            const s = scaled[idx];
+            const lines = [`  ${s.users.toLocaleString()} users`, `  Avg time: ${fmtTime(s.avgTimeSeconds)}`];
+            if (idx > 0) {
+              const rate = ((s.users / scaled[idx - 1].users) * 100).toFixed(1);
+              lines.push(`  Conversion: ${rate}%`);
+            }
+            return lines;
+          },
+        },
+      },
+    },
+    scales: {
+      x: { grid: { display: false }, ticks: { color: '#9ca3af', font: { size: 11 } }, border: { color: '#e5e7eb' } },
+      y: {
+        beginAtZero: true,
+        grid: { color: 'rgba(0,0,0,0.05)' },
+        ticks: { color: '#9ca3af', font: { size: 11 }, callback: (v: number | string) => Number(v).toLocaleString() },
+        border: { display: false },
+      },
+    },
+  };
+
+  const totalRate = scaled.length > 1
+    ? ((scaled[scaled.length - 1].users / scaled[0].users) * 100).toFixed(1)
+    : '100';
+
+  return (
+    <div style={{ width: '100%' }}>
+      {/* Cohort selector */}
+      <div style={{ display: 'flex', gap: 8, marginBottom: 20, flexWrap: 'wrap' }}>
+        {COHORTS.map((c) => (
+          <button
+            key={c}
+            onClick={() => setCohort(c)}
+            style={{
+              padding: '6px 14px',
+              borderRadius: 20,
+              border: '1px solid',
+              borderColor: cohort === c ? '#6366f1' : '#e2e8f0',
+              background: cohort === c ? '#6366f1' : '#fff',
+              color: cohort === c ? '#fff' : '#475569',
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            {c}
+          </button>
+        ))}
+        <span style={{ marginLeft: 'auto', fontSize: 13, color: '#64748b', alignSelf: 'center' }}>
+          Overall completion: <strong style={{ color: parseFloat(totalRate) < 30 ? '#ef4444' : '#6366f1' }}>{totalRate}%</strong>
+        </span>
+      </div>
+
+      <Bar data={data} options={options} />
+
+      {/* Conversion rate row */}
+      <div style={{ display: 'flex', justifyContent: 'space-around', marginTop: 10 }}>
+        {scaled.map((s, i) => {
+          if (i === 0) return <div key={s.label} style={{ flex: 1 }} />;
+          const rate = ((s.users / scaled[i - 1].users) * 100).toFixed(1);
+          const bad = s.users / scaled[i - 1].users < 0.6;
+          return (
+            <div key={s.label} style={{ flex: 1, textAlign: 'center', fontSize: 12, fontWeight: 600, color: bad ? '#ef4444' : '#6366f1' }}>
+              {rate}%
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Drop-off highlights */}
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 16 }}>
+        {scaled.map((s, i) => {
+          if (i === 0) return null;
+          const rate = s.users / scaled[i - 1].users;
+          if (rate >= 0.6) return null;
+          return (
+            <div key={s.label} style={{ padding: '6px 12px', borderRadius: 8, background: '#fef2f2', border: '1px solid #fecaca', fontSize: 12, color: '#dc2626' }}>
+              ⚠ Drop-off at <strong>{s.label}</strong>: {((1 - rate) * 100).toFixed(1)}% lost
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Step detail */}
+      {activeIdx !== null && (
+        <div style={{ marginTop: 16, padding: '12px 16px', borderRadius: 12, background: '#f8fafc', border: '1px solid #e2e8f0', fontSize: 13 }}>
+          <strong>{scaled[activeIdx].label}</strong> — {scaled[activeIdx].users.toLocaleString()} users &nbsp;|&nbsp; Avg time: {fmtTime(scaled[activeIdx].avgTimeSeconds)}
+          {activeIdx > 0 && (
+            <span style={{ marginLeft: 12, color: '#64748b' }}>
+              Conversion: {((scaled[activeIdx].users / scaled[activeIdx - 1].users) * 100).toFixed(1)}%
+            </span>
+          )}
+          <button onClick={() => setActiveIdx(null)} style={{ marginLeft: 16, fontSize: 12, color: '#6366f1', background: 'none', border: 'none', cursor: 'pointer' }}>
+            Close
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/analytics/lib/engagement-score.ts
+++ b/analytics/lib/engagement-score.ts
@@ -1,0 +1,69 @@
+export interface ContentItem {
+  id: string;
+  title: string;
+  views: number;
+  likes: number;
+  comments: number;
+  shares: number;
+  bookmarks: number;
+  avgReadSeconds: number;
+}
+
+export interface ScoredContent extends ContentItem {
+  score: number;
+  breakdown: Record<string, number>;
+}
+
+/** Weights must sum to 1 */
+const WEIGHTS = {
+  views:           0.10,
+  likes:           0.25,
+  comments:        0.25,
+  shares:          0.20,
+  bookmarks:       0.10,
+  avgReadSeconds:  0.10,
+} as const;
+
+/** Normalise a value to [0, 100] given the max in the dataset */
+function norm(value: number, max: number): number {
+  return max === 0 ? 0 : (value / max) * 100;
+}
+
+export function calcEngagementScores(items: ContentItem[]): ScoredContent[] {
+  if (items.length === 0) return [];
+
+  const maxes = {
+    views:          Math.max(...items.map((i) => i.views)),
+    likes:          Math.max(...items.map((i) => i.likes)),
+    comments:       Math.max(...items.map((i) => i.comments)),
+    shares:         Math.max(...items.map((i) => i.shares)),
+    bookmarks:      Math.max(...items.map((i) => i.bookmarks)),
+    avgReadSeconds: Math.max(...items.map((i) => i.avgReadSeconds)),
+  };
+
+  return items
+    .map((item) => {
+      const breakdown = {
+        views:          parseFloat((norm(item.views,          maxes.views)          * WEIGHTS.views).toFixed(2)),
+        likes:          parseFloat((norm(item.likes,          maxes.likes)          * WEIGHTS.likes).toFixed(2)),
+        comments:       parseFloat((norm(item.comments,       maxes.comments)       * WEIGHTS.comments).toFixed(2)),
+        shares:         parseFloat((norm(item.shares,         maxes.shares)         * WEIGHTS.shares).toFixed(2)),
+        bookmarks:      parseFloat((norm(item.bookmarks,      maxes.bookmarks)      * WEIGHTS.bookmarks).toFixed(2)),
+        avgReadSeconds: parseFloat((norm(item.avgReadSeconds, maxes.avgReadSeconds) * WEIGHTS.avgReadSeconds).toFixed(2)),
+      };
+      const score = parseFloat(Object.values(breakdown).reduce((a, b) => a + b, 0).toFixed(2));
+      return { ...item, score, breakdown };
+    })
+    .sort((a, b) => b.score - a.score);
+}
+
+export const MOCK_CONTENT: ContentItem[] = [
+  { id: '1', title: 'Hidden Gems in Downtown',   views: 4200, likes: 380, comments: 92, shares: 145, bookmarks: 210, avgReadSeconds: 180 },
+  { id: '2', title: 'Best Street Food Spots',    views: 6800, likes: 620, comments: 134, shares: 290, bookmarks: 340, avgReadSeconds: 240 },
+  { id: '3', title: 'Weekend Hiking Trails',     views: 3100, likes: 270, comments: 58, shares: 88,  bookmarks: 155, avgReadSeconds: 210 },
+  { id: '4', title: 'Local Art Exhibitions',     views: 1900, likes: 190, comments: 44, shares: 62,  bookmarks: 98,  avgReadSeconds: 150 },
+  { id: '5', title: 'Night Market Guide',        views: 5500, likes: 510, comments: 110, shares: 220, bookmarks: 280, avgReadSeconds: 195 },
+  { id: '6', title: 'Coffee Shop Reviews',       views: 7200, likes: 680, comments: 155, shares: 310, bookmarks: 390, avgReadSeconds: 260 },
+  { id: '7', title: 'Community Events This Week',views: 2800, likes: 230, comments: 67, shares: 95,  bookmarks: 120, avgReadSeconds: 130 },
+  { id: '8', title: 'Parking Tips & Tricks',     views: 1400, likes: 110, comments: 28, shares: 40,  bookmarks: 65,  avgReadSeconds: 90  },
+];


### PR DESCRIPTION
## Summary

Resolves four analytics issues in a single PR.

Closes #364
Closes #365
Closes #366
Closes #367

## Changes

### #364 — User Onboarding Completion Funnel
- `analytics/components/charts/OnboardingFunnel.tsx`
- Multi-step bar chart with cohort filter (All / Mobile / Desktop / Referral)
- Drop-off highlights for steps below 60% conversion
- Avg time-per-step in tooltip, click-to-drill-down detail panel

### #365 — Content Engagement Score Calculator
- `analytics/lib/engagement-score.ts` — pure weighted-scoring function (views, likes, comments, shares, bookmarks, read time)
- `analytics/app/content-scores/page.tsx` — leaderboard table + stacked bar breakdown for top 5, CSV export

### #366 — Server Uptime & Status Page
- `analytics/app/uptime/page.tsx`
- Per-service status badges (operational / degraded / incident)
- 30-day response time line chart
- Incident timeline with date, service, duration, and description

### #367 — SLA Compliance Dashboard
- `analytics/app/sla/page.tsx`
- Targets vs actual table with delta and breach count per metric
- Compliance % trend line chart and monthly breach count bar chart
- KPI cards: overall compliance %, total breaches, SLAs at risk