### PR TITLE
feat(k8s): setup horizontal pod autoscaling

### DIFF
--- a/infrastructure/k8s/custom-metrics.yaml
+++ b/infrastructure/k8s/custom-metrics.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-metrics-config
+  namespace: gistpin-prod
+data:
+  metrics.yaml: |
+    rules:
+      - seriesQuery: 'http_requests_total{namespace!="",pod!=""}'
+        resources:
+          overrides:
+            namespace: {resource: "namespace"}
+            pod: {resource: "pod"}
+        name:
+          matches: "http_requests_total"
+          as: "http_requests_per_second"
+        metricsQuery: |
+          sum(rate(http_requests_total{<<.LabelMatchers>>}[2m])) by (<<.GroupBy>>)

--- a/infrastructure/k8s/hpa-backend.yaml
+++ b/infrastructure/k8s/hpa-backend.yaml
@@ -1,0 +1,32 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: backend-hpa
+  namespace: gistpin-prod
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: backend-deployment
+  minReplicas: 3
+  maxReplicas: 15
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 20
+          periodSeconds: 60
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/infrastructure/k8s/hpa-frontend.yaml
+++ b/infrastructure/k8s/hpa-frontend.yaml
@@ -1,0 +1,32 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: frontend-hpa
+  namespace: gistpin-prod
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: frontend-deployment
+  minReplicas: 2
+  maxReplicas: 12
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 25
+          periodSeconds: 60
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 65
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 70


### PR DESCRIPTION
Closes #407

## Summary
- add backend and frontend HPAs with CPU/memory autoscaling targets
- configure min/max replicas and scale-down stabilization behavior
- add custom metrics adapter mapping config

## Implementation
- created `infrastructure/k8s/hpa-backend.yaml`
- created `infrastructure/k8s/hpa-frontend.yaml`
- created `infrastructure/k8s/custom-metrics.yaml`

## Testing
- Kubernetes manifest configuration reviewed for autoscaling policy correctness
- cluster runtime validation should confirm custom metrics adapter wiring