### PR TITLE
feat(logger): add production log file rotation with separate error/info streams

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -20,3 +20,6 @@ PINATA_SECRET_KEY=
 
 # Optional: backend signing keypair for submitting txs to Soroban
 STELLAR_SECRET_KEY=
+
+# Logging — directory for rotated log files (production only)
+LOG_DIR=logs

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -39,6 +39,7 @@
     "joi": "^18.2.1",
     "nest-winston": "^1.10.2",
     "pg": "^8.13.3",
+    "winston-daily-rotate-file": "^5.0.0",
     "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/Backend/src/app.module.ts
+++ b/Backend/src/app.module.ts
@@ -25,7 +25,10 @@ import { buildWinstonOptions } from './common/logger/winston.config';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (config: ConfigService) =>
-        buildWinstonOptions(config.get<string>('NODE_ENV', 'development')),
+        buildWinstonOptions(
+          config.get<string>('NODE_ENV', 'development'),
+          config.get<string>('LOG_DIR', 'logs'),
+        ),
     }),
     ThrottlerModule.forRootAsync({
       imports: [ConfigModule],

--- a/Backend/src/common/logger/winston.config.spec.ts
+++ b/Backend/src/common/logger/winston.config.spec.ts
@@ -1,0 +1,118 @@
+import * as winston from 'winston';
+import { buildWinstonOptions } from './winston.config';
+
+// Capture constructor args so we can assert on them without a real FS
+const mockDailyRotateInstances: Record<string, unknown>[] = [];
+
+jest.mock('winston-daily-rotate-file', () => {
+  return jest.fn().mockImplementation((opts: Record<string, unknown>) => {
+    const instance = { ...opts, _mock: 'DailyRotateFile' };
+    mockDailyRotateInstances.push(instance);
+    return instance;
+  });
+});
+
+jest.mock('./correlation-id.store', () => ({
+  getCorrelationId: () => 'test-id',
+}));
+
+describe('buildWinstonOptions', () => {
+  beforeEach(() => {
+    mockDailyRotateInstances.length = 0;
+  });
+
+  describe('development mode', () => {
+    it('returns debug log level', () => {
+      const opts = buildWinstonOptions('development');
+      expect(opts.level).toBe('debug');
+    });
+
+    it('uses a single Console transport', () => {
+      const opts = buildWinstonOptions('development');
+      expect(opts.transports).toHaveLength(1);
+      expect((opts.transports as winston.transport[])[0]).toBeInstanceOf(
+        winston.transports.Console,
+      );
+    });
+
+    it('does not create any file transports', () => {
+      buildWinstonOptions('development');
+      expect(mockDailyRotateInstances).toHaveLength(0);
+    });
+  });
+
+  describe('production mode', () => {
+    it('returns info log level', () => {
+      const opts = buildWinstonOptions('production');
+      expect(opts.level).toBe('info');
+    });
+
+    it('uses three transports: Console + 2 file transports', () => {
+      const opts = buildWinstonOptions('production');
+      expect(opts.transports).toHaveLength(3);
+      expect((opts.transports as winston.transport[])[0]).toBeInstanceOf(
+        winston.transports.Console,
+      );
+    });
+
+    it('creates a combined log file transport at info level', () => {
+      buildWinstonOptions('production');
+      const combined = mockDailyRotateInstances.find((t) =>
+        (t.filename as string).includes('combined'),
+      );
+      expect(combined).toBeDefined();
+      expect(combined!.level).toBe('info');
+    });
+
+    it('creates an error-only log file transport', () => {
+      buildWinstonOptions('production');
+      const errorFile = mockDailyRotateInstances.find((t) =>
+        (t.filename as string).includes('error'),
+      );
+      expect(errorFile).toBeDefined();
+      expect(errorFile!.level).toBe('error');
+    });
+
+    it('uses the default log directory "logs"', () => {
+      buildWinstonOptions('production');
+      for (const t of mockDailyRotateInstances) {
+        expect(t.dirname).toBe('logs');
+      }
+    });
+
+    it('respects a custom logDir', () => {
+      buildWinstonOptions('production', '/var/log/gistpin');
+      for (const t of mockDailyRotateInstances) {
+        expect(t.dirname).toBe('/var/log/gistpin');
+      }
+    });
+
+    it('enables zipped archiving', () => {
+      buildWinstonOptions('production');
+      for (const t of mockDailyRotateInstances) {
+        expect(t.zippedArchive).toBe(true);
+      }
+    });
+
+    it('caps file size at 20m', () => {
+      buildWinstonOptions('production');
+      for (const t of mockDailyRotateInstances) {
+        expect(t.maxSize).toBe('20m');
+      }
+    });
+
+    it('retains logs for 14 days', () => {
+      buildWinstonOptions('production');
+      for (const t of mockDailyRotateInstances) {
+        expect(t.maxFiles).toBe('14d');
+      }
+    });
+
+    it('uses daily date pattern', () => {
+      buildWinstonOptions('production');
+      for (const t of mockDailyRotateInstances) {
+        expect(t.datePattern).toBe('YYYY-MM-DD');
+      }
+    });
+  });
+});

--- a/Backend/src/common/logger/winston.config.ts
+++ b/Backend/src/common/logger/winston.config.ts
@@ -1,5 +1,6 @@
 import { utilities as nestWinstonUtilities, WinstonModuleOptions } from 'nest-winston';
 import * as winston from 'winston';
+import 'winston-daily-rotate-file';
 import { getCorrelationId } from './correlation-id.store';
 
 const correlationFormat = winston.format((info) => {
@@ -21,12 +22,45 @@ const prettyFormat = winston.format.combine(
   nestWinstonUtilities.format.nestLike('GistPin', { prettyPrint: true, colors: true }),
 );
 
-export function buildWinstonOptions(nodeEnv: string): WinstonModuleOptions {
+function buildFileTransports(logDir: string): winston.transport[] {
+  const sharedOptions = {
+    dirname: logDir,
+    datePattern: 'YYYY-MM-DD',
+    zippedArchive: true,
+    maxSize: '20m',
+    maxFiles: '14d',
+    format: jsonFormat,
+  };
+
+  return [
+    new winston.transports.DailyRotateFile({
+      ...sharedOptions,
+      filename: 'combined-%DATE%.log',
+      level: 'info',
+    }),
+    new winston.transports.DailyRotateFile({
+      ...sharedOptions,
+      filename: 'error-%DATE%.log',
+      level: 'error',
+    }),
+  ];
+}
+
+export function buildWinstonOptions(nodeEnv: string, logDir = 'logs'): WinstonModuleOptions {
   const isProd = nodeEnv === 'production';
+
+  const transports: winston.transport[] = [
+    new winston.transports.Console({
+      format: isProd ? jsonFormat : prettyFormat,
+    }),
+  ];
+
+  if (isProd) {
+    transports.push(...buildFileTransports(logDir));
+  }
 
   return {
     level: isProd ? 'info' : 'debug',
-    format: isProd ? jsonFormat : prettyFormat,
-    transports: [new winston.transports.Console()],
+    transports,
   };
 }

--- a/Backend/src/config/env.validation.ts
+++ b/Backend/src/config/env.validation.ts
@@ -38,4 +38,7 @@ export const envValidationSchema = Joi.object({
   // Throttling
   THROTTLE_TTL_MS: Joi.number().integer().min(0).default(60000),
   THROTTLE_LIMIT: Joi.number().integer().min(1).default(10),
+
+  // Logging
+  LOG_DIR: Joi.string().default('logs'),
 });


### PR DESCRIPTION
## Summary

Closes #93

Adds production-ready log file rotation on top of the existing Winston setup. In development nothing changes — logs remain pretty-printed to the console. In production two additional `DailyRotateFile` transports are activated alongside the existing JSON console transport.

## Changes

| File | What changed |
|---|---|
| `package.json` | Added `winston-daily-rotate-file ^5.0.0` |
| `src/common/logger/winston.config.ts` | File transports injected in production; `logDir` param added |
| `src/app.module.ts` | Passes `LOG_DIR` env var to `buildWinstonOptions` |
| `src/config/env.validation.ts` | Added `LOG_DIR` env var (default: `"logs"`) |
| `.env.example` | Documented `LOG_DIR` |
| `src/common/logger/winston.config.spec.ts` | 12 unit tests covering all rotation config |

## Log file behaviour (production only)
combined-YYYY-MM-DD.log   # info level and above, JSON
error-YYYY-MM-DD.log      # error level only, JSON

- Daily rotation with date-stamped filenames
- Max file size: **20 MB** before rotation
- Retention: **14 days**, then auto-deleted
- Older files are **gzip-compressed**
- Log directory is configurable via `LOG_DIR` env var

## Testing

- 12 unit tests in `winston.config.spec.ts` — mocks `winston-daily-rotate-file` to assert transport count, filenames, levels, and all rotation parameters
- Dev mode asserted to produce zero file transports
