### PR TITLE
feat(k8s): implement network policies for isolation

### DIFF
--- a/infrastructure/k8s/network-policies/backend-policy.yaml
+++ b/infrastructure/k8s/network-policies/backend-policy.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: backend-allow-policy
+  namespace: gistpin-prod
+spec:
+  podSelector:
+    matchLabels:
+      app: gistpin-backend
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: gistpin-frontend
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: postgres
+      ports:
+        - protocol: TCP
+          port: 5432
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+  policyTypes:
+    - Ingress
+    - Egress

--- a/infrastructure/k8s/network-policies/db-policy.yaml
+++ b/infrastructure/k8s/network-policies/db-policy.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: db-isolation-policy
+  namespace: gistpin-prod
+spec:
+  podSelector:
+    matchLabels:
+      app: postgres
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: gistpin-backend
+      ports:
+        - protocol: TCP
+          port: 5432
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: gistpin-backend
+      ports:
+        - protocol: TCP
+          port: 10250
+  policyTypes:
+    - Ingress
+    - Egress

--- a/infrastructure/k8s/network-policies/default-deny.yaml
+++ b/infrastructure/k8s/network-policies/default-deny.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: gistpin-prod
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress


### PR DESCRIPTION
Closes #410

## Summary
- add default-deny network policy baseline
- allow only required frontend->backend and backend->db/service egress paths
- isolate database from external access and enforce backend-only ingress

## Implementation
- created `infrastructure/k8s/network-policies/default-deny.yaml`
- created `infrastructure/k8s/network-policies/backend-policy.yaml`
- created `infrastructure/k8s/network-policies/db-policy.yaml`

## Testing
- Kubernetes manifest policy flow reviewed for ingress/egress isolation intent
- cluster-level validation should verify label selectors match deployed pods