### PR TITLE
feat(k8s): create persistent volume claims for storage

### DIFF
--- a/infrastructure/k8s/pvc-backups.yaml
+++ b/infrastructure/k8s/pvc-backups.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: backups-pvc
+  namespace: gistpin-prod
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: gistpin-ssd
+  resources:
+    requests:
+      storage: 200Gi

--- a/infrastructure/k8s/pvc-database.yaml
+++ b/infrastructure/k8s/pvc-database.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: database-pvc
+  namespace: gistpin-prod
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: gistpin-ssd
+  resources:
+    requests:
+      storage: 100Gi

--- a/infrastructure/k8s/storage-class.yaml
+++ b/infrastructure/k8s/storage-class.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gistpin-ssd
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Retain
+allowVolumeExpansion: true


### PR DESCRIPTION
Closes #408

## Summary
- define storage class for persistent workloads
- add database PVC with RWO access mode
- add backup PVC with RWX access mode

## Implementation
- created `infrastructure/k8s/storage-class.yaml`
- created `infrastructure/k8s/pvc-database.yaml`
- created `infrastructure/k8s/pvc-backups.yaml`

## Testing
- Kubernetes manifest configuration reviewed for requested storage sizing and access mode setup
- storage class compatibility should be validated in target cluster environment