### PR TITLE
feat(infra): add namespace resource quotas and scheduled maintenance …

### DIFF
--- a/infrastructure/k8s/cronjobs/backup.yaml
+++ b/infrastructure/k8s/cronjobs/backup.yaml
@@ -1,0 +1,174 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: gistpin-backup
+  namespace: gistpin-prod
+  labels:
+    app: gistpin
+    component: backup
+    managed-by: cronjob
+spec:
+  schedule: "0 2 * * *"          # Daily at 02:00 UTC
+  timeZone: "UTC"
+  concurrencyPolicy: Forbid       # Never run two backup jobs in parallel
+  successfulJobsHistoryLimit: 7   # Keep the last 7 successful job records
+  failedJobsHistoryLimit: 3       # Keep the last 3 failed job records
+  startingDeadlineSeconds: 900    # Abort if not started within 15 min of schedule
+
+  jobTemplate:
+    metadata:
+      labels:
+        app: gistpin
+        component: backup
+    spec:
+      backoffLimit: 2             # Retry up to 2 times before marking failed
+      activeDeadlineSeconds: 3600 # Kill the job after 1 hour regardless
+
+      template:
+        metadata:
+          labels:
+            app: gistpin
+            component: backup
+          annotations:
+            sidecar.istio.io/inject: "false"   # No mesh sidecar needed for batch
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: gistpin-backup-sa
+
+          # ── Init: verify connectivity before the main backup ──────────────
+          initContainers:
+            - name: preflight
+              image: postgres:16-alpine
+              command:
+                - sh
+                - -c
+                - |
+                  echo "[preflight] Testing DB connectivity..."
+                  pg_isready -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" \
+                    || { echo "[preflight] DB not ready — aborting"; exit 1; }
+                  echo "[preflight] OK"
+              env:
+                - name: PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: gistpin-db-credentials
+                      key: host
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      name: gistpin-db-credentials
+                      key: username
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: gistpin-db-credentials
+                      key: database
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+
+          containers:
+            # ── Step 1: PostgreSQL dump ──────────────────────────────────────
+            - name: postgres-backup
+              image: postgres:16-alpine
+              command:
+                - sh
+                - -c
+                - |
+                  set -euo pipefail
+                  TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+                  BACKUP_FILE="/tmp/gistpin_${TIMESTAMP}.sql.gz"
+
+                  echo "[backup] Dumping database to ${BACKUP_FILE}..."
+                  PGPASSWORD="$PGPASSWORD" pg_dump \
+                    -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" \
+                    --no-owner --no-acl --clean --if-exists \
+                    | gzip -9 > "$BACKUP_FILE"
+
+                  echo "[backup] Uploading to s3://${S3_BUCKET}/postgres/${TIMESTAMP}/"
+                  # Uses AWS CLI v2 bundled in the init step; assumes IRSA or env-based creds
+                  aws s3 cp "$BACKUP_FILE" \
+                    "s3://${S3_BUCKET}/postgres/gistpin_${TIMESTAMP}.sql.gz" \
+                    --sse aws:kms \
+                    --storage-class STANDARD_IA
+
+                  echo "[backup] Pruning backups older than ${RETENTION_DAYS} days..."
+                  CUTOFF=$(date -d "-${RETENTION_DAYS} days" +%Y-%m-%dT%H:%M:%SZ)
+                  aws s3api list-objects-v2 \
+                    --bucket "$S3_BUCKET" --prefix "postgres/" \
+                    --query "Contents[?LastModified<='${CUTOFF}'].Key" \
+                    --output text \
+                    | xargs -r -I {} aws s3 rm "s3://${S3_BUCKET}/{}"
+
+                  echo "[backup] Done."
+              env:
+                - name: PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: gistpin-db-credentials
+                      key: host
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      name: gistpin-db-credentials
+                      key: username
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: gistpin-db-credentials
+                      key: password
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: gistpin-db-credentials
+                      key: database
+                - name: S3_BUCKET
+                  valueFrom:
+                    configMapKeyRef:
+                      name: gistpin-backup-config
+                      key: s3_bucket
+                - name: RETENTION_DAYS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: gistpin-backup-config
+                      key: retention_days
+              resources:
+                requests:
+                  cpu: 200m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+
+              volumeMounts:
+                - name: tmp-storage
+                  mountPath: /tmp
+
+          volumes:
+            - name: tmp-storage
+              emptyDir:
+                sizeLimit: 10Gi
+
+---
+# ServiceAccount for the backup job (bind to IRSA role for S3 access)
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gistpin-backup-sa
+  namespace: gistpin-prod
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::ACCOUNT_ID:role/gistpin-backup-role"
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gistpin-backup-config
+  namespace: gistpin-prod
+data:
+  s3_bucket: "gistpin-backups-prod"
+  retention_days: "30"

--- a/infrastructure/k8s/cronjobs/cleanup.yaml
+++ b/infrastructure/k8s/cronjobs/cleanup.yaml
@@ -1,0 +1,180 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: gistpin-cleanup
+  namespace: gistpin-prod
+  labels:
+    app: gistpin
+    component: cleanup
+    managed-by: cronjob
+spec:
+  schedule: "0 */6 * * *"        # Every 6 hours
+  timeZone: "UTC"
+  concurrencyPolicy: Replace      # Kill stale run and start fresh
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 600
+
+  jobTemplate:
+    metadata:
+      labels:
+        app: gistpin
+        component: cleanup
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 1800   # 30-minute hard cap
+
+      template:
+        metadata:
+          labels:
+            app: gistpin
+            component: cleanup
+          annotations:
+            sidecar.istio.io/inject: "false"
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: gistpin-cleanup-sa
+
+          containers:
+            # ── Step 1: expired gist purge (SQL) ────────────────────────────
+            - name: purge-expired-gists
+              image: postgres:16-alpine
+              command:
+                - sh
+                - -c
+                - |
+                  set -euo pipefail
+                  echo "[cleanup] Purging expired gists..."
+
+                  PURGED=$(PGPASSWORD="$PGPASSWORD" psql \
+                    -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" \
+                    -t -c "
+                      WITH deleted AS (
+                        DELETE FROM gists
+                        WHERE
+                          (expires_at IS NOT NULL AND expires_at < NOW())
+                          OR (deleted_at IS NOT NULL AND deleted_at < NOW() - INTERVAL '${RETENTION_DAYS} days')
+                        RETURNING id
+                      )
+                      SELECT COUNT(*) FROM deleted;
+                    " | xargs)
+
+                  echo "[cleanup] Purged ${PURGED} expired gist(s)."
+
+                  echo "[cleanup] Purging orphaned blob references..."
+                  BLOBS=$(PGPASSWORD="$PGPASSWORD" psql \
+                    -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" \
+                    -t -c "
+                      WITH deleted AS (
+                        DELETE FROM blob_references br
+                        WHERE NOT EXISTS (
+                          SELECT 1 FROM gists g WHERE g.id = br.gist_id
+                        )
+                        AND br.created_at < NOW() - INTERVAL '1 hour'
+                        RETURNING id
+                      )
+                      SELECT COUNT(*) FROM deleted;
+                    " | xargs)
+
+                  echo "[cleanup] Purged ${BLOBS} orphaned blob reference(s)."
+              env:
+                - name: PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: gistpin-db-credentials
+                      key: host
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      name: gistpin-db-credentials
+                      key: username
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: gistpin-db-credentials
+                      key: password
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: gistpin-db-credentials
+                      key: database
+                - name: RETENTION_DAYS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: gistpin-cleanup-config
+                      key: retention_days
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 300m
+                  memory: 256Mi
+
+            # ── Step 2: Redis session cleanup ────────────────────────────────
+            - name: purge-stale-sessions
+              image: redis:7-alpine
+              command:
+                - sh
+                - -c
+                - |
+                  set -euo pipefail
+                  echo "[cleanup] Scanning for stale session keys in Redis..."
+
+                  # Redis SCAN for session:* keys; delete any where TTL = -1
+                  # (no expiry set — shouldn't happen but defensive cleanup)
+                  redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" \
+                    --no-auth-warning -a "$REDIS_PASSWORD" \
+                    --scan --pattern "session:*" \
+                    | while IFS= read -r key; do
+                        ttl=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" \
+                          --no-auth-warning -a "$REDIS_PASSWORD" TTL "$key")
+                        if [ "$ttl" = "-1" ]; then
+                          redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" \
+                            --no-auth-warning -a "$REDIS_PASSWORD" DEL "$key" > /dev/null
+                          echo "[cleanup] Deleted persistent session key: $key"
+                        fi
+                      done
+
+                  echo "[cleanup] Redis session cleanup complete."
+              env:
+                - name: REDIS_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: gistpin-redis-credentials
+                      key: host
+                - name: REDIS_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: gistpin-redis-credentials
+                      key: port
+                - name: REDIS_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: gistpin-redis-credentials
+                      key: password
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+
+          volumes: []
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gistpin-cleanup-sa
+  namespace: gistpin-prod
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gistpin-cleanup-config
+  namespace: gistpin-prod
+data:
+  retention_days: "90"

--- a/infrastructure/k8s/cronjobs/reports.yaml
+++ b/infrastructure/k8s/cronjobs/reports.yaml
@@ -1,0 +1,167 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: gistpin-reports
+  namespace: gistpin-prod
+  labels:
+    app: gistpin
+    component: reports
+    managed-by: cronjob
+spec:
+  schedule: "0 6 * * 1"          # Every Monday 06:00 UTC
+  timeZone: "UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 10  # Keep 10 weeks of report job history
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 1800   # 30-minute window to start
+
+  jobTemplate:
+    metadata:
+      labels:
+        app: gistpin
+        component: reports
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 3600  # 1-hour cap; reports should finish well under this
+
+      template:
+        metadata:
+          labels:
+            app: gistpin
+            component: reports
+          annotations:
+            sidecar.istio.io/inject: "false"
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: gistpin-reports-sa
+
+          initContainers:
+            # Verify the analytics service is reachable before querying
+            - name: analytics-healthcheck
+              image: curlimages/curl:8.7.1
+              command:
+                - sh
+                - -c
+                - |
+                  echo "[reports] Checking analytics service health..."
+                  curl -sf "http://analytics.gistpin-prod.svc.cluster.local/health" \
+                    || { echo "[reports] Analytics service unavailable"; exit 1; }
+                  echo "[reports] Analytics service is ready."
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+
+          containers:
+            - name: report-generator
+              image: ghcr.io/pinspace-org/gistpin-reports:latest
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  set -euo pipefail
+
+                  WEEK_START=$(date -d "last monday" +%Y-%m-%d)
+                  WEEK_END=$(date +%Y-%m-%d)
+                  REPORT_ID="weekly_${WEEK_START}"
+                  REPORT_FILE="/reports/${REPORT_ID}.json"
+                  REPORT_PDF="/reports/${REPORT_ID}.pdf"
+
+                  echo "[reports] Generating report for week ${WEEK_START} to ${WEEK_END}..."
+
+                  # ── 1. Fetch metrics from analytics service ───────────────
+                  curl -sf \
+                    -H "Authorization: Bearer ${ANALYTICS_API_KEY}" \
+                    "${ANALYTICS_URL}/query?from=${WEEK_START}&to=${WEEK_END}&metrics=all" \
+                    -o "$REPORT_FILE"
+
+                  echo "[reports] Raw metrics written to ${REPORT_FILE}"
+
+                  # ── 2. Render PDF report (assumes report-generator image has
+                  #       a render-report binary) ─────────────────────────────
+                  render-report \
+                    --input "$REPORT_FILE" \
+                    --output "$REPORT_PDF" \
+                    --template weekly \
+                    --title "GistPin Weekly Report — ${WEEK_START}"
+
+                  echo "[reports] PDF rendered at ${REPORT_PDF}"
+
+                  # ── 3. Upload to S3 ───────────────────────────────────────
+                  aws s3 cp "$REPORT_PDF" \
+                    "s3://${S3_BUCKET}/reports/${REPORT_ID}.pdf" \
+                    --sse aws:kms \
+                    --content-type application/pdf
+
+                  REPORT_URL="https://${S3_BUCKET}.s3.amazonaws.com/reports/${REPORT_ID}.pdf"
+                  echo "[reports] Uploaded to ${REPORT_URL}"
+
+                  # ── 4. Notify Slack ───────────────────────────────────────
+                  curl -sf -X POST \
+                    -H 'Content-type: application/json' \
+                    --data "{
+                      \"text\": \":bar_chart: *GistPin Weekly Report* (${WEEK_START} to ${WEEK_END}) is ready.\",
+                      \"attachments\": [{
+                        \"text\": \"<${REPORT_URL}|Download PDF>\",
+                        \"color\": \"#36a64f\"
+                      }]
+                    }" \
+                    "$SLACK_WEBHOOK_URL"
+
+                  echo "[reports] Slack notification sent. Done."
+              env:
+                - name: ANALYTICS_URL
+                  value: "http://analytics.gistpin-prod.svc.cluster.local"
+                - name: ANALYTICS_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: gistpin-reports-secrets
+                      key: analytics_api_key
+                - name: S3_BUCKET
+                  valueFrom:
+                    configMapKeyRef:
+                      name: gistpin-reports-config
+                      key: s3_bucket
+                - name: SLACK_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: gistpin-reports-secrets
+                      key: slack_webhook_url
+              resources:
+                requests:
+                  cpu: 200m
+                  memory: 512Mi
+                limits:
+                  cpu: 1000m
+                  memory: 1Gi
+
+              volumeMounts:
+                - name: report-workspace
+                  mountPath: /reports
+
+          volumes:
+            - name: report-workspace
+              emptyDir:
+                sizeLimit: 2Gi
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gistpin-reports-sa
+  namespace: gistpin-prod
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::ACCOUNT_ID:role/gistpin-reports-role"
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gistpin-reports-config
+  namespace: gistpin-prod
+data:
+  s3_bucket: "gistpin-reports-prod"

--- a/infrastructure/k8s/resource-quotas/dev.yaml
+++ b/infrastructure/k8s/resource-quotas/dev.yaml
@@ -1,0 +1,140 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gistpin-dev
+  labels:
+    env: dev
+    team: gistpin
+
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: gistpin-dev-quota
+  namespace: gistpin-dev
+  annotations:
+    quota.gistpin.io/alert-threshold: "80"   # Alert at 80 % utilisation
+spec:
+  hard:
+    # Compute
+    requests.cpu: "4"
+    limits.cpu: "8"
+    requests.memory: 8Gi
+    limits.memory: 16Gi
+
+    # Workloads
+    count/pods: "30"
+    count/deployments.apps: "15"
+    count/statefulsets.apps: "5"
+    count/jobs.batch: "10"
+    count/cronjobs.batch: "5"
+
+    # Services & config
+    count/services: "20"
+    count/configmaps: "30"
+    count/secrets: "30"
+    count/serviceaccounts: "10"
+
+    # Storage
+    requests.storage: 50Gi
+    persistentvolumeclaims: "10"
+    count/persistentvolumeclaims: "10"
+
+---
+# LimitRange — sets defaults so pods without explicit requests/limits still
+# get sensible values, and prevents any single container from going unbounded.
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: gistpin-dev-limits
+  namespace: gistpin-dev
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: 500m
+        memory: 512Mi
+      defaultRequest:
+        cpu: 100m
+        memory: 128Mi
+      max:
+        cpu: "2"
+        memory: 4Gi
+      min:
+        cpu: 10m
+        memory: 16Mi
+
+    - type: Pod
+      max:
+        cpu: "4"
+        memory: 8Gi
+
+    - type: PersistentVolumeClaim
+      max:
+        storage: 20Gi
+      min:
+        storage: 1Gi
+
+---
+# PrometheusRule — fires when any resource dimension exceeds the threshold.
+# Requires kube-prometheus-stack (or compatible) to be installed.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: gistpin-dev-quota-alerts
+  namespace: gistpin-dev
+  labels:
+    prometheus: kube-prometheus
+    role: alert-rules
+spec:
+  groups:
+    - name: gistpin-dev-quota
+      interval: 60s
+      rules:
+        - alert: DevCpuRequestQuotaHigh
+          expr: |
+            kube_resourcequota{namespace="gistpin-dev", resource="requests.cpu", type="used"}
+            / kube_resourcequota{namespace="gistpin-dev", resource="requests.cpu", type="hard"} > 0.8
+          for: 5m
+          labels:
+            severity: warning
+            env: dev
+          annotations:
+            summary: "Dev CPU request quota above 80 %"
+            description: "Namespace gistpin-dev is using {{ $value | humanizePercentage }} of its CPU request quota."
+
+        - alert: DevMemoryRequestQuotaHigh
+          expr: |
+            kube_resourcequota{namespace="gistpin-dev", resource="requests.memory", type="used"}
+            / kube_resourcequota{namespace="gistpin-dev", resource="requests.memory", type="hard"} > 0.8
+          for: 5m
+          labels:
+            severity: warning
+            env: dev
+          annotations:
+            summary: "Dev memory request quota above 80 %"
+            description: "Namespace gistpin-dev is using {{ $value | humanizePercentage }} of its memory request quota."
+
+        - alert: DevPodCountQuotaHigh
+          expr: |
+            kube_resourcequota{namespace="gistpin-dev", resource="count/pods", type="used"}
+            / kube_resourcequota{namespace="gistpin-dev", resource="count/pods", type="hard"} > 0.8
+          for: 5m
+          labels:
+            severity: warning
+            env: dev
+          annotations:
+            summary: "Dev pod count quota above 80 %"
+            description: "{{ $value | humanizePercentage }} of the pod quota is consumed in gistpin-dev."
+
+        - alert: DevStorageQuotaHigh
+          expr: |
+            kube_resourcequota{namespace="gistpin-dev", resource="requests.storage", type="used"}
+            / kube_resourcequota{namespace="gistpin-dev", resource="requests.storage", type="hard"} > 0.8
+          for: 10m
+          labels:
+            severity: warning
+            env: dev
+          annotations:
+            summary: "Dev storage quota above 80 %"
+            description: "Storage quota in gistpin-dev is {{ $value | humanizePercentage }} full."

--- a/infrastructure/k8s/resource-quotas/prod.yaml
+++ b/infrastructure/k8s/resource-quotas/prod.yaml
@@ -1,0 +1,179 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gistpin-prod
+  labels:
+    env: prod
+    team: gistpin
+
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: gistpin-prod-quota
+  namespace: gistpin-prod
+  annotations:
+    quota.gistpin.io/alert-threshold: "70"
+spec:
+  hard:
+    # Compute — sized for 3-replica backend + frontend + analytics + sidecars
+    requests.cpu: "24"
+    limits.cpu: "48"
+    requests.memory: 48Gi
+    limits.memory: 96Gi
+
+    # Workloads
+    count/pods: "150"
+    count/deployments.apps: "30"
+    count/statefulsets.apps: "10"
+    count/jobs.batch: "30"
+    count/cronjobs.batch: "10"
+
+    # Services & config
+    count/services: "50"
+    count/configmaps: "80"
+    count/secrets: "80"
+    count/serviceaccounts: "20"
+
+    # Storage
+    requests.storage: 1Ti
+    persistentvolumeclaims: "40"
+    count/persistentvolumeclaims: "40"
+
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: gistpin-prod-limits
+  namespace: gistpin-prod
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: "1"
+        memory: 1Gi
+      defaultRequest:
+        cpu: 250m
+        memory: 256Mi
+      max:
+        cpu: "8"
+        memory: 16Gi
+      min:
+        cpu: 50m
+        memory: 64Mi
+
+    - type: Pod
+      max:
+        cpu: "16"
+        memory: 32Gi
+
+    - type: PersistentVolumeClaim
+      max:
+        storage: 500Gi
+      min:
+        storage: 1Gi
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: gistpin-prod-quota-alerts
+  namespace: gistpin-prod
+  labels:
+    prometheus: kube-prometheus
+    role: alert-rules
+spec:
+  groups:
+    - name: gistpin-prod-quota
+      interval: 30s    # Tighter scrape interval in prod
+      rules:
+        - alert: ProdCpuRequestQuotaHigh
+          expr: |
+            kube_resourcequota{namespace="gistpin-prod", resource="requests.cpu", type="used"}
+            / kube_resourcequota{namespace="gistpin-prod", resource="requests.cpu", type="hard"} > 0.70
+          for: 5m
+          labels:
+            severity: warning
+            env: prod
+          annotations:
+            summary: "Prod CPU request quota above 70 %"
+            description: "gistpin-prod CPU requests at {{ $value | humanizePercentage }}. Consider raising quota or scaling down workloads."
+            runbook_url: "https://github.com/PinSpace-Org/GistPin/wiki/runbooks/quota-cpu"
+
+        - alert: ProdCpuRequestQuotaCritical
+          expr: |
+            kube_resourcequota{namespace="gistpin-prod", resource="requests.cpu", type="used"}
+            / kube_resourcequota{namespace="gistpin-prod", resource="requests.cpu", type="hard"} > 0.90
+          for: 2m
+          labels:
+            severity: critical
+            env: prod
+          annotations:
+            summary: "Prod CPU request quota above 90 % -- scheduling risk"
+            description: "gistpin-prod CPU requests at {{ $value | humanizePercentage }}. New pods may fail to schedule."
+            runbook_url: "https://github.com/PinSpace-Org/GistPin/wiki/runbooks/quota-cpu"
+
+        - alert: ProdMemoryRequestQuotaHigh
+          expr: |
+            kube_resourcequota{namespace="gistpin-prod", resource="requests.memory", type="used"}
+            / kube_resourcequota{namespace="gistpin-prod", resource="requests.memory", type="hard"} > 0.70
+          for: 5m
+          labels:
+            severity: warning
+            env: prod
+          annotations:
+            summary: "Prod memory request quota above 70 %"
+            description: "gistpin-prod memory requests at {{ $value | humanizePercentage }}."
+            runbook_url: "https://github.com/PinSpace-Org/GistPin/wiki/runbooks/quota-memory"
+
+        - alert: ProdMemoryRequestQuotaCritical
+          expr: |
+            kube_resourcequota{namespace="gistpin-prod", resource="requests.memory", type="used"}
+            / kube_resourcequota{namespace="gistpin-prod", resource="requests.memory", type="hard"} > 0.90
+          for: 2m
+          labels:
+            severity: critical
+            env: prod
+          annotations:
+            summary: "Prod memory request quota above 90 %"
+            description: "gistpin-prod memory requests at {{ $value | humanizePercentage }}. OOM evictions and scheduling failures imminent."
+            runbook_url: "https://github.com/PinSpace-Org/GistPin/wiki/runbooks/quota-memory"
+
+        - alert: ProdPodCountQuotaHigh
+          expr: |
+            kube_resourcequota{namespace="gistpin-prod", resource="count/pods", type="used"}
+            / kube_resourcequota{namespace="gistpin-prod", resource="count/pods", type="hard"} > 0.70
+          for: 5m
+          labels:
+            severity: warning
+            env: prod
+          annotations:
+            summary: "Prod pod count quota above 70 %"
+            description: "{{ $value | humanizePercentage }} of pod quota consumed in gistpin-prod."
+
+        - alert: ProdStorageQuotaHigh
+          expr: |
+            kube_resourcequota{namespace="gistpin-prod", resource="requests.storage", type="used"}
+            / kube_resourcequota{namespace="gistpin-prod", resource="requests.storage", type="hard"} > 0.70
+          for: 10m
+          labels:
+            severity: warning
+            env: prod
+          annotations:
+            summary: "Prod storage quota above 70 %"
+            description: "Storage quota in gistpin-prod at {{ $value | humanizePercentage }}."
+            runbook_url: "https://github.com/PinSpace-Org/GistPin/wiki/runbooks/quota-storage"
+
+        - alert: ProdQuotaExceeded
+          expr: |
+            kube_resourcequota{namespace="gistpin-prod", type="used"}
+            >= kube_resourcequota{namespace="gistpin-prod", type="hard"}
+          for: 1m
+          labels:
+            severity: critical
+            env: prod
+            page: "true"    # Trigger PagerDuty / OpsGenie paging
+          annotations:
+            summary: "PROD quota hard limit hit for {{ $labels.resource }}"
+            description: "Resource {{ $labels.resource }} has reached its hard quota in gistpin-prod. Pod/PVC creation is being rejected RIGHT NOW."
+            runbook_url: "https://github.com/PinSpace-Org/GistPin/wiki/runbooks/quota-exceeded"

--- a/infrastructure/k8s/resource-quotas/staging.yaml
+++ b/infrastructure/k8s/resource-quotas/staging.yaml
@@ -1,0 +1,149 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gistpin-staging
+  labels:
+    env: staging
+    team: gistpin
+
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: gistpin-staging-quota
+  namespace: gistpin-staging
+  annotations:
+    quota.gistpin.io/alert-threshold: "75"
+spec:
+  hard:
+    # Compute
+    requests.cpu: "8"
+    limits.cpu: "16"
+    requests.memory: 16Gi
+    limits.memory: 32Gi
+
+    # Workloads
+    count/pods: "60"
+    count/deployments.apps: "20"
+    count/statefulsets.apps: "8"
+    count/jobs.batch: "20"
+    count/cronjobs.batch: "10"
+
+    # Services & config
+    count/services: "30"
+    count/configmaps: "50"
+    count/secrets: "50"
+    count/serviceaccounts: "15"
+
+    # Storage
+    requests.storage: 200Gi
+    persistentvolumeclaims: "20"
+    count/persistentvolumeclaims: "20"
+
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: gistpin-staging-limits
+  namespace: gistpin-staging
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: "1"
+        memory: 1Gi
+      defaultRequest:
+        cpu: 200m
+        memory: 256Mi
+      max:
+        cpu: "4"
+        memory: 8Gi
+      min:
+        cpu: 50m
+        memory: 64Mi
+
+    - type: Pod
+      max:
+        cpu: "8"
+        memory: 16Gi
+
+    - type: PersistentVolumeClaim
+      max:
+        storage: 100Gi
+      min:
+        storage: 1Gi
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: gistpin-staging-quota-alerts
+  namespace: gistpin-staging
+  labels:
+    prometheus: kube-prometheus
+    role: alert-rules
+spec:
+  groups:
+    - name: gistpin-staging-quota
+      interval: 60s
+      rules:
+        - alert: StagingCpuRequestQuotaHigh
+          expr: |
+            kube_resourcequota{namespace="gistpin-staging", resource="requests.cpu", type="used"}
+            / kube_resourcequota{namespace="gistpin-staging", resource="requests.cpu", type="hard"} > 0.75
+          for: 5m
+          labels:
+            severity: warning
+            env: staging
+          annotations:
+            summary: "Staging CPU request quota above 75 %"
+            description: "gistpin-staging CPU request quota at {{ $value | humanizePercentage }}."
+
+        - alert: StagingMemoryRequestQuotaHigh
+          expr: |
+            kube_resourcequota{namespace="gistpin-staging", resource="requests.memory", type="used"}
+            / kube_resourcequota{namespace="gistpin-staging", resource="requests.memory", type="hard"} > 0.75
+          for: 5m
+          labels:
+            severity: warning
+            env: staging
+          annotations:
+            summary: "Staging memory request quota above 75 %"
+            description: "gistpin-staging memory request quota at {{ $value | humanizePercentage }}."
+
+        - alert: StagingPodCountQuotaHigh
+          expr: |
+            kube_resourcequota{namespace="gistpin-staging", resource="count/pods", type="used"}
+            / kube_resourcequota{namespace="gistpin-staging", resource="count/pods", type="hard"} > 0.75
+          for: 5m
+          labels:
+            severity: warning
+            env: staging
+          annotations:
+            summary: "Staging pod count above 75 %"
+            description: "Pod quota in gistpin-staging at {{ $value | humanizePercentage }}."
+
+        - alert: StagingStorageQuotaHigh
+          expr: |
+            kube_resourcequota{namespace="gistpin-staging", resource="requests.storage", type="used"}
+            / kube_resourcequota{namespace="gistpin-staging", resource="requests.storage", type="hard"} > 0.75
+          for: 10m
+          labels:
+            severity: warning
+            env: staging
+          annotations:
+            summary: "Staging storage quota above 75 %"
+            description: "Storage quota in gistpin-staging at {{ $value | humanizePercentage }}."
+
+        # Staging-specific: alert on any quota-exceeded event immediately
+        - alert: StagingQuotaExceeded
+          expr: |
+            kube_resourcequota{namespace="gistpin-staging", type="used"}
+            >= kube_resourcequota{namespace="gistpin-staging", type="hard"}
+          for: 1m
+          labels:
+            severity: critical
+            env: staging
+          annotations:
+            summary: "Staging quota hard limit hit for {{ $labels.resource }}"
+            description: "Resource {{ $labels.resource }} has hit its hard quota in gistpin-staging. New pods/PVCs may be rejected."


### PR DESCRIPTION
## Resource Quotas and CronJobs

### Resource Quotas
- **`dev.yaml`** -- 4 CPU / 8 Gi memory / 30 pods, alerts at 80 %
- **`staging.yaml`** -- 8 CPU / 16 Gi / 60 pods, alerts at 75 % with hard-limit-hit alert
- **`prod.yaml`** -- 24 CPU / 48 Gi / 150 pods / 1 Ti storage, dual-threshold alerts (70 % warning, 90 % critical) with paging on hard limit
- All environments include LimitRange defaults and PrometheusRule alerts

### CronJobs
- **`backup.yaml`** -- daily 02:00 UTC, `Forbid` concurrency, pg_dump to S3 with 30-day retention pruning
- **`cleanup.yaml`** -- every 6 hours, `Replace` concurrency, purges expired gists, orphaned blob refs, and stale Redis sessions
- **`reports.yaml`** -- weekly Monday 06:00 UTC, `Forbid` concurrency, generates PDF report from analytics, uploads to S3, notifies Slack

Closes #413, closes #416