### PR TITLE
feat(monitoring): create Grafana application metrics dashboard

### DIFF
--- a/infrastructure/monitoring/grafana/dashboards/app-metrics.json
+++ b/infrastructure/monitoring/grafana/dashboards/app-metrics.json
@@ -1,0 +1,33 @@
+﻿{
+  "title": "GistPin Application Metrics",
+  "uid": "gistpin-app",
+  "schemaVersion": 36,
+  "panels": [
+    {
+      "id": 1,
+      "title": "Request Rate",
+      "type": "graph",
+      "targets": [
+        {
+          "expr": "rate(http_requests_total[5m])",
+          "legendFormat": "{{method}} {{path}}"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
+    },
+    {
+      "id": 2,
+      "title": "Error Rate",
+      "type": "graph",
+      "targets": [
+        {
+          "expr": "rate(http_requests_total{status=~\"5..\"}[5m])",
+          "legendFormat": "5xx errors"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
+    }
+  ],
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "30s"
+}


### PR DESCRIPTION
## Summary
Adds a Grafana dashboard JSON for visualizing GistPin application metrics including request rate and error rate.

## Changes
- Add grafana/dashboards/app-metrics.json with request rate and error rate panels
- Dashboard auto-refreshes every 30s with 1h default time range

closes #448