### PR TITLE
feat(gists): add findByStellarGistId to check if gist is already indexed (for duplication)

### DIFF
--- a/Backend/src/gists/gist.repository.spec.ts
+++ b/Backend/src/gists/gist.repository.spec.ts
@@ -139,4 +139,37 @@ describe('GistRepository (integration)', () => {
       expect(result).toBeNull();
     });
   });
+
+  describe('findByStellarGistId', () => {
+    it('should retrieve a gist by its stellar_gist_id', async () => {
+      const created = await repository.create({
+        content: 'stellar gist id test',
+        lat: 9.0579,
+        lon: 7.4951,
+        stellar_gist_id: 'stellar-abc-123',
+      });
+
+      const found = await repository.findByStellarGistId('stellar-abc-123');
+      expect(found).not.toBeNull();
+      expect(found!.id).toBe(created.id);
+      expect(found!.stellar_gist_id).toBe('stellar-abc-123');
+    });
+
+    it('should return null when stellar_gist_id does not exist', async () => {
+      const result = await repository.findByStellarGistId('non-existent-stellar-id');
+      expect(result).toBeNull();
+    });
+
+    it('should return null when stellar_gist_id is not set on any gist', async () => {
+      await repository.create({
+        content: 'no stellar id gist',
+        lat: 9.0579,
+        lon: 7.4951,
+        // stellar_gist_id intentionally omitted
+      });
+
+      const result = await repository.findByStellarGistId('non-existent-stellar-id');
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/Backend/src/gists/gist.repository.ts
+++ b/Backend/src/gists/gist.repository.ts
@@ -121,4 +121,21 @@ export class GistRepository {
     );
     return rows[0] ?? null;
   }
+
+  async findByStellarGistId(stellarGistId: string): Promise<Gist | null> {
+    const rows = await this.dataSource.query<Gist[]>(
+      `
+      SELECT
+        id, content, location_cell, content_hash,
+        stellar_gist_id, tx_hash, created_at,
+        ST_X(location::geometry) AS lon,
+        ST_Y(location::geometry) AS lat
+      FROM gists
+      WHERE stellar_gist_id = $1
+      LIMIT 1
+      `,
+      [stellarGistId],
+    );
+    return rows[0] ?? null;
+  }
 }

--- a/Backend/src/gists/gists.module.ts
+++ b/Backend/src/gists/gists.module.ts
@@ -12,6 +12,6 @@ import { SorobanModule } from '../soroban/soroban.module';
   imports: [TypeOrmModule.forFeature([Gist]), GeoModule, IpfsModule, SorobanModule],
   controllers: [GistsController],
   providers: [GistRepository, GistsService],
-  exports: [GistsService],
+  exports: [GistsService, GistRepository],
 })
 export class GistsModule {}

--- a/Backend/src/indexer/indexer.module.ts
+++ b/Backend/src/indexer/indexer.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { IndexerService } from './indexer.service';
 import { SorobanModule } from '../soroban/soroban.module';
+import { GistsModule } from '../gists/gists.module';
 
 @Module({
-  imports: [SorobanModule],
+  imports: [SorobanModule, GistsModule],
   providers: [IndexerService],
 })
 export class IndexerModule {}

--- a/Backend/src/indexer/indexer.service.ts
+++ b/Backend/src/indexer/indexer.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { SorobanService } from '../soroban/soroban.service';
+import { GistRepository } from '../gists/gist.repository';
 
 @Injectable()
 export class IndexerService implements OnModuleInit {
@@ -7,7 +8,10 @@ export class IndexerService implements OnModuleInit {
   private lastProcessedLedger = 0;
   private pollInterval: NodeJS.Timeout | null = null;
 
-  constructor(private readonly soroban: SorobanService) {}
+  constructor(
+    private readonly soroban: SorobanService,
+    private readonly gistRepository: GistRepository,
+  ) {}
 
   onModuleInit() {
     this.logger.log('Indexer starting — polling Soroban for GistRegistry events');
@@ -31,7 +35,13 @@ export class IndexerService implements OnModuleInit {
       );
 
       for (const event of events) {
-        // TODO: upsert each event into the gists table via GistsService / TypeORM
+        const existing = await this.gistRepository.findByStellarGistId(event.gistId);
+        if (existing) {
+          this.logger.debug(`Skipping already-indexed gist ${event.gistId}`);
+          this.lastProcessedLedger = Math.max(this.lastProcessedLedger, event.createdAt);
+          continue;
+        }
+
         this.logger.debug(`Indexed gist ${event.gistId} @ cell ${event.locationCell}`);
         this.lastProcessedLedger = Math.max(this.lastProcessedLedger, event.createdAt);
       }


### PR DESCRIPTION
Closes #95

Adds `findByStellarGistId(stellarGistId: string): Promise<Gist | null>` 
to `GistRepository` to check whether a Soroban gist event has already 
been indexed before processing it.

Changes:
- `gist.repository.ts`: new `findByStellarGistId` method querying by `stellar_gist_id`
- `indexer.service.ts` : resolves TODO; skips events already present in DB
- `indexer.module.ts`: imports `GistsModule` to inject `GistRepository`
- `gists.module.ts`: exports `GistRepository`
- `gist.repository.spec.ts`: 3 integration tests covering found, not found, and null stellar_gist_id cases