### PR TITLE
feat(k8s): setup PostgreSQL StatefulSet

### DIFF
--- a/infrastructure/k8s/postgres-pvc.yaml
+++ b/infrastructure/k8s/postgres-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  namespace: gistpin
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: standard

--- a/infrastructure/k8s/postgres-service.yaml
+++ b/infrastructure/k8s/postgres-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-headless
+  namespace: gistpin
+spec:
+  clusterIP: None
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432

--- a/infrastructure/k8s/postgres-statefulset.yaml
+++ b/infrastructure/k8s/postgres-statefulset.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: gistpin
+spec:
+  serviceName: postgres-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      initContainers:
+        - name: init-permissions
+          image: busybox:1.36
+          command: ["sh", "-c", "chown -R 999:999 /var/lib/postgresql/data"]
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+      containers:
+        - name: postgres
+          image: postgres:16
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_DB
+              value: gistpin
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: password
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres"]
+            initialDelaySeconds: 10
+            periodSeconds: 5
+        - name: backup-sidecar
+          image: postgres:16
+          command:
+            - sh
+            - -c
+            - |
+              while true; do
+                pg_dump -h 127.0.0.1 -U "$POSTGRES_USER" "$POSTGRES_DB" > /backups/gistpin-$(date +%Y%m%d%H%M%S).sql || true
+                find /backups -type f -mtime +7 -delete
+                sleep 86400
+              done
+          env:
+            - name: POSTGRES_DB
+              value: gistpin
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: username
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: password
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "250m"
+              memory: "256Mi"
+          volumeMounts:
+            - name: backup-data
+              mountPath: /backups
+      volumes:
+        - name: backup-data
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 20Gi
+        storageClassName: standard


### PR DESCRIPTION
Closes #402

## Summary
- add PostgreSQL StatefulSet with persistent storage
- add headless service for stable pod identity
- add backup sidecar and init container setup

## Implementation
- created `infrastructure/k8s/postgres-statefulset.yaml` with StatefulSet config, init permissions container, resource reservations, health probes, and backup sidecar
- created `infrastructure/k8s/postgres-pvc.yaml` for persistent storage claims
- created `infrastructure/k8s/postgres-service.yaml` as headless service for StatefulSet networking

## Testing
- manifest structure reviewed for StatefulSet, storage, and service wiring
- cluster-level validation should be performed during deployment in target environment