### PR TITLE
fix: add authorAddress filter for gist queries

### DIFF
--- a/Backend/src/database/migrations/AddAuthorAddressColumn1750000000001.ts
+++ b/Backend/src/database/migrations/AddAuthorAddressColumn1750000000001.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAuthorAddressColumn1750000000001 implements MigrationInterface {
+  name = 'AddAuthorAddressColumn1750000000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "gists"
+        ADD COLUMN IF NOT EXISTS "author_address" VARCHAR(80)
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_gists_author_address"
+        ON "gists" ("author_address")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_gists_author_address"`);
+    await queryRunner.query(`ALTER TABLE "gists" DROP COLUMN IF EXISTS "author_address"`);
+  }
+}

--- a/Backend/src/gists/dto/query-gists.dto.ts
+++ b/Backend/src/gists/dto/query-gists.dto.ts
@@ -40,4 +40,14 @@ export class QueryGistsDto {
   @IsOptional()
   @IsString()
   cursor?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Filter by Stellar address of the author. Case-sensitive exact match against `author_address`.',
+    example: 'GABC...XYZ',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(80)
+  authorAddress?: string;
 }

--- a/Backend/src/gists/entities/gist.entity.ts
+++ b/Backend/src/gists/entities/gist.entity.ts
@@ -2,6 +2,7 @@ import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, Index } from 
 
 @Entity('gists')
 @Index('idx_gists_location_cell')
+@Index('idx_gists_author_address')
 export class Gist {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -20,6 +21,9 @@ export class Gist {
 
   @Column({ type: 'varchar', length: 80, nullable: true })
   tx_hash: string | null;
+
+  @Column({ type: 'varchar', length: 80, nullable: true })
+  author_address: string | null;
 
   /**
    * PostGIS geography(Point, 4326) column.

--- a/Backend/src/gists/gist.repository.spec.ts
+++ b/Backend/src/gists/gist.repository.spec.ts
@@ -5,7 +5,12 @@ import { GistRepository } from './gist.repository';
 import { Gist } from './entities/gist.entity';
 import { DatabaseModule } from '../database/database.module';
 
-type GistWithCoords = Gist & { lat: number; lon: number; distance_meters?: number };
+type GistWithCoords = Gist & {
+  lat: number;
+  lon: number;
+  distance_meters?: number;
+  author_address?: string | null;
+};
 
 describe('GistRepository (integration)', () => {
   let repository: GistRepository;
@@ -170,6 +175,162 @@ describe('GistRepository (integration)', () => {
 
       const result = await repository.findByStellarGistId('non-existent-stellar-id');
       expect(result).toBeNull();
+    });
+  });
+
+  describe('author_address persistence and filter', () => {
+    it('should persist author_address on create', async () => {
+      const gist = await repository.create({
+        content: 'authored gist',
+        lat: 9.0579,
+        lon: 7.4951,
+        author_address: 'GABC123',
+      });
+
+      expect(gist.author_address).toBe('GABC123');
+    });
+
+    it('should default author_address to null when not provided', async () => {
+      const gist = await repository.create({
+        content: 'anonymous gist',
+        lat: 9.0579,
+        lon: 7.4951,
+      });
+
+      expect(gist.author_address).toBeNull();
+    });
+
+    it('should filter by authorAddress and return only matching gists', async () => {
+      await repository.create({
+        content: 'alice nearby',
+        lat: 9.058,
+        lon: 7.495,
+        location_cell: 's1t7d8c',
+        author_address: 'GALICE',
+      });
+      await repository.create({
+        content: 'bob nearby',
+        lat: 9.058,
+        lon: 7.495,
+        location_cell: 's1t7d8c',
+        author_address: 'GBOB',
+      });
+
+      const result = await repository.findNearby({
+        lat: 9.0579,
+        lon: 7.4951,
+        radiusMeters: 500,
+        limit: 50,
+        authorAddress: 'GALICE',
+      });
+
+      expect(result.data.length).toBeGreaterThan(0);
+      for (const gist of result.data as GistWithCoords[]) {
+        expect(gist.author_address).toBe('GALICE');
+      }
+      // Bob's gist must never be returned when filtering by GALICE.
+      const bobMarker = 'bob-filter-author-marker';
+      for (const gist of result.data as GistWithCoords[]) {
+        expect(gist.content).not.toBe(bobMarker);
+      }
+    });
+
+    it('should return empty result when authorAddress matches no gists in radius', async () => {
+      await repository.create({
+        content: 'far-away alice',
+        lat: 9.058,
+        lon: 7.495,
+        location_cell: 's1t7d8c',
+        author_address: 'GALICE_FAR',
+      });
+
+      const result = await repository.findNearby({
+        lat: 51.5074, // London
+        lon: -0.1278,
+        radiusMeters: 100,
+        limit: 50,
+        authorAddress: 'GALICE_FAR',
+      });
+
+      expect(result.data).toHaveLength(0);
+      expect(result.pagination.hasMore).toBe(false);
+    });
+
+    it('should combine authorAddress filter with cursor pagination', async () => {
+      await repository.create({
+        content: 'paged alice 1',
+        lat: 9.058,
+        lon: 7.495,
+        location_cell: 's1t7d8c',
+        author_address: 'GALICE_PAGED',
+      });
+      await repository.create({
+        content: 'paged alice 2',
+        lat: 9.058,
+        lon: 7.495,
+        location_cell: 's1t7d8c',
+        author_address: 'GALICE_PAGED',
+      });
+      await repository.create({
+        content: 'paged alice 3',
+        lat: 9.058,
+        lon: 7.495,
+        location_cell: 's1t7d8c',
+        author_address: 'GALICE_PAGED',
+      });
+
+      const page1 = await repository.findNearby({
+        lat: 9.0579,
+        lon: 7.4951,
+        radiusMeters: 5000,
+        limit: 1,
+        authorAddress: 'GALICE_PAGED',
+      });
+
+      expect(page1.data.length).toBeLessThanOrEqual(1);
+      for (const gist of page1.data as GistWithCoords[]) {
+        expect(gist.author_address).toBe('GALICE_PAGED');
+      }
+
+      if (page1.pagination.hasMore && page1.pagination.cursor) {
+        const page2 = await repository.findNearby({
+          lat: 9.0579,
+          lon: 7.4951,
+          radiusMeters: 5000,
+          limit: 1,
+          authorAddress: 'GALICE_PAGED',
+          cursor: page1.pagination.cursor,
+        });
+
+        for (const gist of page2.data as GistWithCoords[]) {
+          expect(gist.author_address).toBe('GALICE_PAGED');
+        }
+
+        if (page1.data[0] && page2.data[0]) {
+          expect(page2.data[0].id).not.toBe(page1.data[0].id);
+        }
+      }
+    });
+
+    it('should not regress: omitting authorAddress still returns all gists in radius', async () => {
+      await repository.create({
+        content: 'unauthored regression check',
+        lat: 9.058,
+        lon: 7.495,
+        location_cell: 's1t7d8c',
+      });
+
+      const result = await repository.findNearby({
+        lat: 9.0579,
+        lon: 7.4951,
+        radiusMeters: 500,
+        limit: 50,
+      });
+
+      expect(result.data.length).toBeGreaterThan(0);
+      // Should include both authored and anonymous gists
+      const hasNullAuthor = result.data.some((g) => (g as GistWithCoords).author_address === null);
+      expect(hasNullAuthor).toBe(true);
     });
   });
 });

--- a/Backend/src/gists/gist.repository.ts
+++ b/Backend/src/gists/gist.repository.ts
@@ -10,6 +10,7 @@ export interface NearbyQuery {
   radiusMeters?: number;
   limit?: number;
   cursor?: string; // base64 encoded cursor or raw ISO date string
+  authorAddress?: string;
 }
 
 export interface CreateGistData {
@@ -20,6 +21,7 @@ export interface CreateGistData {
   content_hash?: string;
   stellar_gist_id?: string;
   tx_hash?: string;
+  author_address?: string;
 }
 
 @Injectable()
@@ -35,43 +37,52 @@ export class GistRepository {
       content_hash = null,
       stellar_gist_id = null,
       tx_hash = null,
+      author_address = null,
     } = data;
 
     const result = await this.dataSource.query<Gist[]>(
       `
       INSERT INTO gists (
         content, location, location_cell,
-        content_hash, stellar_gist_id, tx_hash
+        content_hash, stellar_gist_id, tx_hash, author_address
       )
       VALUES (
         $1,
         ST_SetSRID(ST_MakePoint($2, $3), 4326)::geography,
-        $4, $5, $6, $7
+        $4, $5, $6, $7, $8
       )
       RETURNING
         id, content, location_cell, content_hash,
-        stellar_gist_id, tx_hash, created_at,
+        stellar_gist_id, tx_hash, author_address, created_at,
         ST_X(location::geometry) AS lon,
         ST_Y(location::geometry) AS lat
       `,
-      [content, lon, lat, location_cell, content_hash, stellar_gist_id, tx_hash],
+      [content, lon, lat, location_cell, content_hash, stellar_gist_id, tx_hash, author_address],
     );
 
     return result[0];
   }
 
   async findNearby(query: NearbyQuery): Promise<PaginatedResponse<Gist>> {
-    const { lat, lon, radiusMeters = 500, limit = 20, cursor } = query;
+    const { lat, lon, radiusMeters = 500, limit = 20, cursor, authorAddress } = query;
 
     const params: unknown[] = [lon, lat, radiusMeters, limit];
-    let cursorClause = '';
+    const clauses: string[] = [];
 
     if (cursor) {
       // Support both base64 encoded cursors and raw ISO strings
       const decoded = PaginationHelper.decodeCursor(cursor) ?? cursor;
       params.push(decoded);
-      cursorClause = `AND g.created_at < $${params.length}`;
+      clauses.push(`g.created_at < $${params.length}`);
     }
+
+    if (authorAddress) {
+      // Case-sensitive exact match — Stellar addresses are encoded payloads
+      params.push(authorAddress);
+      clauses.push(`g.author_address = $${params.length}`);
+    }
+
+    const extraWhere = clauses.length > 0 ? `AND ${clauses.join(' AND ')}` : '';
 
     const items = await this.dataSource.query<Gist[]>(
       `
@@ -82,6 +93,7 @@ export class GistRepository {
         g.content_hash,
         g.stellar_gist_id,
         g.tx_hash,
+        g.author_address,
         g.created_at,
         ST_X(g.location::geometry)                              AS lon,
         ST_Y(g.location::geometry)                              AS lat,
@@ -95,7 +107,7 @@ export class GistRepository {
         ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography,
         $3
       )
-      ${cursorClause}
+      ${extraWhere}
       ORDER BY g.created_at DESC
       LIMIT $4
       `,
@@ -110,7 +122,7 @@ export class GistRepository {
       `
       SELECT
         id, content, location_cell, content_hash,
-        stellar_gist_id, tx_hash, created_at,
+        stellar_gist_id, tx_hash, author_address, created_at,
         ST_X(location::geometry) AS lon,
         ST_Y(location::geometry) AS lat
       FROM gists
@@ -127,7 +139,7 @@ export class GistRepository {
       `
       SELECT
         id, content, location_cell, content_hash,
-        stellar_gist_id, tx_hash, created_at,
+        stellar_gist_id, tx_hash, author_address, created_at,
         ST_X(location::geometry) AS lon,
         ST_Y(location::geometry) AS lat
       FROM gists
@@ -137,6 +149,8 @@ export class GistRepository {
       [stellarGistId],
     );
     return rows[0] ?? null;
+  }
+
   async existsByStellarGistId(stellarGistId: string): Promise<boolean> {
     const [row] = await this.dataSource.query<Array<{ cnt: string }>>(
       `SELECT COUNT(*) AS cnt FROM gists WHERE stellar_gist_id = $1`,

--- a/Backend/src/gists/gists.service.ts
+++ b/Backend/src/gists/gists.service.ts
@@ -46,6 +46,7 @@ export class GistsService {
       content_hash: cid,
       stellar_gist_id: gistId,
       tx_hash: txHash,
+      author_address: dto.author,
     });
   }
 
@@ -56,6 +57,7 @@ export class GistsService {
       radiusMeters: query.radius,
       limit: query.limit,
       cursor: query.cursor,
+      authorAddress: query.authorAddress,
     });
   }
 


### PR DESCRIPTION
## Summary
Adds an `authorAddress` query parameter to `GET /gists` so callers can
filter gists by the Stellar address of the author. The Stellar author
address is also persisted on gist creation and indexed for lookup.

## Changes
- Migration `AddAuthorAddressColumn1750000000001` adds nullable
  `author_address` (`VARCHAR(80)`) on `gists` plus a b-tree index
  `idx_gists_author_address`
- `CreateGistDto.author` (Stellar address) is now stored as
  `author_address` on gist creation via `GistsService.create` →
  `GistRepository.create`
- `GET /gists` accepts an optional `authorAddress` query param,
  validated with class-validator (`@IsString`, `@MaxLength(80)`,
  `@IsOptional`) and documented via Swagger `@ApiPropertyOptional`
- `GistRepository.findNearby` combines the `authorAddress` filter
  with the existing radius and cursor filters in a single
  parameterised SQL query (case-sensitive exact match against the
  indexed column)
- `author_address` is included in the SELECT shape of `findNearby`,
  `findByGistId`, and `findByStellarGistId` so callers see the new
  field consistently
- Side-fix: a missing closing brace in `gist.repository.ts` between
  `findByStellarGistId` and `existsByStellarGistId` was preventing
  the file from compiling — the one-line fix was required for this
  PR to build

## Testing
- Six new integration tests in `gist.repository.spec.ts` cover:
  - Persistence of `author_address` on create
  - Default `null` when not provided
  - Single `authorAddress` filter returns only matching rows
  - `authorAddress` + radius combination excludes out-of-radius rows
  - `authorAddress` + cursor pagination works correctly
  - No regression when `authorAddress` is omitted
- New migration is reversible via `npm run migration:revert`
- Existing repository tests untouched

Closes #97