### PR TITLE
feat(monitoring): setup uptime monitoring with multi-region health checks

### DIFF
--- a/infrastructure/monitoring/uptime-config.yml
+++ b/infrastructure/monitoring/uptime-config.yml
@@ -1,0 +1,37 @@
+uptime:
+  provider: betteruptime
+  check_interval: 60
+
+monitors:
+  - name: GistPin API Health
+    url: https://api.gistpin.com/health
+    method: GET
+    expected_status: 200
+    regions: [us-east, eu-west, ap-southeast]
+    alert_after: 2
+
+  - name: GistPin Frontend
+    url: https://gistpin.com
+    method: GET
+    expected_status: 200
+    regions: [us-east, eu-west]
+    alert_after: 2
+
+  - name: GistPin API Ping
+    url: https://api.gistpin.com/ping
+    method: GET
+    expected_status: 200
+    regions: [us-east]
+    alert_after: 1
+
+response_time_thresholds:
+  warning_ms: 1000
+  critical_ms: 3000
+
+status_page:
+  enabled: true
+  public_url: https://status.gistpin.com
+  components:
+    - API
+    - Frontend
+    - Database


### PR DESCRIPTION
## Summary
- Add `infrastructure/monitoring/uptime-config.yml` monitoring API health, frontend, and ping endpoints
- Multi-region checks (us-east, eu-west, ap-southeast)
- Response time thresholds at 1 s warning / 3 s critical
- Status page config at `status.gistpin.com`

Closes #453