### PR TITLE
feat(infra): setup docker-compose for local development

### DIFF
--- a/infrastructure/docker/docker-compose.yml
+++ b/infrastructure/docker/docker-compose.yml
@@ -1,0 +1,42 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: ../../Backend
+      dockerfile: ../infrastructure/docker/backend.Dockerfile
+    ports: ["3000:3000"]
+    environment:
+      NODE_ENV: development
+      DATABASE_URL: postgresql://gistpin:gistpin@postgres:5432/gistpin
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - ../../Backend:/app
+      - /app/node_modules
+
+  frontend:
+    build:
+      context: ../../Frontend
+      dockerfile: ../infrastructure/docker/frontend.Dockerfile
+    ports: ["3001:80"]
+    depends_on: [backend]
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: gistpin
+      POSTGRES_PASSWORD: gistpin
+      POSTGRES_DB: gistpin
+    ports: ["5432:5432"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U gistpin"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- Add `infrastructure/docker/docker-compose.yml` defining `backend`, `frontend`, and `postgres` services
- Volume mounts on backend enable hot-reload during development
- Postgres health check prevents dependent services starting before the DB is ready

Closes #444