### PR TITLE
feat(k8s): implement ConfigMaps and Secrets management

### DIFF
--- a/infrastructure/docs/secrets-management.md
+++ b/infrastructure/docs/secrets-management.md
@@ -1,0 +1,24 @@
+# Secrets Management Strategy
+
+## Overview
+This repository uses a layered strategy for application configuration and secrets:
+- `ConfigMap` for non-sensitive runtime config
+- `SealedSecret` for encrypted secret material in git
+- `ExternalSecret` for pulling secrets from an external store with periodic refresh
+
+## Version Control Strategy
+- Commit only templates/placeholders for raw `Secret` objects
+- Commit sealed/encrypted payloads instead of plaintext values
+- Keep sensitive values out of CI logs and pull request descriptions
+
+## Rotation Procedure
+1. Rotate credential in source system (DB, Redis, identity provider, etc.)
+2. Update secret manager entry used by `ExternalSecret`
+3. Re-seal values for fallback `SealedSecret` flow (if used)
+4. Roll deployment to pick up new secret versions
+5. Validate service health and revoke old credentials
+
+## Operational Notes
+- `ExternalSecret` refreshes every hour by default
+- Use namespace-scoped secret stores and least-privilege RBAC for secret reads
+- Store emergency recovery secrets in restricted break-glass vault paths

--- a/infrastructure/k8s/configmaps/app-config.yaml
+++ b/infrastructure/k8s/configmaps/app-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  namespace: gistpin-prod
+data:
+  NODE_ENV: production
+  APP_ENV: production
+  API_BASE_URL: https://api.gistpin.app
+  LOG_LEVEL: info
+  FEATURE_FLAGS: '{"newDashboard":true,"betaReports":false}'

--- a/infrastructure/k8s/configmaps/frontend-config.yaml
+++ b/infrastructure/k8s/configmaps/frontend-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-config
+  namespace: gistpin-prod
+data:
+  NEXT_PUBLIC_APP_NAME: GistPin
+  NEXT_PUBLIC_API_URL: https://api.gistpin.app
+  NEXT_PUBLIC_CDN_URL: https://cdn.gistpin.app

--- a/infrastructure/k8s/sealed-secrets.yaml
+++ b/infrastructure/k8s/sealed-secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: app-secrets
+  namespace: gistpin-prod
+spec:
+  encryptedData:
+    DATABASE_URL: AgREPLACE_WITH_SEALED_VALUE
+    JWT_SECRET: AgREPLACE_WITH_SEALED_VALUE
+    REDIS_URL: AgREPLACE_WITH_SEALED_VALUE
+  template:
+    metadata:
+      name: app-secrets
+      namespace: gistpin-prod
+    type: Opaque

--- a/infrastructure/k8s/secrets/app-secrets-template.yaml
+++ b/infrastructure/k8s/secrets/app-secrets-template.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secrets
+  namespace: gistpin-prod
+type: Opaque
+stringData:
+  DATABASE_URL: REPLACE_ME
+  JWT_SECRET: REPLACE_ME
+  REDIS_URL: REPLACE_ME

--- a/infrastructure/k8s/secrets/external-secrets.yaml
+++ b/infrastructure/k8s/secrets/external-secrets.yaml
@@ -1,0 +1,38 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: gistpin-vault
+  namespace: gistpin-prod
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: security-secrets
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: app-secrets
+  namespace: gistpin-prod
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gistpin-vault
+    kind: SecretStore
+  target:
+    name: app-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: DATABASE_URL
+      remoteRef:
+        key: gistpin/database-url
+    - secretKey: JWT_SECRET
+      remoteRef:
+        key: gistpin/jwt-secret
+    - secretKey: REDIS_URL
+      remoteRef:
+        key: gistpin/redis-url


### PR DESCRIPTION
Closes #406

## Summary
- add app/frontend ConfigMaps for non-sensitive runtime settings
- add sealed/external secrets manifests for secure secret delivery
- add secrets management guide covering version control and rotation

## Implementation
- created `infrastructure/k8s/configmaps/app-config.yaml` and `infrastructure/k8s/configmaps/frontend-config.yaml`
- created `infrastructure/k8s/secrets/app-secrets-template.yaml` and `infrastructure/k8s/secrets/external-secrets.yaml`
- created `infrastructure/k8s/sealed-secrets.yaml` and `infrastructure/docs/secrets-management.md`

## Testing
- manifest structure reviewed for ConfigMap, SealedSecret, and ExternalSecret integration
- cluster/operator-level validation should be performed where external-secrets and sealed-secrets controllers are installed