### PR TITLE
feat(k8s): create backend service kubernetes deployment

### DIFF
--- a/infrastructure/k8s/backend-configmap.yaml
+++ b/infrastructure/k8s/backend-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backend-config
+  namespace: gistpin
+data:
+  NODE_ENV: production
+  PORT: "3000"
+  LOG_LEVEL: info
+  APP_ENV: production

--- a/infrastructure/k8s/backend-deployment.yaml
+++ b/infrastructure/k8s/backend-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-deployment
+  namespace: gistpin
+  labels:
+    app: gistpin-backend
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: gistpin-backend
+  template:
+    metadata:
+      labels:
+        app: gistpin-backend
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/pinspace-org/gistpin-backend:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          envFrom:
+            - configMapRef:
+                name: backend-config
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3

--- a/infrastructure/k8s/backend-service.yaml
+++ b/infrastructure/k8s/backend-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-service
+  namespace: gistpin
+spec:
+  selector:
+    app: gistpin-backend
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3000
+  type: ClusterIP


### PR DESCRIPTION
Closes #401

## Summary
- add Kubernetes deployment manifest for NestJS backend with 3 replicas
- add backend ClusterIP service
- add backend ConfigMap for environment-specific runtime values

## Implementation
- created `infrastructure/k8s/backend-deployment.yaml` with rolling update strategy, CPU/memory requests/limits, and liveness/readiness probes
- created `infrastructure/k8s/backend-service.yaml` exposing backend pods on port 80 -> 3000
- created `infrastructure/k8s/backend-configmap.yaml` for environment-level configuration

## Testing
- manifest structure and field coverage reviewed for required deployment behavior
- deploy-time validation should be performed in target Kubernetes cluster