### PR TITLE
feat(infra): build frontend production Dockerfile

### DIFF
--- a/infrastructure/docker/frontend.Dockerfile
+++ b/infrastructure/docker/frontend.Dockerfile
@@ -1,0 +1,22 @@
+# ---------- deps ----------
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+
+# ---------- build ----------
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN npm run build
+
+# ---------- runner ----------
+FROM nginx:1.27-alpine AS runner
+WORKDIR /usr/share/nginx/html
+RUN rm -rf ./*
+COPY --from=builder /app/out ./
+EXPOSE 80
+HEALTHCHECK --interval=30s --timeout=5s CMD wget -qO- http://localhost/ping || exit 1
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- Add `infrastructure/docker/frontend.Dockerfile` with three-stage build (`deps`, `builder`, `runner`)
- Static export served by NGINX Alpine for minimal image size
- `NEXT_TELEMETRY_DISABLED=1` prevents telemetry during build
- Health check polls `/ping` every 30s

Closes #442