### PR TITLE
feat(infra): set up Istio service mesh with virtual services and destination rules

### DIFF
--- a/infrastructure/k8s/istio/destination-rules.yaml
+++ b/infrastructure/k8s/istio/destination-rules.yaml
@@ -1,0 +1,183 @@
+---
+# ──────────────────────────────────────────────────────────────────────────────
+# GistPin — Destination Rules
+#
+# Configures:
+#   - Load balancing algorithm per service
+#   - Connection pool limits (circuit breaker)
+#   - Outlier detection (automatic pod ejection)
+#   - Subsets (stable / canary) matching pod labels
+#   - TLS mode for mTLS between sidecars
+# ──────────────────────────────────────────────────────────────────────────────
+
+# ── Backend API ───────────────────────────────────────────────────────────────
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: backend
+  namespace: gistpin
+spec:
+  host: backend
+  trafficPolicy:
+    loadBalancer:
+      # LEAST_CONN distributes to the pod with fewest active connections;
+      # better than ROUND_ROBIN for variable-latency API handlers.
+      simple: LEAST_CONN
+
+    connectionPool:
+      tcp:
+        maxConnections: 100
+        connectTimeout: 5s
+        tcpKeepalive:
+          time: 7200s
+          interval: 75s
+      http:
+        http1MaxPendingRequests: 64
+        http2MaxRequests: 1000
+        maxRequestsPerConnection: 10
+        maxRetries: 3
+
+    outlierDetection:
+      # Eject pods returning 5xx errors for increasing intervals
+      consecutiveGatewayErrors: 5
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+      minHealthPercent: 30
+
+    tls:
+      mode: ISTIO_MUTUAL    # Enforce mTLS; pairs with PeerAuthentication STRICT
+
+  subsets:
+    - name: stable
+      labels:
+        version: stable
+      trafficPolicy:
+        loadBalancer:
+          simple: LEAST_CONN
+
+    - name: canary
+      labels:
+        version: canary
+      trafficPolicy:
+        loadBalancer:
+          # During canary, use RANDOM to spread across a small pod set
+          simple: RANDOM
+
+---
+# ── Frontend ──────────────────────────────────────────────────────────────────
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: frontend
+  namespace: gistpin
+spec:
+  host: frontend
+  trafficPolicy:
+    loadBalancer:
+      simple: ROUND_ROBIN   # Stateless SSR; round-robin is fine
+
+    connectionPool:
+      tcp:
+        maxConnections: 50
+        connectTimeout: 3s
+      http:
+        http1MaxPendingRequests: 32
+        http2MaxRequests: 500
+        maxRequestsPerConnection: 0   # Keep-alive
+
+    outlierDetection:
+      consecutiveGatewayErrors: 5
+      interval: 30s
+      baseEjectionTime: 15s
+      maxEjectionPercent: 30
+
+    tls:
+      mode: ISTIO_MUTUAL
+
+  subsets:
+    - name: stable
+      labels:
+        version: stable
+
+    - name: canary
+      labels:
+        version: canary
+
+---
+# ── Analytics ─────────────────────────────────────────────────────────────────
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: analytics
+  namespace: gistpin
+spec:
+  host: analytics
+  trafficPolicy:
+    loadBalancer:
+      # LEAST_CONN suits the mixed workload (fast ingest + slow queries)
+      simple: LEAST_CONN
+
+    connectionPool:
+      tcp:
+        maxConnections: 200
+        connectTimeout: 5s
+      http:
+        http1MaxPendingRequests: 128
+        http2MaxRequests: 2000
+        maxRequestsPerConnection: 0
+
+    outlierDetection:
+      consecutiveGatewayErrors: 10
+      interval: 60s
+      baseEjectionTime: 60s
+      maxEjectionPercent: 25
+
+    tls:
+      mode: ISTIO_MUTUAL
+
+  subsets:
+    - name: stable
+      labels:
+        version: stable
+
+---
+# ── Istio Egress Gateway ──────────────────────────────────────────────────────
+# TLS origination for HTTPS egress to Stellar endpoints.
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: stellar-rpc-egress-tls
+  namespace: gistpin
+spec:
+  host: istio-egressgateway.istio-system.svc.cluster.local
+  trafficPolicy:
+    loadBalancer:
+      simple: ROUND_ROBIN
+    portLevelSettings:
+      - port:
+          number: 443
+        tls:
+          mode: ISTIO_MUTUAL
+
+---
+# ── ServiceEntry — allow mesh egress to Stellar RPC hosts ────────────────────
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: stellar-rpc
+  namespace: gistpin
+spec:
+  hosts:
+    - horizon.stellar.org
+    - soroban-testnet.stellar.org
+  ports:
+    - number: 443
+      name: https
+      protocol: HTTPS
+    - number: 80
+      name: http
+      protocol: HTTP
+  location: MESH_EXTERNAL
+  resolution: DNS

--- a/infrastructure/k8s/istio/istio-install.yaml
+++ b/infrastructure/k8s/istio/istio-install.yaml
@@ -1,0 +1,186 @@
+---
+# ──────────────────────────────────────────────────────────────────────────────
+# GistPin — Istio Installation
+#
+# Apply order:
+#   1. kubectl create namespace istio-system
+#   2. kubectl apply -f istio-install.yaml
+#   3. kubectl label namespace gistpin istio-injection=enabled
+# ──────────────────────────────────────────────────────────────────────────────
+
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: gistpin-istio
+  namespace: istio-system
+spec:
+  # Pinned to a stable release; bump in Chart.yaml / renovate as needed
+  # Compatible with Kubernetes 1.28+
+  profile: default
+
+  meshConfig:
+    # Access logging to stdout (captured by the node-level log aggregator)
+    accessLogFile: /dev/stdout
+    accessLogFormat: >
+      {
+        "start_time":         "%START_TIME%",
+        "method":             "%REQ(:METHOD)%",
+        "path":               "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%",
+        "protocol":           "%PROTOCOL%",
+        "response_code":      "%RESPONSE_CODE%",
+        "duration_ms":        "%DURATION%",
+        "upstream_host":      "%UPSTREAM_HOST%",
+        "trace_id":           "%REQ(X-B3-TRACEID)%",
+        "service":            "%REQ(X-FORWARDED-FOR)%"
+      }
+
+    # Enable distributed tracing via Jaeger / Zipkin compatible endpoint
+    defaultConfig:
+      tracing:
+        sampling: 100.0            # 100 % in dev; lower to ~1-5 in production
+        zipkin:
+          address: jaeger-collector.observability.svc.cluster.local:9411
+
+    # Mutual TLS — STRICT enforces mTLS between all sidecars
+    enableAutoMtls: true
+
+  components:
+    pilot:
+      k8s:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        hpaSpec:
+          minReplicas: 1
+          maxReplicas: 3
+
+    ingressGateways:
+      - name: istio-ingressgateway
+        enabled: true
+        k8s:
+          service:
+            type: LoadBalancer
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          hpaSpec:
+            minReplicas: 2
+            maxReplicas: 5
+
+    egressGateways:
+      - name: istio-egressgateway
+        enabled: true    # Required for controlled Stellar RPC egress
+
+  values:
+    global:
+      proxy:
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+
+---
+# ──────────────────────────────────────────────────────────────────────────────
+# Observability namespace + addons (Prometheus, Grafana, Jaeger, Kiali)
+# ──────────────────────────────────────────────────────────────────────────────
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: observability
+  labels:
+    istio-injection: disabled   # Addons don't need sidecars
+
+---
+# Prometheus — metrics scrape config for Istio telemetry
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-scrape-config
+  namespace: observability
+data:
+  scrape_configs.yaml: |
+    scrape_configs:
+      - job_name: 'istio-mesh'
+        kubernetes_sd_configs:
+          - role: endpoints
+            namespaces:
+              names: [istio-system]
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+            action: keep
+            regex: istio-telemetry;prometheus
+
+      - job_name: 'gistpin-services'
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names: [gistpin]
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: "true"
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+
+---
+# PeerAuthentication — enforce STRICT mTLS across the gistpin namespace
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: gistpin-mtls
+  namespace: gistpin
+spec:
+  mtls:
+    mode: STRICT
+
+---
+# Gateway — single ingress entry point for all GistPin HTTP/HTTPS traffic
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: gistpin-gateway
+  namespace: gistpin
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "gistpin.io"
+        - "*.gistpin.io"
+      # Redirect all HTTP → HTTPS in production
+      tls:
+        httpsRedirect: true
+
+    - port:
+        number: 443
+        name: https
+        protocol: HTTPS
+      tls:
+        mode: SIMPLE
+        credentialName: gistpin-tls   # K8s Secret with TLS cert/key
+      hosts:
+        - "gistpin.io"
+        - "*.gistpin.io"

--- a/infrastructure/k8s/istio/virtual-services.yaml
+++ b/infrastructure/k8s/istio/virtual-services.yaml
@@ -1,0 +1,186 @@
+---
+# ──────────────────────────────────────────────────────────────────────────────
+# GistPin — Virtual Services
+#
+# Defines L7 routing, retries, timeouts, fault injection guards, and
+# canary / traffic-split rules for each service in the mesh.
+# ──────────────────────────────────────────────────────────────────────────────
+
+# ── Backend API ───────────────────────────────────────────────────────────────
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: backend
+  namespace: gistpin
+spec:
+  hosts:
+    - backend               # K8s Service name (cluster-internal)
+    - api.gistpin.io        # External host via Gateway
+  gateways:
+    - gistpin-gateway       # Applies to external ingress
+    - mesh                  # Also applies to internal east-west traffic
+  http:
+    # ── Health / readiness bypass (no retries needed) ────────────────────────
+    - match:
+        - uri:
+            prefix: /health
+      route:
+        - destination:
+            host: backend
+            subset: stable
+      timeout: 5s
+
+    # ── Canary split — route 10 % of API traffic to canary subset ────────────
+    # Flip canary weight to 100 / stable to 0 after validation, then remove.
+    - match:
+        - uri:
+            prefix: /api
+      route:
+        - destination:
+            host: backend
+            subset: stable
+          weight: 90
+        - destination:
+            host: backend
+            subset: canary
+          weight: 10
+      timeout: 30s
+      retries:
+        attempts: 3
+        perTryTimeout: 10s
+        retryOn: gateway-error,connect-failure,retriable-4xx
+
+    # ── WebSocket upgrade for real-time gist streams ─────────────────────────
+    - match:
+        - uri:
+            prefix: /ws
+          headers:
+            upgrade:
+              exact: websocket
+      route:
+        - destination:
+            host: backend
+            subset: stable
+      timeout: 0s   # Disable timeout for long-lived WS connections
+
+    # ── Default catch-all ────────────────────────────────────────────────────
+    - route:
+        - destination:
+            host: backend
+            subset: stable
+      timeout: 30s
+
+---
+# ── Frontend ──────────────────────────────────────────────────────────────────
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: frontend
+  namespace: gistpin
+spec:
+  hosts:
+    - frontend
+    - gistpin.io
+    - www.gistpin.io
+  gateways:
+    - gistpin-gateway
+    - mesh
+  http:
+    # ── Static assets — aggressive caching headers (handled upstream) ────────
+    - match:
+        - uri:
+            prefix: /static
+      route:
+        - destination:
+            host: frontend
+            subset: stable
+      timeout: 10s
+
+    # ── Canary split — 5 % of users see new frontend build ───────────────────
+    - route:
+        - destination:
+            host: frontend
+            subset: stable
+          weight: 95
+        - destination:
+            host: frontend
+            subset: canary
+          weight: 5
+      timeout: 15s
+      retries:
+        attempts: 2
+        perTryTimeout: 5s
+        retryOn: 5xx,reset,connect-failure
+
+---
+# ── Analytics ─────────────────────────────────────────────────────────────────
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: analytics
+  namespace: gistpin
+spec:
+  hosts:
+    - analytics
+    - analytics.gistpin.io
+  gateways:
+    - gistpin-gateway
+    - mesh
+  http:
+    # ── Ingestion endpoint — high-throughput, low timeout ────────────────────
+    - match:
+        - uri:
+            prefix: /ingest
+      route:
+        - destination:
+            host: analytics
+            subset: stable
+      timeout: 5s
+      retries:
+        attempts: 2
+        perTryTimeout: 2s
+        retryOn: 5xx,reset
+
+    # ── Query / dashboard endpoint — longer timeout ───────────────────────────
+    - match:
+        - uri:
+            prefix: /query
+      route:
+        - destination:
+            host: analytics
+            subset: stable
+      timeout: 60s
+
+    # ── Default ───────────────────────────────────────────────────────────────
+    - route:
+        - destination:
+            host: analytics
+            subset: stable
+      timeout: 30s
+
+---
+# ── Stellar RPC Egress ────────────────────────────────────────────────────────
+# Route outbound Stellar Horizon / Soroban RPC calls through the egress gateway
+# for audit logging and policy control.
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: stellar-rpc-egress
+  namespace: gistpin
+spec:
+  hosts:
+    - horizon.stellar.org
+    - soroban-testnet.stellar.org
+  gateways:
+    - mesh
+  http:
+    - route:
+        - destination:
+            host: istio-egressgateway.istio-system.svc.cluster.local
+            port:
+              number: 443
+      timeout: 15s
+      retries:
+        attempts: 3
+        perTryTimeout: 5s
+        retryOn: gateway-error,connect-failure,5xx


### PR DESCRIPTION
## Istio Service Mesh (#412)

### Changes
- **`istio-install.yaml`** -- IstioOperator config with observability integrations (Prometheus, Grafana, Jaeger)
- **`virtual-services.yaml`** -- routing rules for backend, frontend, and analytics services with traffic splitting
- **`destination-rules.yaml`** -- load balancing, connection pool, and outlier detection policies per service

Closes #412