### PR TITLE
feat(infra): create multi-environment Terraform workspaces

### DIFF
--- a/infrastructure/terraform/workspaces.tf
+++ b/infrastructure/terraform/workspaces.tf
@@ -1,0 +1,39 @@
+﻿# Multi-environment workspace configuration
+locals {
+  env_config = {
+    dev = {
+      instance_type = "t3.micro"
+      min_capacity  = 1
+      max_capacity  = 2
+    }
+    staging = {
+      instance_type = "t3.small"
+      min_capacity  = 1
+      max_capacity  = 3
+    }
+    prod = {
+      instance_type = "t3.medium"
+      min_capacity  = 2
+      max_capacity  = 10
+    }
+  }
+
+  current_env    = terraform.workspace
+  current_config = lookup(local.env_config, local.current_env, local.env_config["dev"])
+}
+
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "gistpin"
+}
+
+output "workspace_name" {
+  description = "Current Terraform workspace"
+  value       = terraform.workspace
+}
+
+output "instance_type" {
+  description = "Instance type for current environment"
+  value       = local.current_config.instance_type
+}


### PR DESCRIPTION
## Summary
Adds Terraform workspace configuration with environment-specific settings for dev, staging, and prod.

## Changes
- locals.env_config map with instance type and capacity per environment
- Workspace-aware locals using terraform.workspace
- Outputs: workspace_name, instance_type

closes #437