### PR TITLE
feat(infra): implement Docker image scanning with Trivy

### DIFF
--- a/infrastructure/docker/scan-images.sh
+++ b/infrastructure/docker/scan-images.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="${1:?Usage: scan-images.sh <image> [report-dir]}"
+REPORT_DIR="${2:-reports}"
+mkdir -p "$REPORT_DIR"
+REPORT="$REPORT_DIR/trivy-$(date +%Y%m%d-%H%M%S).json"
+
+echo "Scanning $IMAGE for vulnerabilities..."
+
+trivy image \
+  --exit-code 1 \
+  --severity CRITICAL,HIGH \
+  --format json \
+  --output "$REPORT" \
+  "$IMAGE"
+
+echo "Scan complete. Report: $REPORT"


### PR DESCRIPTION
## Summary
- Add `infrastructure/docker/scan-images.sh` wrapping Trivy for container vulnerability scanning
- Exits with code 1 on `CRITICAL` or `HIGH` severity findings (CI-friendly)
- Outputs a timestamped JSON report to a configurable reports directory

Closes #445