### PR TITLE
feat(k8s): create frontend deployment and service

### DIFF
--- a/infrastructure/k8s/frontend-deployment.yaml
+++ b/infrastructure/k8s/frontend-deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend-deployment
+  namespace: gistpin
+  labels:
+    app: gistpin-frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: gistpin-frontend
+  template:
+    metadata:
+      labels:
+        app: gistpin-frontend
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/pinspace-org/gistpin-frontend:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: NEXT_TELEMETRY_DISABLED
+              value: "1"
+            - name: PORT
+              value: "3000"
+            - name: CDN_BASE_URL
+              value: https://cdn.gistpin.app
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 5

--- a/infrastructure/k8s/frontend-hpa.yaml
+++ b/infrastructure/k8s/frontend-hpa.yaml
@@ -1,0 +1,25 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: frontend-hpa
+  namespace: gistpin
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: frontend-deployment
+  minReplicas: 2
+  maxReplicas: 8
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/infrastructure/k8s/frontend-service.yaml
+++ b/infrastructure/k8s/frontend-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-service
+  namespace: gistpin
+spec:
+  type: LoadBalancer
+  selector:
+    app: gistpin-frontend
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3000


### PR DESCRIPTION
Closes #403

## Summary
- add frontend Deployment for Next.js runtime
- add LoadBalancer Service for external traffic
- add HPA for autoscaling behavior

## Implementation
- created `infrastructure/k8s/frontend-deployment.yaml` with env vars, resources, and liveness/readiness checks
- created `infrastructure/k8s/frontend-service.yaml` with `LoadBalancer` exposure
- created `infrastructure/k8s/frontend-hpa.yaml` using autoscaling/v2 cpu+memory utilization targets

## Testing
- manifest configuration reviewed for deployment, service, and scaling requirements
- runtime validation should be performed in target cluster