### PR TITLE
feat: add email campaigns, support, roadmap, and NPS analytics pages

### DIFF
--- a/analytics/app/email-campaigns/page.tsx
+++ b/analytics/app/email-campaigns/page.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  PointElement,
+  LineElement,
+  ArcElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Bar, Line, Doughnut } from 'react-chartjs-2';
+import { useState } from 'react';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, PointElement, LineElement, ArcElement, Tooltip, Legend);
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface Campaign {
+  name: string;
+  sent: number;
+  opens: number;
+  clicks: number;
+  unsubscribes: number;
+  date: string;
+}
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+
+const CAMPAIGNS: Campaign[] = [
+  { name: 'Welcome Series',       sent: 12400, opens: 7068, clicks: 2604, unsubscribes: 62,  date: '2026-05-01' },
+  { name: 'Feature Announcement', sent: 18200, opens: 9282, clicks: 3276, unsubscribes: 91,  date: '2026-05-05' },
+  { name: 'Weekly Digest #18',    sent: 21500, opens: 9675, clicks: 2795, unsubscribes: 108, date: '2026-05-12' },
+  { name: 'Re-engagement',        sent: 8900,  opens: 2670, clicks: 712,  unsubscribes: 267, date: '2026-05-15' },
+  { name: 'Product Update v2.4',  sent: 19800, opens: 11286,clicks: 4158, unsubscribes: 79,  date: '2026-05-20' },
+  { name: 'Weekly Digest #19',    sent: 22100, opens: 10387,clicks: 3094, unsubscribes: 133, date: '2026-05-26' },
+];
+
+const BEST_SEND_TIMES = [
+  { day: 'Mon', hour: '10am', rate: 28.4 },
+  { day: 'Tue', hour: '9am',  rate: 31.2 },
+  { day: 'Wed', hour: '11am', rate: 34.7 },
+  { day: 'Thu', hour: '10am', rate: 33.1 },
+  { day: 'Fri', hour: '9am',  rate: 29.8 },
+  { day: 'Sat', hour: '12pm', rate: 22.1 },
+  { day: 'Sun', hour: '2pm',  rate: 19.6 },
+];
+
+const fmt = (n: number) => n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+const pct = (a: number, b: number) => ((a / b) * 100).toFixed(1) + '%';
+
+export default function EmailCampaignsPage() {
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const visible = selected ? CAMPAIGNS.filter((c) => c.name === selected) : CAMPAIGNS;
+
+  const totalSent   = CAMPAIGNS.reduce((s, c) => s + c.sent, 0);
+  const totalOpens  = CAMPAIGNS.reduce((s, c) => s + c.opens, 0);
+  const totalClicks = CAMPAIGNS.reduce((s, c) => s + c.clicks, 0);
+  const totalUnsubs = CAMPAIGNS.reduce((s, c) => s + c.unsubscribes, 0);
+
+  const openRateData = {
+    labels: CAMPAIGNS.map((c) => c.name),
+    datasets: [
+      {
+        label: 'Open Rate %',
+        data: CAMPAIGNS.map((c) => +((c.opens / c.sent) * 100).toFixed(1)),
+        backgroundColor: 'rgba(99, 102, 241, 0.7)',
+        borderColor: 'rgb(99, 102, 241)',
+        borderWidth: 1,
+      },
+      {
+        label: 'Click Rate %',
+        data: CAMPAIGNS.map((c) => +((c.clicks / c.sent) * 100).toFixed(1)),
+        backgroundColor: 'rgba(16, 185, 129, 0.7)',
+        borderColor: 'rgb(16, 185, 129)',
+        borderWidth: 1,
+      },
+    ],
+  };
+
+  const unsubData = {
+    labels: CAMPAIGNS.map((c) => c.name),
+    datasets: [{
+      label: 'Unsubscribes',
+      data: CAMPAIGNS.map((c) => c.unsubscribes),
+      borderColor: 'rgb(239, 68, 68)',
+      backgroundColor: 'rgba(239, 68, 68, 0.1)',
+      tension: 0.3,
+      fill: true,
+    }],
+  };
+
+  const bestTimeData = {
+    labels: BEST_SEND_TIMES.map((t) => `${t.day} ${t.hour}`),
+    datasets: [{
+      label: 'Avg Open Rate %',
+      data: BEST_SEND_TIMES.map((t) => t.rate),
+      backgroundColor: BEST_SEND_TIMES.map((t) =>
+        t.rate === Math.max(...BEST_SEND_TIMES.map((x) => x.rate))
+          ? 'rgba(245, 158, 11, 0.9)'
+          : 'rgba(99, 102, 241, 0.6)'
+      ),
+      borderRadius: 4,
+    }],
+  };
+
+  const chartOpts = { responsive: true, maintainAspectRatio: false, plugins: { legend: { position: 'bottom' as const } } };
+
+  return (
+    <main className="p-6 space-y-8 max-w-7xl mx-auto">
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Email Campaign Performance</h1>
+
+      {/* KPI cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {[
+          { label: 'Total Sent',    value: fmt(totalSent),   sub: `${CAMPAIGNS.length} campaigns` },
+          { label: 'Avg Open Rate', value: pct(totalOpens, totalSent),  sub: `${fmt(totalOpens)} opens` },
+          { label: 'Avg Click Rate',value: pct(totalClicks, totalSent), sub: `${fmt(totalClicks)} clicks` },
+          { label: 'Unsubscribes',  value: fmt(totalUnsubs), sub: pct(totalUnsubs, totalSent) + ' rate' },
+        ].map((kpi) => (
+          <div key={kpi.label} className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-gray-100 dark:border-gray-700">
+            <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">{kpi.label}</p>
+            <p className="text-2xl font-bold text-gray-900 dark:text-white mt-1">{kpi.value}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{kpi.sub}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Open & click rates */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-4">Open Rate vs Click Rate by Campaign</h2>
+        <div className="h-64">
+          <Bar data={openRateData} options={chartOpts} />
+        </div>
+      </div>
+
+      {/* Unsubscribe trend + best send time */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-4">Unsubscribe Trend</h2>
+          <div className="h-56">
+            <Line data={unsubData} options={{ ...chartOpts, plugins: { legend: { display: false } } }} />
+          </div>
+        </div>
+
+        <div className="bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-4">Best Send Time (Avg Open Rate %)</h2>
+          <div className="h-56">
+            <Bar data={bestTimeData} options={{ ...chartOpts, plugins: { legend: { display: false } } }} />
+          </div>
+        </div>
+      </div>
+
+      {/* Campaign table */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-4">Campaign List</h2>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                <th className="pb-2 pr-4">Campaign</th>
+                <th className="pb-2 pr-4 text-right">Sent</th>
+                <th className="pb-2 pr-4 text-right">Open Rate</th>
+                <th className="pb-2 pr-4 text-right">Click Rate</th>
+                <th className="pb-2 pr-4 text-right">Unsubs</th>
+                <th className="pb-2 text-right">Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              {CAMPAIGNS.map((c) => (
+                <tr
+                  key={c.name}
+                  onClick={() => setSelected(selected === c.name ? null : c.name)}
+                  className="border-b border-gray-50 dark:border-gray-700/50 last:border-0 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/30"
+                >
+                  <td className="py-2 pr-4 font-medium text-gray-900 dark:text-white">{c.name}</td>
+                  <td className="py-2 pr-4 text-right text-gray-600 dark:text-gray-300">{fmt(c.sent)}</td>
+                  <td className="py-2 pr-4 text-right text-indigo-600 dark:text-indigo-400 font-medium">{pct(c.opens, c.sent)}</td>
+                  <td className="py-2 pr-4 text-right text-emerald-600 dark:text-emerald-400 font-medium">{pct(c.clicks, c.sent)}</td>
+                  <td className="py-2 pr-4 text-right text-red-500 dark:text-red-400">{c.unsubscribes}</td>
+                  <td className="py-2 text-right text-gray-500 dark:text-gray-400">{c.date}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/analytics/app/roadmap/page.tsx
+++ b/analytics/app/roadmap/page.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  PointElement,
+  LineElement,
+  ArcElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Bar, Line, Doughnut } from 'react-chartjs-2';
+import { useState } from 'react';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, PointElement, LineElement, ArcElement, Tooltip, Legend);
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type Status = 'Planned' | 'In Progress' | 'Completed' | 'Under Review';
+type Segment = 'Enterprise' | 'Pro' | 'Free';
+
+interface Feature {
+  id: number;
+  title: string;
+  votes: number;
+  status: Status;
+  trend: number[];   // last 6 weeks
+  segments: Record<Segment, number>;
+  priority: number;  // 0–100
+}
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+
+const FEATURES: Feature[] = [
+  {
+    id: 1, title: 'Offline mode',
+    votes: 1842, status: 'Planned',
+    trend: [980, 1120, 1340, 1510, 1680, 1842],
+    segments: { Enterprise: 620, Pro: 810, Free: 412 },
+    priority: 88,
+  },
+  {
+    id: 2, title: 'Custom map layers',
+    votes: 1534, status: 'In Progress',
+    trend: [800, 950, 1100, 1250, 1400, 1534],
+    segments: { Enterprise: 780, Pro: 540, Free: 214 },
+    priority: 82,
+  },
+  {
+    id: 3, title: 'Team workspaces',
+    votes: 1287, status: 'Under Review',
+    trend: [600, 720, 890, 1010, 1150, 1287],
+    segments: { Enterprise: 910, Pro: 290, Free: 87 },
+    priority: 79,
+  },
+  {
+    id: 4, title: 'Export to CSV/PDF',
+    votes: 987,  status: 'Completed',
+    trend: [400, 520, 680, 790, 900, 987],
+    segments: { Enterprise: 310, Pro: 480, Free: 197 },
+    priority: 65,
+  },
+  {
+    id: 5, title: 'Dark mode',
+    votes: 876,  status: 'Completed',
+    trend: [300, 420, 580, 700, 810, 876],
+    segments: { Enterprise: 180, Pro: 390, Free: 306 },
+    priority: 60,
+  },
+  {
+    id: 6, title: 'Webhook integrations',
+    votes: 743,  status: 'Planned',
+    trend: [200, 310, 430, 560, 660, 743],
+    segments: { Enterprise: 520, Pro: 180, Free: 43 },
+    priority: 72,
+  },
+];
+
+const WEEKS = ['W1', 'W2', 'W3', 'W4', 'W5', 'W6'];
+const SEGMENTS: Segment[] = ['Enterprise', 'Pro', 'Free'];
+const SEGMENT_COLORS: Record<Segment, string> = {
+  Enterprise: 'rgba(99, 102, 241, 0.8)',
+  Pro:        'rgba(16, 185, 129, 0.8)',
+  Free:       'rgba(107, 114, 128, 0.8)',
+};
+
+const STATUS_COLORS: Record<Status, string> = {
+  'Planned':      'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  'In Progress':  'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  'Completed':    'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  'Under Review': 'bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300',
+};
+
+const chartOpts = { responsive: true, maintainAspectRatio: false, plugins: { legend: { position: 'bottom' as const } } };
+
+export default function RoadmapPage() {
+  const [activeFeature, setActiveFeature] = useState<Feature>(FEATURES[0]);
+
+  const totalVotes = FEATURES.reduce((s, f) => s + f.votes, 0);
+
+  const votesBarData = {
+    labels: FEATURES.map((f) => f.title),
+    datasets: [{
+      label: 'Votes',
+      data: FEATURES.map((f) => f.votes),
+      backgroundColor: FEATURES.map((f) =>
+        f.id === activeFeature.id ? 'rgba(99, 102, 241, 0.9)' : 'rgba(99, 102, 241, 0.4)'
+      ),
+      borderColor: 'rgb(99, 102, 241)',
+      borderWidth: 1,
+      borderRadius: 4,
+    }],
+  };
+
+  const trendData = {
+    labels: WEEKS,
+    datasets: [{
+      label: activeFeature.title,
+      data: activeFeature.trend,
+      borderColor: 'rgb(99, 102, 241)',
+      backgroundColor: 'rgba(99, 102, 241, 0.1)',
+      tension: 0.3,
+      fill: true,
+    }],
+  };
+
+  const segmentData = {
+    labels: SEGMENTS,
+    datasets: [{
+      data: SEGMENTS.map((s) => activeFeature.segments[s]),
+      backgroundColor: SEGMENTS.map((s) => SEGMENT_COLORS[s]),
+      borderWidth: 1,
+    }],
+  };
+
+  return (
+    <main className="p-6 space-y-8 max-w-7xl mx-auto">
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Product Roadmap Voting</h1>
+
+      {/* KPI cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {[
+          { label: 'Total Votes',      value: totalVotes.toLocaleString(), sub: 'across all features' },
+          { label: 'Feature Requests', value: String(FEATURES.length),     sub: 'tracked items' },
+          { label: 'In Progress',      value: String(FEATURES.filter((f) => f.status === 'In Progress').length), sub: 'being built' },
+          { label: 'Top Priority',     value: FEATURES.sort((a, b) => b.priority - a.priority)[0].title, sub: `score ${FEATURES[0].priority}/100` },
+        ].map((kpi) => (
+          <div key={kpi.label} className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-gray-100 dark:border-gray-700">
+            <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">{kpi.label}</p>
+            <p className="text-xl font-bold text-gray-900 dark:text-white mt-1 truncate">{kpi.value}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{kpi.sub}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Vote counts bar */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-1">Vote Counts</h2>
+        <p className="text-xs text-gray-400 dark:text-gray-500 mb-4">Click a feature row below to drill in</p>
+        <div className="h-56">
+          <Bar data={votesBarData} options={{ ...chartOpts, plugins: { legend: { display: false } } }} />
+        </div>
+      </div>
+
+      {/* Trend + segment breakdown for selected feature */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2 bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-4">
+            Vote Trend — <span className="text-indigo-600 dark:text-indigo-400">{activeFeature.title}</span>
+          </h2>
+          <div className="h-52">
+            <Line data={trendData} options={{ ...chartOpts, plugins: { legend: { display: false } } }} />
+          </div>
+        </div>
+
+        <div className="bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-4">User Segment Breakdown</h2>
+          <div className="h-52">
+            <Doughnut data={segmentData} options={chartOpts} />
+          </div>
+        </div>
+      </div>
+
+      {/* Feature request list */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-4">Feature Requests</h2>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                <th className="pb-2 pr-4">Feature</th>
+                <th className="pb-2 pr-4 text-right">Votes</th>
+                <th className="pb-2 pr-4">Status</th>
+                <th className="pb-2 text-right">Priority Score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {[...FEATURES].sort((a, b) => b.votes - a.votes).map((f) => (
+                <tr
+                  key={f.id}
+                  onClick={() => setActiveFeature(f)}
+                  className={`border-b border-gray-50 dark:border-gray-700/50 last:border-0 cursor-pointer transition-colors ${
+                    f.id === activeFeature.id ? 'bg-indigo-50 dark:bg-indigo-900/20' : 'hover:bg-gray-50 dark:hover:bg-gray-700/30'
+                  }`}
+                >
+                  <td className="py-2 pr-4 font-medium text-gray-900 dark:text-white">{f.title}</td>
+                  <td className="py-2 pr-4 text-right text-gray-700 dark:text-gray-300 font-semibold">{f.votes.toLocaleString()}</td>
+                  <td className="py-2 pr-4">
+                    <span className={`px-2 py-0.5 rounded text-xs font-medium ${STATUS_COLORS[f.status]}`}>{f.status}</span>
+                  </td>
+                  <td className="py-2 text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      <div className="w-20 h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+                        <div className="h-full bg-indigo-500 rounded-full" style={{ width: `${f.priority}%` }} />
+                      </div>
+                      <span className="text-xs text-gray-600 dark:text-gray-400 w-8 text-right">{f.priority}</span>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/analytics/app/support/page.tsx
+++ b/analytics/app/support/page.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  PointElement,
+  LineElement,
+  ArcElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Bar, Line, Doughnut } from 'react-chartjs-2';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, PointElement, LineElement, ArcElement, Tooltip, Legend);
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+
+const WEEKS = ['W1', 'W2', 'W3', 'W4', 'W5', 'W6', 'W7', 'W8'];
+
+const TICKET_VOLUME = [142, 158, 134, 171, 189, 163, 177, 195];
+const RESOLVED     = [128, 149, 130, 155, 172, 158, 165, 181];
+
+const CATEGORIES = ['Bug Report', 'Feature Request', 'Billing', 'Account Access', 'General'];
+const CATEGORY_COUNTS = [312, 198, 145, 221, 87];
+const CATEGORY_COLORS = [
+  'rgba(239, 68, 68, 0.8)',
+  'rgba(99, 102, 241, 0.8)',
+  'rgba(245, 158, 11, 0.8)',
+  'rgba(16, 185, 129, 0.8)',
+  'rgba(107, 114, 128, 0.8)',
+];
+
+const RESOLUTION_BUCKETS = ['<1h', '1–4h', '4–8h', '8–24h', '1–3d', '>3d'];
+const RESOLUTION_DIST    = [89, 214, 178, 312, 143, 27];
+
+const AGENTS = [
+  { name: 'Alice M.',  resolved: 312, avgHours: 3.2, csat: 4.8 },
+  { name: 'Bob K.',    resolved: 287, avgHours: 4.1, csat: 4.6 },
+  { name: 'Carol T.',  resolved: 341, avgHours: 2.9, csat: 4.9 },
+  { name: 'David R.',  resolved: 198, avgHours: 5.8, csat: 4.2 },
+  { name: 'Eva S.',    resolved: 265, avgHours: 3.7, csat: 4.7 },
+];
+
+const chartOpts = { responsive: true, maintainAspectRatio: false, plugins: { legend: { position: 'bottom' as const } } };
+
+export default function SupportPage() {
+  const totalOpen     = TICKET_VOLUME.reduce((a, b) => a + b, 0);
+  const totalResolved = RESOLVED.reduce((a, b) => a + b, 0);
+  const resolutionRate = ((totalResolved / totalOpen) * 100).toFixed(1);
+  const avgResolutionH = (AGENTS.reduce((s, a) => s + a.avgHours, 0) / AGENTS.length).toFixed(1);
+
+  const volumeData = {
+    labels: WEEKS,
+    datasets: [
+      {
+        label: 'Opened',
+        data: TICKET_VOLUME,
+        backgroundColor: 'rgba(99, 102, 241, 0.7)',
+        borderColor: 'rgb(99, 102, 241)',
+        borderWidth: 1,
+      },
+      {
+        label: 'Resolved',
+        data: RESOLVED,
+        backgroundColor: 'rgba(16, 185, 129, 0.7)',
+        borderColor: 'rgb(16, 185, 129)',
+        borderWidth: 1,
+      },
+    ],
+  };
+
+  const categoryData = {
+    labels: CATEGORIES,
+    datasets: [{
+      data: CATEGORY_COUNTS,
+      backgroundColor: CATEGORY_COLORS,
+      borderWidth: 1,
+    }],
+  };
+
+  const resolutionData = {
+    labels: RESOLUTION_BUCKETS,
+    datasets: [{
+      label: 'Tickets',
+      data: RESOLUTION_DIST,
+      backgroundColor: RESOLUTION_DIST.map((_, i) =>
+        i <= 1 ? 'rgba(16, 185, 129, 0.75)' : i <= 3 ? 'rgba(245, 158, 11, 0.75)' : 'rgba(239, 68, 68, 0.75)'
+      ),
+      borderRadius: 4,
+    }],
+  };
+
+  return (
+    <main className="p-6 space-y-8 max-w-7xl mx-auto">
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Support Ticket Analytics</h1>
+
+      {/* KPI cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {[
+          { label: 'Total Tickets',    value: totalOpen.toLocaleString(),  sub: 'last 8 weeks' },
+          { label: 'Resolution Rate',  value: resolutionRate + '%',        sub: `${totalResolved.toLocaleString()} resolved` },
+          { label: 'Avg Resolution',   value: avgResolutionH + 'h',        sub: 'across all agents' },
+          { label: 'Avg CSAT',         value: (AGENTS.reduce((s, a) => s + a.csat, 0) / AGENTS.length).toFixed(1) + ' / 5', sub: 'customer satisfaction' },
+        ].map((kpi) => (
+          <div key={kpi.label} className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-gray-100 dark:border-gray-700">
+            <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">{kpi.label}</p>
+            <p className="text-2xl font-bold text-gray-900 dark:text-white mt-1">{kpi.value}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{kpi.sub}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Volume over time */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-4">Ticket Volume Over Time</h2>
+        <div className="h-64">
+          <Bar data={volumeData} options={chartOpts} />
+        </div>
+      </div>
+
+      {/* Category + resolution distribution */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-4">Category Breakdown</h2>
+          <div className="h-56">
+            <Doughnut data={categoryData} options={chartOpts} />
+          </div>
+        </div>
+
+        <div className="bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-4">Resolution Time Distribution</h2>
+          <div className="h-56">
+            <Bar data={resolutionData} options={{ ...chartOpts, plugins: { legend: { display: false } } }} />
+          </div>
+        </div>
+      </div>
+
+      {/* Agent performance table */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-4">Agent Performance</h2>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                <th className="pb-2 pr-4">Agent</th>
+                <th className="pb-2 pr-4 text-right">Resolved</th>
+                <th className="pb-2 pr-4 text-right">Avg Resolution</th>
+                <th className="pb-2 text-right">CSAT</th>
+              </tr>
+            </thead>
+            <tbody>
+              {AGENTS.sort((a, b) => b.resolved - a.resolved).map((agent) => (
+                <tr key={agent.name} className="border-b border-gray-50 dark:border-gray-700/50 last:border-0">
+                  <td className="py-2 pr-4 font-medium text-gray-900 dark:text-white">{agent.name}</td>
+                  <td className="py-2 pr-4 text-right text-gray-600 dark:text-gray-300">{agent.resolved}</td>
+                  <td className="py-2 pr-4 text-right text-amber-600 dark:text-amber-400">{agent.avgHours}h</td>
+                  <td className="py-2 text-right">
+                    <span className={`font-semibold ${agent.csat >= 4.7 ? 'text-emerald-600 dark:text-emerald-400' : 'text-gray-700 dark:text-gray-300'}`}>
+                      {agent.csat}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/analytics/components/charts/NPSChart.tsx
+++ b/analytics/components/charts/NPSChart.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  PointElement,
+  LineElement,
+  ArcElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Bar, Line, Doughnut } from 'react-chartjs-2';
+import { calcNPS, npsOverTime, npsBySegment, type NPSResponse } from '@/lib/nps';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, PointElement, LineElement, ArcElement, Tooltip, Legend);
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+
+const MOCK_RESPONSES: NPSResponse[] = [
+  ...Array.from({ length: 80 },  (_, i) => ({ score: 9 + (i % 2),  segment: 'Enterprise', date: `2026-0${(i % 5) + 1}-${String((i % 28) + 1).padStart(2, '0')}` })),
+  ...Array.from({ length: 120 }, (_, i) => ({ score: 7 + (i % 3),  segment: 'Pro',        date: `2026-0${(i % 5) + 1}-${String((i % 28) + 1).padStart(2, '0')}` })),
+  ...Array.from({ length: 100 }, (_, i) => ({ score: 4 + (i % 7),  segment: 'Free',       date: `2026-0${(i % 5) + 1}-${String((i % 28) + 1).padStart(2, '0')}` })),
+];
+
+const chartOpts = { responsive: true, maintainAspectRatio: false, plugins: { legend: { position: 'bottom' as const } } };
+
+export default function NPSChart() {
+  const overall   = calcNPS(MOCK_RESPONSES);
+  const trend     = npsOverTime(MOCK_RESPONSES);
+  const segments  = npsBySegment(MOCK_RESPONSES);
+
+  const breakdownData = {
+    labels: ['Promoters', 'Passives', 'Detractors'],
+    datasets: [{
+      data: [overall.promoters, overall.passives, overall.detractors],
+      backgroundColor: ['rgba(16, 185, 129, 0.8)', 'rgba(245, 158, 11, 0.8)', 'rgba(239, 68, 68, 0.8)'],
+      borderWidth: 1,
+    }],
+  };
+
+  const trendData = {
+    labels: trend.map((t) => t.period),
+    datasets: [{
+      label: 'NPS Score',
+      data: trend.map((t) => t.nps),
+      borderColor: 'rgb(99, 102, 241)',
+      backgroundColor: 'rgba(99, 102, 241, 0.1)',
+      tension: 0.3,
+      fill: true,
+    }],
+  };
+
+  const segmentData = {
+    labels: segments.map((s) => s.segment),
+    datasets: [{
+      label: 'NPS Score',
+      data: segments.map((s) => s.nps),
+      backgroundColor: segments.map((s) =>
+        s.nps >= 50 ? 'rgba(16, 185, 129, 0.75)' : s.nps >= 0 ? 'rgba(245, 158, 11, 0.75)' : 'rgba(239, 68, 68, 0.75)'
+      ),
+      borderRadius: 4,
+    }],
+  };
+
+  const npsColor = overall.nps >= 50 ? 'text-emerald-600 dark:text-emerald-400'
+    : overall.nps >= 0 ? 'text-amber-600 dark:text-amber-400'
+    : 'text-red-600 dark:text-red-400';
+
+  return (
+    <div className="space-y-6">
+      {/* NPS score + breakdown cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-gray-100 dark:border-gray-700 flex flex-col items-center justify-center">
+          <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">NPS Score</p>
+          <p className={`text-4xl font-bold mt-1 ${npsColor}`}>{overall.nps}</p>
+          <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">{overall.total} responses</p>
+        </div>
+        {[
+          { label: 'Promoters',  count: overall.promoters,  pct: overall.total, color: 'text-emerald-600 dark:text-emerald-400' },
+          { label: 'Passives',   count: overall.passives,   pct: overall.total, color: 'text-amber-600 dark:text-amber-400' },
+          { label: 'Detractors', count: overall.detractors, pct: overall.total, color: 'text-red-600 dark:text-red-400' },
+        ].map((item) => (
+          <div key={item.label} className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-gray-100 dark:border-gray-700">
+            <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">{item.label}</p>
+            <p className={`text-2xl font-bold mt-1 ${item.color}`}>{item.count}</p>
+            <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">
+              {((item.count / item.pct) * 100).toFixed(1)}%
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Trend + breakdown */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2 bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-4">NPS Trend Over Time</h2>
+          <div className="h-52">
+            <Line data={trendData} options={{ ...chartOpts, plugins: { legend: { display: false } } }} />
+          </div>
+        </div>
+
+        <div className="bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-4">Promoter / Passive / Detractor</h2>
+          <div className="h-52">
+            <Doughnut data={breakdownData} options={chartOpts} />
+          </div>
+        </div>
+      </div>
+
+      {/* Segment comparison */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-4">NPS by Segment</h2>
+        <div className="h-48">
+          <Bar data={segmentData} options={{ ...chartOpts, plugins: { legend: { display: false } } }} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/analytics/lib/nps.ts
+++ b/analytics/lib/nps.ts
@@ -1,0 +1,59 @@
+// NPS score utilities
+
+export type NPSCategory = 'Promoter' | 'Passive' | 'Detractor';
+
+export interface NPSResponse {
+  score: number;   // 0–10
+  segment?: string;
+  date: string;
+}
+
+export interface NPSBreakdown {
+  promoters: number;
+  passives: number;
+  detractors: number;
+  total: number;
+  nps: number;
+}
+
+/** Classify a single score into NPS category */
+export function classifyScore(score: number): NPSCategory {
+  if (score >= 9) return 'Promoter';
+  if (score >= 7) return 'Passive';
+  return 'Detractor';
+}
+
+/** Calculate NPS and breakdown from a list of responses */
+export function calcNPS(responses: NPSResponse[]): NPSBreakdown {
+  const total = responses.length;
+  if (total === 0) return { promoters: 0, passives: 0, detractors: 0, total: 0, nps: 0 };
+
+  const promoters  = responses.filter((r) => r.score >= 9).length;
+  const passives   = responses.filter((r) => r.score >= 7 && r.score <= 8).length;
+  const detractors = responses.filter((r) => r.score <= 6).length;
+  const nps = Math.round(((promoters - detractors) / total) * 100);
+
+  return { promoters, passives, detractors, total, nps };
+}
+
+/** Group responses by month (YYYY-MM) and return NPS per period */
+export function npsOverTime(responses: NPSResponse[]): { period: string; nps: number }[] {
+  const byPeriod: Record<string, NPSResponse[]> = {};
+  for (const r of responses) {
+    const period = r.date.slice(0, 7);
+    (byPeriod[period] ??= []).push(r);
+  }
+  return Object.entries(byPeriod)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([period, rs]) => ({ period, nps: calcNPS(rs).nps }));
+}
+
+/** Group responses by segment and return NPS per segment */
+export function npsBySegment(responses: NPSResponse[]): { segment: string; nps: number }[] {
+  const bySegment: Record<string, NPSResponse[]> = {};
+  for (const r of responses) {
+    const seg = r.segment ?? 'Unknown';
+    (bySegment[seg] ??= []).push(r);
+  }
+  return Object.entries(bySegment).map(([segment, rs]) => ({ segment, nps: calcNPS(rs).nps }));
+}


### PR DESCRIPTION
## Summary

Implements four new analytics pages and supporting utilities.

### Changes

- **analytics/app/email-campaigns/page.tsx** — Campaign list with open/click rates, unsubscribe trend chart, and best send time analysis
- **analytics/app/support/page.tsx** — Ticket volume over time, resolution time distribution, category breakdown (doughnut), and agent performance table
- **analytics/app/roadmap/page.tsx** — Feature request list with vote counts, vote trend, user segment breakdown, and priority scoring
- **analytics/components/charts/NPSChart.tsx** — NPS score display, promoter/passive/detractor breakdown, trend over time, and segment comparison
- **analytics/lib/nps.ts** — Pure utility functions: `calcNPS`, `npsOverTime`, `npsBySegment`

### Closes

Closes #360
Closes #361
Closes #362
Closes #363