### PR TITLE
feat(infra): setup WAF for application protection

### DIFF
--- a/infrastructure/terraform/waf.tf
+++ b/infrastructure/terraform/waf.tf
@@ -1,0 +1,56 @@
+﻿# WAF for application protection
+resource "aws_wafv2_web_acl" "app_waf" {
+  name  = "${var.app_name}-${var.environment}-waf"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "CommonRuleSetMetric"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.app_name}-waf"
+    sampled_requests_enabled   = true
+  }
+
+  tags = {
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+variable "app_name" {
+  type    = string
+  default = "gistpin"
+}
+
+variable "environment" {
+  type    = string
+  default = "dev"
+}
+
+output "waf_arn" {
+  value = aws_wafv2_web_acl.app_waf.arn
+}


### PR DESCRIPTION
## Summary
Adds Terraform configuration for AWS WAFv2 Web ACL with AWS Managed Rules for common threat protection.

## Changes
- aws_wafv2_web_acl with AWSManagedRulesCommonRuleSet (SQL injection, XSS, etc.)
- CloudWatch metrics enabled for visibility
- Output: waf_arn

closes #436