### PR TITLE
feat(monitoring): implement distributed tracing with Jaeger

### DIFF
--- a/infrastructure/monitoring/jaeger-deployment.yaml
+++ b/infrastructure/monitoring/jaeger-deployment.yaml
@@ -1,0 +1,55 @@
+﻿# Jaeger deployment configuration for distributed tracing
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger
+  namespace: monitoring
+  labels:
+    app: jaeger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jaeger
+  template:
+    metadata:
+      labels:
+        app: jaeger
+    spec:
+      containers:
+        - name: jaeger
+          image: jaegertracing/all-in-one:1.53
+          ports:
+            - containerPort: 16686
+              name: ui
+            - containerPort: 14268
+              name: collector
+            - containerPort: 6831
+              protocol: UDP
+              name: agent
+          env:
+            - name: COLLECTOR_ZIPKIN_HOST_PORT
+              value: ":9411"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger
+  namespace: monitoring
+spec:
+  selector:
+    app: jaeger
+  ports:
+    - name: ui
+      port: 16686
+      targetPort: 16686
+    - name: collector
+      port: 14268
+      targetPort: 14268


### PR DESCRIPTION
## Summary
Adds Jaeger deployment configuration for end-to-end distributed request tracing.

## Changes
- Add jaeger-deployment.yaml with Deployment and Service for Jaeger all-in-one
- Exposes UI (16686), collector (14268), and agent (6831/UDP) ports

closes #449