### PR TITLE
feat(logging): add structured Winston logging with correlation IDs

### DIFF
--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -22,10 +22,12 @@
         "ethers": "^6.15.0",
         "iterare": "^1.2.1",
         "joi": "^18.2.1",
+        "nest-winston": "^1.10.2",
         "pg": "^8.13.3",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
-        "typeorm": "^0.3.28"
+        "typeorm": "^0.3.28",
+        "winston": "^3.19.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -769,6 +771,17 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3023,6 +3036,16 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/@sqltools/formatter": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
@@ -3691,6 +3714,12 @@
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
       }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
     },
     "node_modules/@types/validator": {
       "version": "13.15.2",
@@ -5002,7 +5031,6 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/asynckit": {
@@ -5751,6 +5779,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5768,6 +5809,48 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -6282,6 +6365,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -6968,6 +7057,12 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -7150,6 +7245,12 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -7930,7 +8031,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8906,6 +9006,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -9023,6 +9129,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/logform/node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/lowercase-keys": {
@@ -9388,6 +9520,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nest-winston": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/nest-winston/-/nest-winston-1.10.2.tgz",
+      "integrity": "sha512-Z9IzL/nekBOF/TEwBHUJDiDPMaXUcFquUQOFavIRet6xF0EbuWnOzslyN/ksgzG+fITNgXhMdrL/POp9SdaFxA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-safe-stringify": "^2.1.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^5.0.0 || ^6.6.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "winston": "^3.0.0"
+      }
+    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
@@ -9495,6 +9640,15 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/onetime": {
@@ -10508,6 +10662,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -10898,6 +11061,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/stack-utils": {
@@ -11500,6 +11672,12 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -11588,6 +11766,15 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -12560,6 +12747,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston/node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/word-wrap": {

--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/swagger": "^11.2.6",
         "@nestjs/throttler": "^6.4.0",
         "@nestjs/typeorm": "^11.0.0",
+        "bs-logger": "^0.2.6",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "ethers": "^6.15.0",
@@ -5350,7 +5351,6 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
       "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-json-stable-stringify": "2.x"
@@ -7004,7 +7004,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -36,10 +36,12 @@
     "ethers": "^6.15.0",
     "iterare": "^1.2.1",
     "joi": "^18.2.1",
+    "nest-winston": "^1.10.2",
     "pg": "^8.13.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "typeorm": "^0.3.28"
+    "typeorm": "^0.3.28",
+    "winston": "^3.19.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/Backend/src/app.module.ts
+++ b/Backend/src/app.module.ts
@@ -1,7 +1,8 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { WinstonModule } from 'nest-winston';
 import { DatabaseModule } from './database/database.module';
 import { GeoModule } from './geo/geo.module';
 import { IpfsModule } from './ipfs/ipfs.module';
@@ -9,6 +10,8 @@ import { SorobanModule } from './soroban/soroban.module';
 import { GistsModule } from './gists/gists.module';
 import { HealthModule } from './health/health.module';
 import { envValidationSchema } from './config/env.validation';
+import { CorrelationIdMiddleware } from './common/middleware/correlation-id.middleware';
+import { buildWinstonOptions } from './common/logger/winston.config';
 
 @Module({
   imports: [
@@ -16,6 +19,12 @@ import { envValidationSchema } from './config/env.validation';
       isGlobal: true,
       validationSchema: envValidationSchema,
       validationOptions: { abortEarly: false },
+    }),
+    WinstonModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) =>
+        buildWinstonOptions(config.get<string>('NODE_ENV', 'development')),
     }),
     ThrottlerModule.forRootAsync({
       imports: [ConfigModule],
@@ -41,4 +50,8 @@ import { envValidationSchema } from './config/env.validation';
     },
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(CorrelationIdMiddleware).forRoutes('*');
+  }
+}

--- a/Backend/src/common/interceptors/logging.interceptor.spec.ts
+++ b/Backend/src/common/interceptors/logging.interceptor.spec.ts
@@ -1,0 +1,124 @@
+import { Logger } from '@nestjs/common';
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+import { of, throwError } from 'rxjs';
+import { LoggingInterceptor } from './logging.interceptor';
+import * as correlationStore from '../logger/correlation-id.store';
+
+function makeContext(method: string, url: string, statusCode: number, ip = '::1'): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ method, url, ip }),
+      getResponse: () => ({ statusCode }),
+    }),
+  } as unknown as ExecutionContext;
+}
+
+function makeHandler(value: unknown = null, error?: Error): CallHandler {
+  return { handle: () => (error ? throwError(() => error) : of(value)) };
+}
+
+describe('LoggingInterceptor', () => {
+  let interceptor: LoggingInterceptor;
+  let logSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    interceptor = new LoggingInterceptor();
+    logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    jest.spyOn(correlationStore, 'getCorrelationId').mockReturnValue('test-corr-id');
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('should pass through health check routes without logging', (done) => {
+    const ctx = makeContext('GET', '/health', 200);
+    interceptor.intercept(ctx, makeHandler()).subscribe({
+      complete: () => {
+        expect(logSpy).not.toHaveBeenCalled();
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+
+  it('should also skip /health/* sub-routes', (done) => {
+    const ctx = makeContext('GET', '/health/liveness', 200);
+    interceptor.intercept(ctx, makeHandler()).subscribe({
+      complete: () => {
+        expect(logSpy).not.toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+
+  it('should call logger.log for 2xx responses', (done) => {
+    const ctx = makeContext('GET', '/gists', 200);
+    interceptor.intercept(ctx, makeHandler()).subscribe({
+      complete: () => {
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('GET /gists 200'));
+        done();
+      },
+    });
+  });
+
+  it('should include the correlation ID in 2xx log lines', (done) => {
+    const ctx = makeContext('POST', '/gists', 201);
+    interceptor.intercept(ctx, makeHandler()).subscribe({
+      complete: () => {
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[test-corr-id]'));
+        done();
+      },
+    });
+  });
+
+  it('should call logger.warn for 4xx responses', (done) => {
+    const ctx = makeContext('POST', '/gists', 400);
+    interceptor.intercept(ctx, makeHandler()).subscribe({
+      complete: () => {
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('POST /gists 400'));
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[test-corr-id]'));
+        done();
+      },
+    });
+  });
+
+  it('should call logger.error for 5xx responses', (done) => {
+    const ctx = makeContext('GET', '/gists', 500);
+    interceptor.intercept(ctx, makeHandler()).subscribe({
+      complete: () => {
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('GET /gists 500'));
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('[test-corr-id]'));
+        done();
+      },
+    });
+  });
+
+  it('should call logger.error on thrown errors and include correlation ID', (done) => {
+    const ctx = makeContext('POST', '/gists', 500);
+    const err = new Error('something broke');
+    interceptor.intercept(ctx, makeHandler(null, err)).subscribe({
+      error: () => {
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('POST /gists ERROR'),
+        );
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('[test-corr-id]'));
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('something broke'));
+        done();
+      },
+    });
+  });
+
+  it('should include elapsed time in the log line', (done) => {
+    const ctx = makeContext('GET', '/gists', 200);
+    interceptor.intercept(ctx, makeHandler()).subscribe({
+      complete: () => {
+        expect(logSpy).toHaveBeenCalledWith(expect.stringMatching(/\d+ms/));
+        done();
+      },
+    });
+  });
+});

--- a/Backend/src/common/interceptors/logging.interceptor.ts
+++ b/Backend/src/common/interceptors/logging.interceptor.ts
@@ -1,6 +1,7 @@
 import { Injectable, NestInterceptor, ExecutionContext, CallHandler, Logger } from '@nestjs/common';
 import { Observable, tap } from 'rxjs';
 import { Request, Response } from 'express';
+import { getCorrelationId } from '../logger/correlation-id.store';
 
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {
@@ -11,7 +12,6 @@ export class LoggingInterceptor implements NestInterceptor {
     const res = context.switchToHttp().getResponse<Response>();
     const { method, url, ip } = req;
 
-    // Skip health checks to avoid log noise
     if (url.startsWith('/health')) {
       return next.handle();
     }
@@ -23,7 +23,8 @@ export class LoggingInterceptor implements NestInterceptor {
         next: () => {
           const ms = Date.now() - start;
           const status = res.statusCode;
-          const log = `${method} ${url} ${status} ${ms}ms — ${ip}`;
+          const correlationId = getCorrelationId();
+          const log = `${method} ${url} ${status} ${ms}ms — ${ip} [${correlationId}]`;
 
           if (status >= 500) this.logger.error(log);
           else if (status >= 400) this.logger.warn(log);
@@ -31,7 +32,8 @@ export class LoggingInterceptor implements NestInterceptor {
         },
         error: (err: Error) => {
           const ms = Date.now() - start;
-          this.logger.error(`${method} ${url} ERROR ${ms}ms — ${err.message}`);
+          const correlationId = getCorrelationId();
+          this.logger.error(`${method} ${url} ERROR ${ms}ms [${correlationId}] — ${err.message}`);
         },
       }),
     );

--- a/Backend/src/common/logger/correlation-id.store.ts
+++ b/Backend/src/common/logger/correlation-id.store.ts
@@ -1,0 +1,7 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+export const correlationStore = new AsyncLocalStorage<{ id: string }>();
+
+export function getCorrelationId(): string {
+  return correlationStore.getStore()?.id ?? '-';
+}

--- a/Backend/src/common/logger/winston.config.ts
+++ b/Backend/src/common/logger/winston.config.ts
@@ -1,0 +1,32 @@
+import { utilities as nestWinstonUtilities, WinstonModuleOptions } from 'nest-winston';
+import * as winston from 'winston';
+import { getCorrelationId } from './correlation-id.store';
+
+const correlationFormat = winston.format((info) => {
+  info.correlationId = getCorrelationId();
+  return info;
+});
+
+const jsonFormat = winston.format.combine(
+  correlationFormat(),
+  winston.format.timestamp(),
+  winston.format.errors({ stack: true }),
+  winston.format.json(),
+);
+
+const prettyFormat = winston.format.combine(
+  correlationFormat(),
+  winston.format.timestamp(),
+  winston.format.errors({ stack: true }),
+  nestWinstonUtilities.format.nestLike('GistPin', { prettyPrint: true, colors: true }),
+);
+
+export function buildWinstonOptions(nodeEnv: string): WinstonModuleOptions {
+  const isProd = nodeEnv === 'production';
+
+  return {
+    level: isProd ? 'info' : 'debug',
+    format: isProd ? jsonFormat : prettyFormat,
+    transports: [new winston.transports.Console()],
+  };
+}

--- a/Backend/src/common/middleware/correlation-id.middleware.ts
+++ b/Backend/src/common/middleware/correlation-id.middleware.ts
@@ -1,0 +1,13 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { randomUUID } from 'crypto';
+import { correlationStore } from '../logger/correlation-id.store';
+
+@Injectable()
+export class CorrelationIdMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction): void {
+    const id = (req.headers['x-correlation-id'] as string | undefined) ?? randomUUID();
+    res.setHeader('x-correlation-id', id);
+    correlationStore.run({ id }, next);
+  }
+}

--- a/Backend/src/main.ts
+++ b/Backend/src/main.ts
@@ -2,11 +2,13 @@ import 'reflect-metadata';
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { AppModule } from './app.module';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, { bufferLogs: true });
+  app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
 
   // Issue 78 — CORS
   const allowedOrigins = process.env.CORS_ORIGINS


### PR DESCRIPTION
## Summary

Closes #89

Replaces NestJS's default text logger with **Winston**, configured for structured JSON output in production and human-readable colourised output in development. Every log line — including from existing `new Logger()` calls across all services — is enriched with a **correlation ID** that ties every log entry in a request lifecycle together.

### What changed

| File | Change |
|---|---|
| `src/common/logger/winston.config.ts` | Builds Winston options: JSON format (prod) / pretty NestJS-like format (dev), with a custom format step that stamps `correlationId` on every log entry |
| `src/common/logger/correlation-id.store.ts` | `AsyncLocalStorage` store + `getCorrelationId()` helper — zero-overhead ID propagation with no manual passing |
| `src/common/middleware/correlation-id.middleware.ts` | Per-request middleware: reads `x-correlation-id` from incoming headers (or generates a UUID), echoes it back in the response header, and runs the request inside the store context |
| `src/app.module.ts` | Registers `WinstonModule.forRootAsync` (reads `NODE_ENV` from config) and applies `CorrelationIdMiddleware` to all routes |
| `src/main.ts` | Sets Winston as NestJS's app-wide logger via `WINSTON_MODULE_NEST_PROVIDER`; adds `bufferLogs: true` so bootstrap logs aren't lost before Winston is ready |
| `src/common/interceptors/logging.interceptor.ts` | HTTP log lines now include `[correlationId]` — e.g. `GET /gists 200 12ms — ::1 [3f2a…]` |

### Production log shape (JSON)

```json
{
  "level": "info",
  "message": "GET /gists 200 12ms — ::1 [3f2a1c9e-…]",
  "context": "HTTP",
  "correlationId": "3f2a1c9e-2b44-4d1e-a8fc-e0d6e3c91234",
  "timestamp": "2026-06-16T11:42:00.000Z"
}
```

### How correlation IDs flow

```
Client request
  → CorrelationIdMiddleware generates / reads x-correlation-id
    → AsyncLocalStorage.run() wraps the entire request pipeline
      → any Logger call anywhere in that request reads getCorrelationId()
  → x-correlation-id echoed in response header
```

No manual ID passing is needed — existing `Logger` calls in `GistsService`, `IpfsService`, `SorobanService`, `IndexerService`, and `AllExceptionsFilter` all gain correlation IDs automatically.

## Test plan

- [ ] `NODE_ENV=production npm run start` — confirm logs are newline-delimited JSON with `correlationId` field
- [ ] `NODE_ENV=development npm run start:dev` — confirm colourised pretty output
- [ ] `curl -H "x-correlation-id: my-trace-id" http://localhost:3000/gists?lat=9&lon=7` — confirm `x-correlation-id: my-trace-id` in response headers and `"correlationId":"my-trace-id"` in logs
- [ ] Omit the header — confirm a UUID is auto-generated and appears consistently across all log lines for that request
- [ ] `npx tsc --noEmit` — zero errors