### PR TITLE
feat(ci): semantic version bumping automation

### DIFF
--- a/infrastructure/ci/version-bump.yml
+++ b/infrastructure/ci/version-bump.yml
@@ -1,0 +1,56 @@
+name: Semantic Version Bump
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version
+        run: bash infrastructure/scripts/bump-version.sh
+
+      - name: Commit version updates
+        run: |
+          if git diff --quiet -- '**/package.json'; then
+            echo "No package.json version changes."
+            exit 0
+          fi
+          git add '**/package.json'
+          git commit -m "chore(release): bump version"
+          git push
+
+      - name: Create and push tag
+        run: |
+          if [ ! -f ".next-version-tag" ]; then
+            echo "Missing .next-version-tag output."
+            exit 1
+          fi
+          TAG="$(cat .next-version-tag)"
+          if git rev-parse "${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists."
+            exit 0
+          fi
+          git tag "${TAG}"
+          git push origin "${TAG}"
+
+      - name: Trigger release workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run "Semantic Version Bump" || true

--- a/infrastructure/ci/version-rules.json
+++ b/infrastructure/ci/version-rules.json
@@ -1,0 +1,19 @@
+{
+  "majorPatterns": [
+    "BREAKING CHANGE",
+    "!:"
+  ],
+  "minorTypes": [
+    "feat"
+  ],
+  "patchTypes": [
+    "fix",
+    "perf",
+    "refactor",
+    "build",
+    "ci",
+    "chore"
+  ],
+  "defaultBump": "patch",
+  "tagPrefix": "v"
+}

--- a/infrastructure/scripts/bump-version.sh
+++ b/infrastructure/scripts/bump-version.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+RULES_PATH="${REPO_ROOT}/infrastructure/ci/version-rules.json"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required."
+  exit 1
+fi
+
+cd "${REPO_ROOT}"
+
+latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [[ -n "${latest_tag}" ]]; then
+  range="${latest_tag}..HEAD"
+else
+  range="$(git rev-list --max-parents=0 HEAD)..HEAD"
+fi
+
+log_data="$(git log --pretty=format:'%s%n%b<<END>>' ${range})"
+
+bump="none"
+if grep -Eq "BREAKING CHANGE|!:" <<<"${log_data}"; then
+  bump="major"
+elif grep -Eiq '^feat(\(.+\))?:' <<<"${log_data}"; then
+  bump="minor"
+elif grep -Eiq '^(fix|perf|refactor|build|ci|chore)(\(.+\))?:' <<<"${log_data}"; then
+  bump="patch"
+else
+  bump="$(jq -r '.defaultBump // "patch"' "${RULES_PATH}")"
+fi
+
+version_files="$(find . -name package.json -not -path "*/node_modules/*" -print)"
+if [[ -z "${version_files}" ]]; then
+  echo "No package.json files found."
+  exit 1
+fi
+
+first_file="$(awk 'NR==1{print $0}' <<<"${version_files}")"
+current_version="$(jq -r '.version // "0.1.0"' "${first_file}")"
+
+IFS='.' read -r major minor patch <<<"${current_version}"
+major="${major:-0}"
+minor="${minor:-1}"
+patch="${patch:-0}"
+
+case "${bump}" in
+  major) major=$((major + 1)); minor=0; patch=0 ;;
+  minor) minor=$((minor + 1)); patch=0 ;;
+  patch) patch=$((patch + 1)) ;;
+  *) echo "No bump computed"; exit 1 ;;
+esac
+
+new_version="${major}.${minor}.${patch}"
+tag_prefix="$(jq -r '.tagPrefix // "v"' "${RULES_PATH}")"
+new_tag="${tag_prefix}${new_version}"
+
+while IFS= read -r pkg; do
+  tmp="$(mktemp)"
+  jq --arg v "${new_version}" '.version = $v' "${pkg}" > "${tmp}"
+  mv "${tmp}" "${pkg}"
+done <<<"${version_files}"
+
+echo "Bump type: ${bump}"
+echo "New version: ${new_version}"
+echo "New tag: ${new_tag}"
+echo "${new_tag}" > .next-version-tag


### PR DESCRIPTION
Closes #392

## Summary
- add a semantic version bump workflow for `main` pushes and manual runs
- add centralized version bump rules for commit-to-version mapping
- add an automation script that bumps all `package.json` versions, creates a version tag, and prepares release automation

## Implementation
- created `infrastructure/ci/version-bump.yml` with bump, commit, tag, and push steps
- created `infrastructure/ci/version-rules.json` for major/minor/patch decision rules and tag prefix
- created `infrastructure/scripts/bump-version.sh` to detect bump type from commits and update all package versions

## Testing
- `bash -n infrastructure/scripts/bump-version.sh`
- `bash infrastructure/scripts/bump-version.sh` (manual local validation of bump + tag output)