### PR TITLE
feat(k8s): setup ingress controller configuration

### DIFF
--- a/infrastructure/k8s/ingress-controller.yaml
+++ b/infrastructure/k8s/ingress-controller.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ingress-nginx
+  template:
+    metadata:
+      labels:
+        app: ingress-nginx
+    spec:
+      serviceAccountName: ingress-nginx
+      containers:
+        - name: controller
+          image: registry.k8s.io/ingress-nginx/controller:v1.11.3
+          args:
+            - /nginx-ingress-controller
+            - --enable-ssl-passthrough
+          ports:
+            - name: http
+              containerPort: 80
+            - name: https
+              containerPort: 443

--- a/infrastructure/k8s/ingress.yaml
+++ b/infrastructure/k8s/ingress.yaml
@@ -1,0 +1,42 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gistpin-ingress
+  namespace: gistpin
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/limit-rps: "20"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "3"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://gistpin.app,https://www.gistpin.app"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "Authorization,Content-Type,Accept"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+spec:
+  tls:
+    - hosts:
+        - gistpin.app
+        - api.gistpin.app
+      secretName: gistpin-tls
+  rules:
+    - host: gistpin.app
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend-service
+                port:
+                  number: 80
+    - host: api.gistpin.app
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backend-service
+                port:
+                  number: 80

--- a/infrastructure/k8s/tls-secrets.yaml
+++ b/infrastructure/k8s/tls-secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gistpin-tls
+  namespace: gistpin
+type: kubernetes.io/tls
+data:
+  tls.crt: REPLACE_WITH_BASE64_CERT
+  tls.key: REPLACE_WITH_BASE64_KEY


### PR DESCRIPTION
Closes #404

## Summary
- add NGINX ingress controller deployment baseline
- add ingress routes for frontend and backend services
- add TLS secret manifest and ingress-level rate limiting/CORS controls

## Implementation
- created `infrastructure/k8s/ingress-controller.yaml` for ingress controller namespace/deployment
- created `infrastructure/k8s/ingress.yaml` with host-based routing, TLS termination, rate limiting, and CORS annotations
- created `infrastructure/k8s/tls-secrets.yaml` template for TLS certificate/key material

## Testing
- Kubernetes manifest structure reviewed for ingress, routing, and TLS mapping
- runtime validation should be executed in target cluster with real TLS material