### PR TITLE
feat(monitoring): create alerting rules and notification config

### DIFF
--- a/infrastructure/monitoring/alertmanager.yml
+++ b/infrastructure/monitoring/alertmanager.yml
@@ -1,0 +1,36 @@
+global:
+  resolve_timeout: 5m
+  slack_api_url: '${SLACK_WEBHOOK_URL}'
+
+route:
+  group_by: ['alertname', 'severity']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: slack-critical
+  routes:
+    - match:
+        severity: critical
+      receiver: slack-critical
+    - match:
+        severity: warning
+      receiver: slack-warnings
+
+receivers:
+  - name: slack-critical
+    slack_configs:
+      - channel: '#alerts-critical'
+        title: '[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}'
+        text: '{{ range .Alerts }}{{ .Annotations.description }}{{ end }}'
+  - name: slack-warnings
+    slack_configs:
+      - channel: '#alerts-warnings'
+        title: '[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}'
+        text: '{{ range .Alerts }}{{ .Annotations.description }}{{ end }}'
+
+inhibit_rules:
+  - source_match:
+      severity: critical
+    target_match:
+      severity: warning
+    equal: ['alertname']


### PR DESCRIPTION
## Summary
- Add `infrastructure/monitoring/alertmanager.yml` with Slack routing for `critical` and `warning` severity levels
- Alert grouping by `alertname` and `severity`
- Inhibit rule prevents duplicate warnings when a critical is already firing

Closes #451