### PR TITLE
feat(ci): setup CI/CD pipeline monitoring

### DIFF
--- a/infrastructure/ci/pipeline-monitoring.yml
+++ b/infrastructure/ci/pipeline-monitoring.yml
@@ -1,0 +1,53 @@
+name: Pipeline Monitoring
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_run:
+    workflows: ["*"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: read
+  issues: write
+
+jobs:
+  collect-metrics:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Collect pipeline statistics
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash infrastructure/scripts/collect-pipeline-stats.sh PinSpace-Org GistPin
+
+      - name: Persist latest metrics snapshot
+        run: |
+          if git diff --quiet infrastructure/monitoring/pipeline-stats-latest.json; then
+            echo "No metrics change."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add infrastructure/monitoring/pipeline-stats-latest.json
+          git commit -m "chore(monitoring): update pipeline metrics snapshot"
+          git push
+
+      - name: Alert on high failure rate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          rate="$(jq -r '.failure_rate' infrastructure/monitoring/pipeline-stats-latest.json)"
+          threshold="$(jq -r '.alerts.failure_rate_threshold' infrastructure/monitoring/pipeline-metrics.json)"
+          compare="$(jq -n --argjson r "$rate" --argjson t "$threshold" '$r > $t')"
+          if [ "$compare" = "true" ]; then
+            gh issue create \
+              --repo PinSpace-Org/GistPin \
+              --title "CI pipeline alert: elevated failure rate" \
+              --body "Failure rate is ${rate}, above threshold ${threshold}. Please investigate recent workflow runs." \
+              --label monitoring || true
+          fi

--- a/infrastructure/monitoring/pipeline-metrics.json
+++ b/infrastructure/monitoring/pipeline-metrics.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "metrics": {
+    "build_time_seconds": {
+      "description": "Pipeline build duration in seconds",
+      "type": "histogram"
+    },
+    "failure_rate": {
+      "description": "Rolling ratio of failed runs",
+      "type": "gauge"
+    },
+    "success_rate": {
+      "description": "Rolling ratio of successful runs",
+      "type": "gauge"
+    }
+  },
+  "dashboard": {
+    "title": "CI/CD Pipeline Health",
+    "panels": [
+      "build_time_seconds_p50",
+      "build_time_seconds_p95",
+      "failure_rate",
+      "success_rate"
+    ]
+  },
+  "alerts": {
+    "failure_rate_threshold": 0.2,
+    "build_time_threshold_seconds": 1800
+  }
+}

--- a/infrastructure/scripts/collect-pipeline-stats.sh
+++ b/infrastructure/scripts/collect-pipeline-stats.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_OWNER="${1:-PinSpace-Org}"
+REPO_NAME="${2:-GistPin}"
+WORKFLOW_NAME="${3:-}"
+OUTPUT_FILE="infrastructure/monitoring/pipeline-stats-latest.json"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required."
+  exit 1
+fi
+
+repo="${REPO_OWNER}/${REPO_NAME}"
+runs_json="$(gh run list --repo "${repo}" --limit 50 --json workflowName,conclusion,startedAt,updatedAt,databaseId)"
+
+if [[ -n "${WORKFLOW_NAME}" ]]; then
+  runs_json="$(jq --arg wf "${WORKFLOW_NAME}" '[.[] | select(.workflowName == $wf)]' <<<"${runs_json}")"
+fi
+
+total_runs="$(jq 'length' <<<"${runs_json}")"
+if [[ "${total_runs}" -eq 0 ]]; then
+  jq -n '{total_runs:0, failed_runs:0, success_runs:0, failure_rate:0, success_rate:0, average_duration_seconds:0}' > "${OUTPUT_FILE}"
+  echo "No workflow runs found."
+  exit 0
+fi
+
+failed_runs="$(jq '[.[] | select(.conclusion == "failure")] | length' <<<"${runs_json}")"
+success_runs="$(jq '[.[] | select(.conclusion == "success")] | length' <<<"${runs_json}")"
+
+duration_sum="$(
+  jq '[.[] | ((.updatedAt | fromdateiso8601) - (.startedAt | fromdateiso8601))] | add' <<<"${runs_json}"
+)"
+
+failure_rate="$(jq -n --argjson f "${failed_runs}" --argjson t "${total_runs}" '$f / $t')"
+success_rate="$(jq -n --argjson s "${success_runs}" --argjson t "${total_runs}" '$s / $t')"
+avg_duration="$(jq -n --argjson d "${duration_sum}" --argjson t "${total_runs}" '$d / $t')"
+
+jq -n \
+  --argjson total "${total_runs}" \
+  --argjson failed "${failed_runs}" \
+  --argjson success "${success_runs}" \
+  --argjson fr "${failure_rate}" \
+  --argjson sr "${success_rate}" \
+  --argjson avg "${avg_duration}" \
+  --arg collected_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  '{
+    collected_at: $collected_at,
+    total_runs: $total,
+    failed_runs: $failed,
+    success_runs: $success,
+    failure_rate: $fr,
+    success_rate: $sr,
+    average_duration_seconds: $avg
+  }' > "${OUTPUT_FILE}"
+
+echo "Pipeline stats written to ${OUTPUT_FILE}"


### PR DESCRIPTION
Closes #399

## Summary
- add monitoring workflow for CI/CD pipeline health
- add pipeline metrics schema for dashboard/alerts
- add stats collection script for build time and failure trends

## Implementation
- created `infrastructure/ci/pipeline-monitoring.yml` to collect metrics, persist snapshots, and alert on high failure rates
- created `infrastructure/monitoring/pipeline-metrics.json` defining tracked metrics, dashboard panels, and alert thresholds
- created `infrastructure/scripts/collect-pipeline-stats.sh` to aggregate workflow run outcomes and durations

## Testing
- `bash -n infrastructure/scripts/collect-pipeline-stats.sh`
- runtime collection path is validated in CI where GitHub API access is available