### PR TITLE
feat(k8s): setup pod disruption budgets

### DIFF
--- a/infrastructure/k8s/pdb-backend.yaml
+++ b/infrastructure/k8s/pdb-backend.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: backend-pdb
+  namespace: gistpin-prod
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: gistpin-backend

--- a/infrastructure/k8s/pdb-database.yaml
+++ b/infrastructure/k8s/pdb-database.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: database-pdb
+  namespace: gistpin-prod
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: postgres

--- a/infrastructure/k8s/pdb-frontend.yaml
+++ b/infrastructure/k8s/pdb-frontend.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: frontend-pdb
+  namespace: gistpin-prod
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: gistpin-frontend


### PR DESCRIPTION
Closes #409

## Summary
- add pod disruption budgets for backend, frontend, and database services
- enforce minimum available replicas for critical app services
- prevent database voluntary disruptions with strict availability rule

## Implementation
- created `infrastructure/k8s/pdb-backend.yaml`
- created `infrastructure/k8s/pdb-frontend.yaml`
- created `infrastructure/k8s/pdb-database.yaml`

## Testing
- Kubernetes manifest configuration reviewed for disruption budget policy behavior
- cluster apply-time validation should confirm selectors match deployed workload labels