### PR TITLE
feat(indexer): implement IndexerService to poll and persist Soroban events

### DIFF
--- a/Backend/src/gists/gist.repository.ts
+++ b/Backend/src/gists/gist.repository.ts
@@ -121,4 +121,12 @@ export class GistRepository {
     );
     return rows[0] ?? null;
   }
+
+  async existsByStellarGistId(stellarGistId: string): Promise<boolean> {
+    const [row] = await this.dataSource.query<Array<{ cnt: string }>>(
+      `SELECT COUNT(*) AS cnt FROM gists WHERE stellar_gist_id = $1`,
+      [stellarGistId],
+    );
+    return parseInt(row.cnt, 10) > 0;
+  }
 }

--- a/Backend/src/indexer/indexer.module.ts
+++ b/Backend/src/indexer/indexer.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { IndexerService } from './indexer.service';
 import { SorobanModule } from '../soroban/soroban.module';
+import { GeoModule } from '../geo/geo.module';
+import { GistRepository } from '../gists/gist.repository';
 
 @Module({
-  imports: [SorobanModule],
-  providers: [IndexerService],
+  imports: [SorobanModule, GeoModule],
+  providers: [IndexerService, GistRepository],
 })
 export class IndexerModule {}

--- a/Backend/src/indexer/indexer.service.spec.ts
+++ b/Backend/src/indexer/indexer.service.spec.ts
@@ -1,0 +1,168 @@
+import { Logger } from '@nestjs/common';
+import { IndexerService } from './indexer.service';
+import { SorobanService } from '../soroban/soroban.service';
+import { GistRepository } from '../gists/gist.repository';
+import { GeoService } from '../geo/geo.service';
+import { GistEvent } from '../soroban/soroban.service';
+
+function makeEvent(overrides: Partial<GistEvent> = {}): GistEvent {
+  return {
+    gistId: 'gist-1',
+    locationCell: 'u4pruyd',
+    contentHash: 'QmAbc123',
+    author: 'GABCD',
+    ledger: 100,
+    createdAt: 1700000000,
+    ...overrides,
+  };
+}
+
+describe('IndexerService', () => {
+  let service: IndexerService;
+  let soroban: jest.Mocked<SorobanService>;
+  let gistRepo: jest.Mocked<GistRepository>;
+  let geoService: jest.Mocked<GeoService>;
+  let logSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    soroban = {
+      getEventsSince: jest.fn(),
+    } as unknown as jest.Mocked<SorobanService>;
+
+    gistRepo = {
+      existsByStellarGistId: jest.fn(),
+      create: jest.fn(),
+    } as unknown as jest.Mocked<GistRepository>;
+
+    geoService = {
+      decode: jest.fn().mockReturnValue({ lat: 48.85, lon: 2.35 }),
+    } as unknown as jest.Mocked<GeoService>;
+
+    service = new IndexerService(soroban, gistRepo, geoService);
+
+    logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+    errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('poll()', () => {
+    it('does nothing when no events are returned', async () => {
+      soroban.getEventsSince.mockResolvedValue([]);
+      await service.poll();
+      expect(gistRepo.existsByStellarGistId).not.toHaveBeenCalled();
+      expect(gistRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('persists a new event to the DB', async () => {
+      soroban.getEventsSince.mockResolvedValue([makeEvent()]);
+      gistRepo.existsByStellarGistId.mockResolvedValue(false);
+      gistRepo.create.mockResolvedValue({} as never);
+
+      await service.poll();
+
+      expect(gistRepo.create).toHaveBeenCalledWith({
+        content: '',
+        lat: 48.85,
+        lon: 2.35,
+        location_cell: 'u4pruyd',
+        content_hash: 'QmAbc123',
+        stellar_gist_id: 'gist-1',
+        tx_hash: null,
+      });
+    });
+
+    it('decodes the locationCell via GeoService', async () => {
+      soroban.getEventsSince.mockResolvedValue([makeEvent({ locationCell: 'u4pruyd' })]);
+      gistRepo.existsByStellarGistId.mockResolvedValue(false);
+      gistRepo.create.mockResolvedValue({} as never);
+
+      await service.poll();
+
+      expect(geoService.decode).toHaveBeenCalledWith('u4pruyd');
+    });
+
+    it('skips an event that is already indexed', async () => {
+      soroban.getEventsSince.mockResolvedValue([makeEvent()]);
+      gistRepo.existsByStellarGistId.mockResolvedValue(true);
+
+      await service.poll();
+
+      expect(gistRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('advances lastProcessedLedger to the highest event ledger', async () => {
+      const events = [
+        makeEvent({ gistId: 'g1', ledger: 200 }),
+        makeEvent({ gistId: 'g2', ledger: 350 }),
+        makeEvent({ gistId: 'g3', ledger: 275 }),
+      ];
+      soroban.getEventsSince.mockResolvedValue(events);
+      gistRepo.existsByStellarGistId.mockResolvedValue(false);
+      gistRepo.create.mockResolvedValue({} as never);
+
+      await service.poll();
+      // A second poll should query from ledger 350
+      soroban.getEventsSince.mockResolvedValue([]);
+      await service.poll();
+
+      expect(soroban.getEventsSince).toHaveBeenNthCalledWith(2, 350);
+    });
+
+    it('also advances lastProcessedLedger for already-indexed events', async () => {
+      soroban.getEventsSince.mockResolvedValue([makeEvent({ ledger: 500 })]);
+      gistRepo.existsByStellarGistId.mockResolvedValue(true);
+
+      await service.poll();
+      soroban.getEventsSince.mockResolvedValue([]);
+      await service.poll();
+
+      expect(soroban.getEventsSince).toHaveBeenNthCalledWith(2, 500);
+    });
+
+    it('logs the number of events fetched', async () => {
+      soroban.getEventsSince.mockResolvedValue([makeEvent(), makeEvent({ gistId: 'g2' })]);
+      gistRepo.existsByStellarGistId.mockResolvedValue(false);
+      gistRepo.create.mockResolvedValue({} as never);
+
+      await service.poll();
+
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('2 new event(s)'));
+    });
+
+    it('logs an error and does not throw when soroban fails', async () => {
+      soroban.getEventsSince.mockRejectedValue(new Error('RPC timeout'));
+
+      await expect(service.poll()).resolves.toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Indexer poll failed',
+        'RPC timeout',
+        expect.anything(),
+      );
+    });
+
+    it('logs an error and does not throw when DB write fails', async () => {
+      soroban.getEventsSince.mockResolvedValue([makeEvent()]);
+      gistRepo.existsByStellarGistId.mockResolvedValue(false);
+      gistRepo.create.mockRejectedValue(new Error('DB down'));
+
+      await expect(service.poll()).resolves.toBeUndefined();
+      expect(errorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('onModuleDestroy()', () => {
+    it('clears the poll interval', () => {
+      const clearSpy = jest.spyOn(global, 'clearInterval');
+      service.startPolling(99999);
+      service.onModuleDestroy();
+      expect(clearSpy).toHaveBeenCalled();
+    });
+
+    it('does not throw when called before startPolling', () => {
+      expect(() => service.onModuleDestroy()).not.toThrow();
+    });
+  });
+});

--- a/Backend/src/indexer/indexer.service.ts
+++ b/Backend/src/indexer/indexer.service.ts
@@ -1,46 +1,69 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { SorobanService } from '../soroban/soroban.service';
+import { GistRepository } from '../gists/gist.repository';
+import { GeoService } from '../geo/geo.service';
 
 @Injectable()
-export class IndexerService implements OnModuleInit {
+export class IndexerService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(IndexerService.name);
   private lastProcessedLedger = 0;
   private pollInterval: NodeJS.Timeout | null = null;
 
-  constructor(private readonly soroban: SorobanService) {}
+  constructor(
+    private readonly soroban: SorobanService,
+    private readonly gistRepository: GistRepository,
+    private readonly geoService: GeoService,
+  ) {}
 
-  onModuleInit() {
-    this.logger.log('Indexer starting — polling Soroban for GistRegistry events');
+  onModuleInit(): void {
+    this.logger.log('Indexer starting — polling Soroban for GistRegistry events every 10s');
     this.startPolling();
   }
 
-  private startPolling(intervalMs = 6_000) {
+  startPolling(intervalMs = 10_000): void {
     this.pollInterval = setInterval(() => {
       void this.poll();
     }, intervalMs);
   }
 
-  private async poll() {
+  async poll(): Promise<void> {
     try {
       const events = await this.soroban.getEventsSince(this.lastProcessedLedger);
 
       if (events.length === 0) return;
 
-      this.logger.log(
-        `Indexer: ${events.length} new event(s) from ledger ${this.lastProcessedLedger}`,
-      );
+      this.logger.log(`Indexer: ${events.length} new event(s) from ledger ${this.lastProcessedLedger}`);
 
       for (const event of events) {
-        // TODO: upsert each event into the gists table via GistsService / TypeORM
-        this.logger.debug(`Indexed gist ${event.gistId} @ cell ${event.locationCell}`);
-        this.lastProcessedLedger = Math.max(this.lastProcessedLedger, event.createdAt);
+        const alreadyIndexed = await this.gistRepository.existsByStellarGistId(event.gistId);
+
+        if (alreadyIndexed) {
+          this.lastProcessedLedger = Math.max(this.lastProcessedLedger, event.ledger);
+          continue;
+        }
+
+        const { lat, lon } = this.geoService.decode(event.locationCell);
+
+        await this.gistRepository.create({
+          content: '',
+          lat,
+          lon,
+          location_cell: event.locationCell,
+          content_hash: event.contentHash,
+          stellar_gist_id: event.gistId,
+          tx_hash: null,
+        });
+
+        this.logger.debug(`Indexed gist ${event.gistId} @ cell ${event.locationCell} (ledger ${event.ledger})`);
+
+        this.lastProcessedLedger = Math.max(this.lastProcessedLedger, event.ledger);
       }
     } catch (err) {
-      this.logger.error('Indexer poll failed', err);
+      this.logger.error('Indexer poll failed', (err as Error).message, (err as Error).stack);
     }
   }
 
-  onModuleDestroy() {
+  onModuleDestroy(): void {
     if (this.pollInterval) clearInterval(this.pollInterval);
   }
 }


### PR DESCRIPTION
## Summary

Closes #94

Implements a production-ready `IndexerService` that polls the Soroban contract for on-chain `GistRegistry` events every 10 seconds and persists new gists to the database — completing the background sync pipeline between the blockchain and the API.

---

## Changes

### `src/indexer/indexer.service.ts` — Core implementation
- Injects `GistRepository` and `GeoService` alongside the existing `SorobanService`
- Polls `SorobanService.getEventsSince(lastLedger)` on a **10-second interval**
- For each event:
  1. Checks `GistRepository.existsByStellarGistId()` — skips duplicates (idempotent across restarts)
  2. Decodes `locationCell` (geohash) → `{ lat, lon }` via `GeoService.decode()`
  3. Persists via `GistRepository.create()` with chain-sourced fields (`location_cell`, `content_hash`, `stellar_gist_id`)
  4. Advances `lastProcessedLedger` to the highest seen ledger
- Errors in a single poll cycle are caught and logged — **the poller never crashes**
- Implements both `OnModuleInit` and `OnModuleDestroy` for clean lifecycle management

### `src/indexer/indexer.module.ts` — Dependency wiring
- Added `GeoModule` import and `GistRepository` provider so the injector can resolve all dependencies

### `src/gists/gist.repository.ts` — Deduplication query
- Added `existsByStellarGistId(stellarGistId)` — a lightweight `COUNT` query used by the indexer to skip already-persisted events

### `src/indexer/indexer.service.spec.ts` — Unit tests (11 cases)
- No events → no DB writes
- New event → decoded and persisted with correct fields
- `GeoService.decode()` called with the event's `locationCell`
- Duplicate event → skipped, no `create()` call
- `lastProcessedLedger` advances to the max ledger across a batch (including duplicates)
- Soroban RPC error → logged, poll resolves without throwing
- DB write error → logged, poll resolves without throwing
- `onModuleDestroy()` clears the interval
- `onModuleDestroy()` is safe to call before `startPolling()`

---

## Design decisions

| Decision | Rationale |
|---|---|
| Deduplication via `existsByStellarGistId` | Avoids a migration to add a unique constraint while keeping the indexer idempotent on restart |
| `content: ''` placeholder | Chain events carry a CID, not raw content. Storing empty string keeps the column non-null; content hydration from IPFS is a follow-up concern |
| `tx_hash: null` | `GistEvent` does not expose a transaction hash — field left null until RPC integration exposes it |
| Error isolation per poll cycle | A single failed poll should not stop the indexer — errors are logged and the timer continues |

## Test plan

- [ ] `npm test -- --testPathPattern=indexer` — all 11 unit tests pass
- [ ] Start app with `CONTRACT_ID_GIST_REGISTRY` unset → mock mode, indexer logs empty polls every 10s without errors
- [ ] Confirm `onModuleDestroy` clears the interval on graceful shutdown