### PR TITLE
feat(infra): create Rust contract builder container

### DIFF
--- a/infrastructure/docker/contract-builder.Dockerfile
+++ b/infrastructure/docker/contract-builder.Dockerfile
@@ -1,0 +1,12 @@
+FROM rust:1.82-slim AS builder
+
+RUN rustup target add wasm32v1-none \
+ && cargo install soroban-cli --locked
+
+WORKDIR /workspace
+COPY . .
+
+RUN cargo build --release --target wasm32v1-none
+
+FROM scratch AS artifacts
+COPY --from=builder /workspace/target/wasm32v1-none/release/*.wasm /


### PR DESCRIPTION
## Summary
- Add `infrastructure/docker/contract-builder.Dockerfile` with a two-stage build
- Stage 1 installs the Rust toolchain, `wasm32v1-none` target, and Soroban CLI, then compiles contracts
- Stage 2 (`scratch`) exports only the compiled `.wasm` artefacts for minimal image size

Closes #443