### PR TITLE
feat(ci): add contract audit pipeline

### DIFF
--- a/infrastructure/ci/audit-config.toml
+++ b/infrastructure/ci/audit-config.toml
@@ -1,0 +1,11 @@
+[audit]
+severity_threshold = "critical"
+output_dir = "infrastructure/ci/reports"
+
+[tools]
+run_cargo_audit = true
+run_clippy = true
+run_fmt_check = true
+
+[paths]
+contracts_dir = "contracts"

--- a/infrastructure/ci/contract-audit.yml
+++ b/infrastructure/ci/contract-audit.yml
@@ -1,0 +1,36 @@
+name: Contract Audit Pipeline
+
+on:
+  pull_request:
+    paths:
+      - "contracts/**"
+      - "infrastructure/ci/contract-audit.yml"
+      - "infrastructure/ci/scripts/audit-contracts.sh"
+      - "infrastructure/ci/audit-config.toml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run contract audit pipeline
+        run: bash infrastructure/ci/scripts/audit-contracts.sh
+
+      - name: Upload audit reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: contract-audit-reports
+          path: infrastructure/ci/reports

--- a/infrastructure/ci/scripts/audit-contracts.sh
+++ b/infrastructure/ci/scripts/audit-contracts.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+CONFIG_PATH="${REPO_ROOT}/infrastructure/ci/audit-config.toml"
+
+if [[ ! -f "${CONFIG_PATH}" ]]; then
+  echo "Missing config: ${CONFIG_PATH}"
+  exit 1
+fi
+
+contracts_dir="$(awk -F'=' '/contracts_dir/{gsub(/[ "]/,"",$2); print $2}' "${CONFIG_PATH}")"
+output_dir="$(awk -F'=' '/output_dir/{gsub(/[ "]/,"",$2); print $2}' "${CONFIG_PATH}")"
+severity_threshold="$(awk -F'=' '/severity_threshold/{gsub(/[ "]/,"",$2); print $2}' "${CONFIG_PATH}")"
+run_cargo_audit="$(awk -F'=' '/run_cargo_audit/{gsub(/[ "]/,"",$2); print $2}' "${CONFIG_PATH}")"
+run_clippy="$(awk -F'=' '/run_clippy/{gsub(/[ "]/,"",$2); print $2}' "${CONFIG_PATH}")"
+run_fmt_check="$(awk -F'=' '/run_fmt_check/{gsub(/[ "]/,"",$2); print $2}' "${CONFIG_PATH}")"
+
+contracts_path="${REPO_ROOT}/${contracts_dir}"
+report_path="${REPO_ROOT}/${output_dir}"
+mkdir -p "${report_path}"
+
+if [[ ! -d "${contracts_path}" ]]; then
+  echo "Contracts directory not found: ${contracts_path}"
+  exit 1
+fi
+
+cd "${contracts_path}"
+status=0
+
+if [[ "${run_fmt_check}" == "true" ]]; then
+  cargo fmt --all -- --check 2>&1 | tee "${report_path}/cargo-fmt-report.txt" || status=1
+fi
+
+if [[ "${run_clippy}" == "true" ]]; then
+  cargo clippy --all-targets --all-features -- -D warnings 2>&1 | tee "${report_path}/clippy-report.txt" || status=1
+fi
+
+if [[ "${run_cargo_audit}" == "true" ]]; then
+  cargo audit --json 2>&1 | tee "${report_path}/cargo-audit-report.json" || status=1
+  if [[ -f "${report_path}/cargo-audit-report.json" ]]; then
+    critical_count="$(grep -o "\"severity\":\"${severity_threshold}\"" "${report_path}/cargo-audit-report.json" | wc -l | tr -d ' ')"
+    if [[ "${critical_count}" -gt 0 ]]; then
+      echo "Critical vulnerabilities found: ${critical_count}"
+      status=1
+    fi
+  fi
+fi
+
+if [[ "${status}" -ne 0 ]]; then
+  echo "Contract audit failed. See reports in ${report_path}"
+  exit 1
+fi
+
+echo "Contract audit completed successfully."


### PR DESCRIPTION
Closes #393

## Summary
- add a dedicated smart-contract audit workflow
- add centralized audit configuration for severity/tool toggles
- add audit script that runs fmt, clippy, and cargo-audit with report generation

## Implementation
- created `infrastructure/ci/contract-audit.yml` for PR/manual audit execution
- created `infrastructure/ci/audit-config.toml` to control audit behavior and report output
- created `infrastructure/ci/scripts/audit-contracts.sh` to run static/security checks and fail on critical findings

## Testing
- `bash -n infrastructure/ci/scripts/audit-contracts.sh`
- Full `cargo` audit execution is intended for CI runners with Rust/cargo dependencies installed