### PR TITLE
feat(infra): create PostgreSQL Docker configuration

### DIFF
--- a/infrastructure/docker/postgres-init.sql
+++ b/infrastructure/docker/postgres-init.sql
@@ -1,0 +1,3 @@
+-- GistPin database bootstrap
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pg_stat_statements";

--- a/infrastructure/docker/postgres.Dockerfile
+++ b/infrastructure/docker/postgres.Dockerfile
@@ -1,0 +1,13 @@
+FROM postgres:16-alpine
+
+ENV POSTGRES_USER=gistpin \
+    POSTGRES_PASSWORD=gistpin \
+    POSTGRES_DB=gistpin
+
+# Custom init scripts run in alphabetical order on first start
+COPY postgres-init.sql /docker-entrypoint-initdb.d/01-init.sql
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=5 \
+  CMD pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" || exit 1
+
+EXPOSE 5432


### PR DESCRIPTION
## Summary
- Add `infrastructure/docker/postgres.Dockerfile` based on `postgres:16-alpine` with health check
- Add `postgres-init.sql` enabling `uuid-ossp` and `pg_stat_statements` extensions on first start
- Init SQL is mounted at `/docker-entrypoint-initdb.d/` so it runs automatically

Closes #446