### PR TITLE
feat(k8s): create namespace and RBAC policies

### DIFF
--- a/infrastructure/k8s/namespaces.yaml
+++ b/infrastructure/k8s/namespaces.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gistpin-dev
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gistpin-staging
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gistpin-prod
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: app-quota
+  namespace: gistpin-dev
+spec:
+  hard:
+    requests.cpu: "4"
+    requests.memory: 8Gi
+    limits.cpu: "8"
+    limits.memory: 16Gi
+    pods: "50"
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: app-quota
+  namespace: gistpin-staging
+spec:
+  hard:
+    requests.cpu: "8"
+    requests.memory: 16Gi
+    limits.cpu: "16"
+    limits.memory: 32Gi
+    pods: "100"
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: app-quota
+  namespace: gistpin-prod
+spec:
+  hard:
+    requests.cpu: "16"
+    requests.memory: 32Gi
+    limits.cpu: "32"
+    limits.memory: 64Gi
+    pods: "200"
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: gistpin-prod
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-nginx
+  namespace: gistpin-prod
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+  policyTypes:
+    - Ingress

--- a/infrastructure/k8s/rbac/role-bindings.yaml
+++ b/infrastructure/k8s/rbac/role-bindings.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backend-rolebinding
+  namespace: gistpin-prod
+subjects:
+  - kind: ServiceAccount
+    name: backend-sa
+    namespace: gistpin-prod
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backend-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: frontend-rolebinding
+  namespace: gistpin-prod
+subjects:
+  - kind: ServiceAccount
+    name: frontend-sa
+    namespace: gistpin-prod
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: frontend-role

--- a/infrastructure/k8s/rbac/roles.yaml
+++ b/infrastructure/k8s/rbac/roles.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backend-role
+  namespace: gistpin-prod
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: frontend-role
+  namespace: gistpin-prod
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]

--- a/infrastructure/k8s/rbac/service-accounts.yaml
+++ b/infrastructure/k8s/rbac/service-accounts.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backend-sa
+  namespace: gistpin-dev
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: frontend-sa
+  namespace: gistpin-dev
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backend-sa
+  namespace: gistpin-staging
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: frontend-sa
+  namespace: gistpin-staging
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backend-sa
+  namespace: gistpin-prod
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: frontend-sa
+  namespace: gistpin-prod


### PR DESCRIPTION
Closes #405

## Summary
- add isolated dev/staging/prod namespaces
- add service accounts per service and environment
- add namespace-scoped RBAC roles/bindings, quotas, and baseline network policies

## Implementation
- created `infrastructure/k8s/namespaces.yaml` with environment namespaces, resource quotas, and production network policies
- created `infrastructure/k8s/rbac/service-accounts.yaml` for frontend/backend service accounts across environments
- created `infrastructure/k8s/rbac/roles.yaml` and `infrastructure/k8s/rbac/role-bindings.yaml` for least-privilege namespace access

## Testing
- manifest structure reviewed for RBAC, quota, and network policy validity
- apply-time validation should be run against target Kubernetes cluster