### PR TITLE
fix: add GET /gists/:id endpoint with UUID validation and 404 handling

### DIFF
--- a/Backend/src/gists/gist.repository.ts
+++ b/Backend/src/gists/gist.repository.ts
@@ -137,6 +137,8 @@ export class GistRepository {
       [stellarGistId],
     );
     return rows[0] ?? null;
+  }
+
   async existsByStellarGistId(stellarGistId: string): Promise<boolean> {
     const [row] = await this.dataSource.query<Array<{ cnt: string }>>(
       `SELECT COUNT(*) AS cnt FROM gists WHERE stellar_gist_id = $1`,

--- a/Backend/src/gists/gists.controller.ts
+++ b/Backend/src/gists/gists.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Post, Body, Param, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Query,
+  ParseUUIDPipe,
+} from '@nestjs/common';
 import { Throttle, SkipThrottle } from '@nestjs/throttler';
 import { ApiOperation, ApiTags, ApiParam } from '@nestjs/swagger';
 import { GistsService } from './gists.service';
@@ -28,7 +36,7 @@ export class GistsController {
   @SkipThrottle()
   @ApiOperation({ summary: 'Get a single gist by ID' })
   @ApiParam({ name: 'id', description: 'Gist UUID' })
-  findOne(@Param('id') id: string) {
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
     return this.gistsService.findOne(id);
   }
 }

--- a/Backend/src/gists/gists.service.spec.ts
+++ b/Backend/src/gists/gists.service.spec.ts
@@ -1,0 +1,69 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { GistsService } from './gists.service';
+import { GistRepository } from './gist.repository';
+import { GeoService } from '../geo/geo.service';
+import { IpfsService } from '../ipfs/ipfs.service';
+import { SorobanService } from '../soroban/soroban.service';
+import { Gist } from './entities/gist.entity';
+
+describe('GistsService', () => {
+  let service: GistsService;
+  let gistRepository: jest.Mocked<GistRepository>;
+
+  const fakeGist: Gist = {
+    id: '11111111-1111-4111-8111-111111111111',
+    content: 'hello world',
+    location_cell: 's1t7d8c',
+    content_hash: 'mock_cid',
+    stellar_gist_id: 'stellar-abc-123',
+    tx_hash: 'mock_tx',
+    location: null,
+    created_at: new Date('2026-01-01T00:00:00Z'),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GistsService,
+        {
+          provide: GistRepository,
+          useValue: {
+            findByGistId: jest.fn(),
+            create: jest.fn(),
+            findNearby: jest.fn(),
+          },
+        },
+        // `findOne` does not touch these dependencies, but the constructor
+        // requires them. Use minimal stubs to satisfy DI.
+        { provide: GeoService, useValue: {} },
+        { provide: IpfsService, useValue: {} },
+        { provide: SorobanService, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<GistsService>(GistsService);
+    gistRepository = module.get(GistRepository);
+  });
+
+  describe('findOne', () => {
+    // Issue 96 — return 404 when no gist matches the UUID
+    it('should return the gist when the repository finds it', async () => {
+      gistRepository.findByGistId.mockResolvedValue(fakeGist);
+
+      await expect(service.findOne(fakeGist.id)).resolves.toEqual(fakeGist);
+      expect(gistRepository.findByGistId).toHaveBeenCalledWith(fakeGist.id);
+    });
+
+    it('should throw NotFoundException when the repository returns null', async () => {
+      const id = '00000000-0000-0000-0000-000000000000';
+      gistRepository.findByGistId.mockResolvedValue(null);
+
+      await expect(service.findOne(id)).rejects.toBeInstanceOf(NotFoundException);
+      await expect(service.findOne(id)).rejects.toThrow(
+        `Gist with ID ${id} not found`,
+      );
+      expect(gistRepository.findByGistId).toHaveBeenCalledWith(id);
+    });
+  });
+});

--- a/Backend/src/gists/gists.service.ts
+++ b/Backend/src/gists/gists.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { CreateGistDto } from './dto/create-gist.dto';
 import { QueryGistsDto } from './dto/query-gists.dto';
 import { GistRepository } from './gist.repository';
@@ -59,7 +59,12 @@ export class GistsService {
     });
   }
 
-  async findOne(id: string): Promise<Gist | null> {
-    return this.gistRepository.findByGistId(id);
+  async findOne(id: string): Promise<Gist> {
+    // Issue 96 — return 404 when no gist matches the UUID
+    const gist = await this.gistRepository.findByGistId(id);
+    if (!gist) {
+      throw new NotFoundException(`Gist with ID ${id} not found`);
+    }
+    return gist;
   }
 }

--- a/Backend/test/gists.e2e.spec.ts
+++ b/Backend/test/gists.e2e.spec.ts
@@ -112,6 +112,59 @@ describe('Gists (e2e)', () => {
 
       expect(res.body.data.length).toBeLessThanOrEqual(2);
     });
+  });  describe('GET /gists/:id', () => {
+    it('should return the gist when it exists', async () => {
+      const created = await request(app.getHttpServer())
+        .post('/gists')
+        .send({ content: 'find me by id', lat: 9.0579, lon: 7.4951 })
+        .expect(201);
+
+      const res = await request(app.getHttpServer())
+        .get(`/gists/${created.body.id}`)
+        .expect(200);
+
+      expect(res.body).toMatchObject({
+        id: created.body.id,
+        content: 'find me by id',
+        location_cell: expect.any(String),
+        content_hash: expect.any(String),
+        stellar_gist_id: expect.any(String),
+        tx_hash: expect.any(String),
+        lat: 9.0579,
+        lon: 7.4951,
+      });
+      expect(res.body.created_at).toEqual(expect.any(String));
+    });
+
+    it('should return 404 when no gist matches the UUID', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/gists/00000000-0000-0000-0000-000000000000')
+        .expect(404);
+
+      expect(res.body.statusCode).toBe(404);
+      expect(res.body.message).toEqual(expect.stringContaining('not found'));
+    });
+
+    it('should return 400 when id is not a valid UUID', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/gists/not-a-uuid')
+        .expect(400);
+
+      expect(res.body.statusCode).toBe(400);
+    });
+
+    it('should return 400 when id contains dangerous characters', async () => {
+      // Raw SQL would reject this anyway, but ParseUUIDPipe catches it first.
+      const res = await request(app.getHttpServer())
+        .get("/gists/'; DROP TABLE gists; --")
+        .expect(400);
+
+      expect(res.body.statusCode).toBe(400);
+      // Confirm the failure came from UUID validation rather than URL parsing
+      expect(res.body.message).toEqual(
+        expect.arrayContaining([expect.stringMatching(/UUID|validation/i)]),
+      );
+    });
   });
 
   describe('GET /health', () => {
@@ -123,4 +176,5 @@ describe('Gists (e2e)', () => {
       expect(res.body.services.postgis.status).toBe('ok');
     });
   });
+
 });


### PR DESCRIPTION
## Summary

Closes #96

Implements the missing behaviors for `GET /gists/:id`:

- Validate the `:id` path param as a UUID with `ParseUUIDPipe` so malformed input returns 400 instead of falling through to the database.
- Return **404 Not Found** when no gist matches the UUID, by throwing `NotFoundException` from `GistsService.findOne` instead of returning `null` to the client.

## Changes

- `Backend/src/gists/gists.controller.ts` — add `ParseUUIDPipe` on `@Param(id)` so the `:id` route only accepts valid UUIDs.
- `Backend/src/gists/gists.service.ts` — `findOne` now throws `NotFoundException` when the repository returns `null`. Signature tightened from `Promise<Gist | null>` to `Promise<Gist>`.
- `Backend/src/gists/gist.repository.ts` — fix a real compilation error (missing closing brace between `findByStellarGistId` and `existsByStellarGistId`) that was preventing the file from compiling on `main`. This is bundled because `nest build` cannot succeed without it.
- `Backend/src/gists/gists.service.spec.ts` *(new)* — focused unit test for `GistsService.findOne` covering both the happy path and the new `NotFoundException` behavior, using a mocked `GistRepository`.
- `Backend/test/gists.e2e.spec.ts` — add a `GET /gists/:id` describe block with 4 cases:
  - 200 on a freshly created gist
  - 404 on an unknown UUID (asserts body message contains "not found")
  - 400 on `not-a-uuid`
  - 400 on a SQL-injection-style input (asserts message matches `/UUID|validation/i` to prove the failure comes from `ParseUUIDPipe`)

## Testing

- New unit tests in `Backend/src/gists/gists.service.spec.ts` mock the repository and verify both success and NotFoundException paths.
- New e2e tests in `Backend/test/gists.e2e.spec.ts` exercise the route via supertest against the running app. These require the dev compose stack (Postgres + PostGIS) and run via `npm run test:e2e`.

Closes #96