### PR TITLE
Add transactional gist creation with idempotency (#98)

### DIFF
--- a/Backend/src/database/migrations/AddUniqueStellarGistIdConstraint1700000000002.ts
+++ b/Backend/src/database/migrations/AddUniqueStellarGistIdConstraint1700000000002.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Issue #98 — adds a UNIQUE constraint on `stellar_gist_id` so that two
+ * concurrent create requests producing the same on-chain gist ID collide
+ * at the database layer instead of producing duplicate indexer rows.
+ *
+ * Postgres treats NULLs as distinct in a UNIQUE constraint, so rows without
+ * an on-chain ID (e.g. legacy rows or pre-Soroban indexer entries) are not
+ * affected by this constraint.
+ *
+ * The migration is idempotent: wrapped in a `DO $$ ... EXCEPTION
+ * WHEN duplicate_object THEN NULL ... END $$;` block because Postgres has no
+ * `ADD CONSTRAINT IF NOT EXISTS` syntax. Safe to re-run after a partial
+ * rollback or a failed CI apply.
+ */
+export class AddUniqueStellarGistIdConstraint1700000000002 implements MigrationInterface {
+  name = 'AddUniqueStellarGistIdConstraint1700000000002';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        ALTER TABLE "gists"
+          ADD CONSTRAINT "uq_gists_stellar_gist_id" UNIQUE ("stellar_gist_id");
+      EXCEPTION
+        WHEN duplicate_object THEN NULL;
+      END $$;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        ALTER TABLE "gists"
+          DROP CONSTRAINT "uq_gists_stellar_gist_id";
+      EXCEPTION
+        WHEN undefined_object THEN NULL;
+      END $$;
+    `);
+  }
+}

--- a/Backend/src/gists/gist.repository.spec.ts
+++ b/Backend/src/gists/gist.repository.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule } from '@nestjs/config';
+import { DataSource } from 'typeorm';
 import { GistRepository } from './gist.repository';
 import { Gist } from './entities/gist.entity';
 import { DatabaseModule } from '../database/database.module';
@@ -9,6 +10,7 @@ type GistWithCoords = Gist & { lat: number; lon: number; distance_meters?: numbe
 
 describe('GistRepository (integration)', () => {
   let repository: GistRepository;
+  let dataSource: DataSource;
   let module: TestingModule;
 
   beforeAll(async () => {
@@ -22,9 +24,13 @@ describe('GistRepository (integration)', () => {
     }).compile();
 
     repository = module.get<GistRepository>(GistRepository);
+    dataSource = module.get<DataSource>(DataSource);
   });
 
   afterAll(async () => {
+    // Issue #98 — clean up sentinel rows created by the commit test so they
+    // do not accumulate across CI runs and slow down subsequent test suites.
+    await dataSource.query(`DELETE FROM gists WHERE stellar_gist_id LIKE 'tx-%'`);
     await module.close();
   });
 
@@ -170,6 +176,63 @@ describe('GistRepository (integration)', () => {
 
       const result = await repository.findByStellarGistId('non-existent-stellar-id');
       expect(result).toBeNull();
+    });
+  });
+
+  // Issue #98 — transaction rollback semantics for gist creation.
+  describe('transaction', () => {
+    it('rolls back the INSERT when the transaction body throws', async () => {
+      // Use a unique sentinel content so we can scope our assertion without
+      // depending on row counts (which would race with parallel tests).
+      const sentinel = `tx-rollback-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+      await expect(
+        dataSource.transaction(async (manager) => {
+          await repository.create(
+            {
+              content: sentinel,
+              lat: 9.0579,
+              lon: 7.4951,
+              stellar_gist_id: `tx-rollback-${Date.now()}`,
+            },
+            manager,
+          );
+          throw new Error('Simulated failure inside transaction');
+        }),
+      ).rejects.toThrow('Simulated failure inside transaction');
+
+      // The sentinel content must not be persisted after a rollback.
+      const nearby = await repository.findNearby({
+        lat: 9.0579,
+        lon: 7.4951,
+        radiusMeters: 50_000,
+        limit: 200,
+      });
+      const leaked = nearby.data.find((g) => g.content === sentinel);
+      expect(leaked).toBeUndefined();
+    });
+
+    it('commits the INSERT when the transaction body completes normally (manager arg)', async () => {
+      const sentinel = `tx-commit-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const stellarId = `tx-commit-${Date.now()}`;
+
+      const result = await dataSource.transaction(async (manager) => {
+        return repository.create(
+          {
+            content: sentinel,
+            lat: 9.0579,
+            lon: 7.4951,
+            stellar_gist_id: stellarId,
+          },
+          manager,
+        );
+      });
+
+      expect(result.content).toBe(sentinel);
+
+      const found = await repository.findByStellarGistId(stellarId);
+      expect(found).not.toBeNull();
+      expect(found!.content).toBe(sentinel);
     });
   });
 });

--- a/Backend/src/gists/gist.repository.ts
+++ b/Backend/src/gists/gist.repository.ts
@@ -1,8 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
-import { DataSource } from 'typeorm';
+import { DataSource, EntityManager } from 'typeorm';
 import { Gist } from './entities/gist.entity';
 import { PaginationHelper, PaginatedResponse } from '../common/utils/pagination.helper';
+
+/** Postgres unique-violation SQLSTATE. */
+export const PG_UNIQUE_VIOLATION = '23505';
 
 export interface NearbyQuery {
   lat: number;
@@ -26,7 +29,14 @@ export interface CreateGistData {
 export class GistRepository {
   constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
 
-  async create(data: CreateGistData): Promise<Gist> {
+  /**
+   * Persist a new gist row. When a transactional `EntityManager` is supplied
+   * (e.g. from `GistsService.create`), the INSERT joins the caller's
+   * transaction so the write can be rolled back atomically. When no manager
+   * is provided (e.g. from `IndexerService` on the connection pool), the
+   * INSERT runs in its own implicit transaction.
+   */
+  async create(data: CreateGistData, manager?: EntityManager): Promise<Gist> {
     const {
       content,
       lat,
@@ -37,7 +47,9 @@ export class GistRepository {
       tx_hash = null,
     } = data;
 
-    const result = await this.dataSource.query<Gist[]>(
+    const queryRunner = manager ?? this.dataSource;
+
+    const result = await queryRunner.query<Gist[]>(
       `
       INSERT INTO gists (
         content, location, location_cell,
@@ -137,6 +149,8 @@ export class GistRepository {
       [stellarGistId],
     );
     return rows[0] ?? null;
+  }
+
   async existsByStellarGistId(stellarGistId: string): Promise<boolean> {
     const [row] = await this.dataSource.query<Array<{ cnt: string }>>(
       `SELECT COUNT(*) AS cnt FROM gists WHERE stellar_gist_id = $1`,

--- a/Backend/src/gists/gists.service.spec.ts
+++ b/Backend/src/gists/gists.service.spec.ts
@@ -1,0 +1,158 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { GistsService } from './gists.service';
+import { GistRepository, PG_UNIQUE_VIOLATION } from './gist.repository';
+import { GeoService } from '../geo/geo.service';
+import { IpfsService } from '../ipfs/ipfs.service';
+import { SorobanService } from '../soroban/soroban.service';
+import { Gist } from './entities/gist.entity';
+
+/**
+ * Issue #98 — unit tests for transactional gist creation.
+ *
+ * These are pure unit tests: real TypeORM / Postgres is not required.
+ * We mock the dataSource.transaction() call to simulate the
+ * atomic-rollback contract and assert SQLSTATE 23505 idempotency.
+ */
+describe('GistsService', () => {
+  let service: GistsService;
+  let gistRepository: jest.Mocked<GistRepository>;
+  let transactionMock: jest.Mock;
+
+  const buildGist = (overrides: Partial<Gist> = {}): Gist => ({
+    id: '00000000-0000-0000-0000-000000000001',
+    content: 'hello',
+    location_cell: 's1t7d8c',
+    content_hash: 'mock_cid',
+    stellar_gist_id: 'gist-1',
+    tx_hash: 'mock_tx',
+    location: null,
+    created_at: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  });
+
+  const buildDto = () => ({
+    content: '<b>hello</b>',
+    lat: 9.0579,
+    lon: 7.4951,
+    author: 'GAUTH',
+  });
+
+  beforeEach(async () => {
+    transactionMock = jest.fn(async (cb: (manager: unknown) => unknown) => cb({}));
+
+    const gistRepo = {
+      create: jest.fn(),
+      findByGistId: jest.fn(),
+      findByStellarGistId: jest.fn(),
+      existsByStellarGistId: jest.fn(),
+      findNearby: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GistsService,
+        { provide: DataSource, useValue: { transaction: transactionMock } },
+        { provide: GistRepository, useValue: gistRepo },
+        {
+          provide: GeoService,
+          useValue: { encode: jest.fn().mockReturnValue('s1t7d8c') },
+        },
+        {
+          provide: IpfsService,
+          useValue: { pinJson: jest.fn().mockResolvedValue({ cid: 'mock_cid', mock: true }) },
+        },
+        {
+          provide: SorobanService,
+          useValue: {
+            postGist: jest.fn().mockResolvedValue({
+              gistId: 'gist-1',
+              txHash: 'mock_tx',
+              mock: true,
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(GistsService);
+    gistRepository = module.get(GistRepository) as jest.Mocked<GistRepository>;
+
+    // Silence noisy logger output during the test run.
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('create', () => {
+    it('sanitizes content, encodes the cell, pins IPFS, posts Soroban, and inserts in a transaction', async () => {
+      const created = buildGist();
+      gistRepository.create.mockResolvedValue(created);
+
+      const result = await service.create(buildDto());
+
+      // Wrapped in a TypeORM-style dataSource.transaction() boundary
+      expect(transactionMock).toHaveBeenCalledTimes(1);
+      expect(gistRepository.create).toHaveBeenCalledTimes(1);
+      const writeArgs = gistRepository.create.mock.calls[0];
+      expect(writeArgs[0]).toMatchObject({
+        content: 'hello',
+        lat: 9.0579,
+        lon: 7.4951,
+        location_cell: 's1t7d8c',
+        content_hash: 'mock_cid',
+        stellar_gist_id: 'gist-1',
+        tx_hash: 'mock_tx',
+      });
+      // Second arg must be the manager handed back by the transaction callback
+      expect(writeArgs[1]).toEqual({});
+
+      expect(result).toBe(created);
+    });
+
+    it('returns the existing gist when the INSERT collides on stellar_gist_id (SQLSTATE 23505)', async () => {
+      const existing = buildGist({ id: 'existing-uuid', stellar_gist_id: 'gist-1' });
+      const driverError: Error & { code?: string } = new Error('duplicate key value');
+      driverError.code = PG_UNIQUE_VIOLATION;
+
+      gistRepository.create.mockRejectedValue(driverError);
+      gistRepository.findByStellarGistId.mockResolvedValue(existing);
+
+      const result = await service.create(buildDto());
+
+      expect(transactionMock).toHaveBeenCalledTimes(1);
+      expect(gistRepository.create).toHaveBeenCalledTimes(1);
+      expect(gistRepository.findByStellarGistId).toHaveBeenCalledWith('gist-1');
+      expect(result).toBe(existing);
+    });
+
+    it('throws when the INSERT fails with a non-23505 error', async () => {
+      const driverError: Error & { code?: string } = new Error('connection lost');
+      driverError.code = '08006'; // connection failure
+
+      gistRepository.create.mockRejectedValue(driverError);
+
+      await expect(service.create(buildDto())).rejects.toBe(driverError);
+
+      expect(transactionMock).toHaveBeenCalledTimes(1);
+      expect(gistRepository.findByStellarGistId).not.toHaveBeenCalled();
+    });
+
+    it('rethrows if the idempotent recovery lookup returns null', async () => {
+      const driverError: Error & { code?: string } = new Error('duplicate key value');
+      driverError.code = PG_UNIQUE_VIOLATION;
+
+      gistRepository.create.mockRejectedValue(driverError);
+      // Stranger scenario: 23505 raised but the row cannot be found afterwards
+      gistRepository.findByStellarGistId.mockResolvedValue(null);
+
+      await expect(service.create(buildDto())).rejects.toBe(driverError);
+    });
+  });
+});

--- a/Backend/src/gists/gists.service.ts
+++ b/Backend/src/gists/gists.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
 import { CreateGistDto } from './dto/create-gist.dto';
 import { QueryGistsDto } from './dto/query-gists.dto';
-import { GistRepository } from './gist.repository';
+import { GistRepository, PG_UNIQUE_VIOLATION } from './gist.repository';
 import { GeoService } from '../geo/geo.service';
 import { IpfsService } from '../ipfs/ipfs.service';
 import { SorobanService } from '../soroban/soroban.service';
@@ -14,12 +16,27 @@ export class GistsService {
   private readonly logger = new Logger(GistsService.name);
 
   constructor(
+    @InjectDataSource() private readonly dataSource: DataSource,
     private readonly gistRepository: GistRepository,
     private readonly geoService: GeoService,
     private readonly ipfsService: IpfsService,
     private readonly sorobanService: SorobanService,
   ) {}
 
+  /**
+   * Create a gist end-to-end.
+   *
+   * Issue #98 — atomicity:
+   *   - External side-effects (sanitize, geo-encode, IPFS pin, Soroban post)
+   *     happen OUTSIDE the database transaction because they cannot be
+   *     rolled back from Postgres and would just block a connection slot.
+   *   - The actual database INSERT runs inside `dataSource.transaction()` so
+   *     any error thrown during the write rolls back the row atomically and
+   *     future related writes (audit log, related tables) join the same tx.
+   *   - A duplicate `stellar_gist_id` (e.g. retried Soroban post) raises a
+   *     Postgres unique-violation (SQLSTATE 23505); we catch it and return
+   *     the existing row so the API becomes safely idempotent.
+   */
   async create(dto: CreateGistDto): Promise<Gist> {
     // Issue 87 — sanitize content before storing
     const content = stripHtml(dto.content);
@@ -38,15 +55,36 @@ export class GistsService {
 
     this.logger.log(`Gist posted → cell=${locationCell} cid=${cid} gistId=${gistId}`);
 
-    return this.gistRepository.create({
-      content,
-      lat: dto.lat,
-      lon: dto.lon,
-      location_cell: locationCell,
-      content_hash: cid,
-      stellar_gist_id: gistId,
-      tx_hash: txHash,
-    });
+    try {
+      return await this.dataSource.transaction(async (manager) => {
+        return this.gistRepository.create(
+          {
+            content,
+            lat: dto.lat,
+            lon: dto.lon,
+            location_cell: locationCell,
+            content_hash: cid,
+            stellar_gist_id: gistId,
+            tx_hash: txHash,
+          },
+          manager,
+        );
+      });
+    } catch (err) {
+      const code = (err as { code?: string })?.code;
+      if (code === PG_UNIQUE_VIOLATION) {
+        // Concurrent or retried create with the same on-chain gist ID — the
+        // winning transaction already persisted the row. Return it so the
+        // caller observes a logically idempotent success. Demoted to debug
+        // because this path is the expected happy-path outcome under retries.
+        this.logger.debug(
+          `Gist ${gistId} already indexed — returning existing row (SQLSTATE ${PG_UNIQUE_VIOLATION})`,
+        );
+        const existing = await this.gistRepository.findByStellarGistId(gistId);
+        if (existing) return existing;
+      }
+      throw err;
+    }
   }
 
   async findNearby(query: QueryGistsDto): Promise<PaginatedResponse<Gist>> {

--- a/Backend/src/indexer/indexer.module.ts
+++ b/Backend/src/indexer/indexer.module.ts
@@ -2,15 +2,10 @@ import { Module } from '@nestjs/common';
 import { IndexerService } from './indexer.service';
 import { SorobanModule } from '../soroban/soroban.module';
 import { GistsModule } from '../gists/gists.module';
-
-@Module({
-  imports: [SorobanModule, GistsModule],
-  providers: [IndexerService],
 import { GeoModule } from '../geo/geo.module';
-import { GistRepository } from '../gists/gist.repository';
 
 @Module({
-  imports: [SorobanModule, GeoModule],
-  providers: [IndexerService, GistRepository],
+  imports: [SorobanModule, GistsModule, GeoModule],
+  providers: [IndexerService],
 })
 export class IndexerModule {}

--- a/Backend/src/indexer/indexer.service.ts
+++ b/Backend/src/indexer/indexer.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { SorobanService } from '../soroban/soroban.service';
-import { GistRepository } from '../gists/gist.repository';
+import { GistRepository, PG_UNIQUE_VIOLATION } from '../gists/gist.repository';
 import { GeoService } from '../geo/geo.service';
 
 @Injectable()
@@ -32,7 +32,9 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
 
       if (events.length === 0) return;
 
-      this.logger.log(`Indexer: ${events.length} new event(s) from ledger ${this.lastProcessedLedger}`);
+      this.logger.log(
+        `Indexer: ${events.length} new event(s) from ledger ${this.lastProcessedLedger}`,
+      );
 
       for (const event of events) {
         const existing = await this.gistRepository.findByStellarGistId(event.gistId);
@@ -53,17 +55,36 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
 
         const { lat, lon } = this.geoService.decode(event.locationCell);
 
-        await this.gistRepository.create({
-          content: '',
-          lat,
-          lon,
-          location_cell: event.locationCell,
-          content_hash: event.contentHash,
-          stellar_gist_id: event.gistId,
-          tx_hash: null,
-        });
+        try {
+          await this.gistRepository.create({
+            content: '',
+            lat,
+            lon,
+            location_cell: event.locationCell,
+            content_hash: event.contentHash,
+            stellar_gist_id: event.gistId,
+            tx_hash: null,
+          });
+        } catch (err) {
+          // Issue #98 — concurrent pollers race on the same stellar_gist_id.
+          // The companion migration adds a UNIQUE(stellar_gist_id) constraint,
+          // so the loser of the race surfaces Postgres SQLSTATE 23505. Treat
+          // it as "already indexed by another writer" and advance the cursor
+          // instead of aborting the poll loop.
+          const code = (err as { code?: string })?.code;
+          if (code === PG_UNIQUE_VIOLATION) {
+            this.logger.debug(
+              `Gist ${event.gistId} already indexed (SQLSTATE ${PG_UNIQUE_VIOLATION}); advancing cursor`,
+            );
+            this.lastProcessedLedger = Math.max(this.lastProcessedLedger, event.ledger);
+            continue;
+          }
+          throw err;
+        }
 
-        this.logger.debug(`Indexed gist ${event.gistId} @ cell ${event.locationCell} (ledger ${event.ledger})`);
+        this.logger.debug(
+          `Indexed gist ${event.gistId} @ cell ${event.locationCell} (ledger ${event.ledger})`,
+        );
 
         this.lastProcessedLedger = Math.max(this.lastProcessedLedger, event.ledger);
       }


### PR DESCRIPTION
## Summary

Closes #98.

Wraps gist creation in a Postgres transaction so database-side writes commit or roll back atomically. Adds a UNIQUE constraint on stellar_gist_id and converts SQLSTATE 23505 (duplicate on-chain gist id from retries / concurrent writers) into a safely idempotent response that returns the already-indexed row. The IndexerService is hardened the same way so concurrent pollers do not crash the poll loop.

## Changes

- **DB migration** — AddUniqueStellarGistIdConstraint1700000000002: adds UNIQUE(stellar_gist_id) on gists. Wrapped in a DO 15706 … EXCEPTION WHEN duplicate_object THEN NULL … 15706 block so the migration is idempotent on re-run; down is similarly guarded. Postgres null semantics allow multiple NULLs so legacy rows without an on-chain id are unaffected.
- **GistRepository.create** — accepts an optional EntityManager, so the INSERT can join the caller's transaction (for GistsService.create) or fall back to dataSource.query (preserves backwards compatibility with IndexerService). Also exports PG_UNIQUE_VIOLATION = '23505'.
- **GistsService.create** — injects DataSource, wraps the INSERT in dataSource.transaction(). The sanity side-effects (sanitize, geohash encode, IPFS pin, Soroban post) deliberately stay outside the transaction because they cannot be rolled back from Postgres. On SQLSTATE 23505 it demotes the log to debug and returns findByStellarGistId(gistId) so retrying the same request becomes idempotent.
- **IndexerService.poll** — same SQLSTATE 23505 catch around gistRepository.create. A concurrent indexer that loses the uniqueness race now advances its ledger cursor and continues instead of aborting the poll loop.
- **Pre-existing build-blockers incidentally fixed** — gist.repository.ts was missing the closing } of findByStellarGistId and indexer.module.ts had a duplicated / malformed @Module decorator; both were shipped from the PR-#617 merge and prevented npm run build from succeeding.
- **New unit tests** — Backend/src/gists/gists.service.spec.ts using a mocked DataSource.transaction() covering: happy path; 23505 idempotent duplicate recovery; non-23505 driver-error propagation; the race-y fallback where 23505 is raised but findByStellarGistId returns null.
- **New integration tests** — Backend/src/gists/gist.repository.spec.ts adds a describe('transaction') block that proves rollback when the body throws (sentinel content assertion) and commit when the body completes normally. Uses module.get<DataSource>(DataSource); the shared afterAll cleans up tx-% sentinel rows so CI runs do not accumulate test data.

## Testing

- npm run lint — no new errors from the touched files.
- npm run build — compiles cleanly after the pre-existing structural fixes.
- npm test -- --testPathPattern='gists.service.spec' — four unit tests pass.
- npm test -- --testPathPattern='gist.repository.spec' — sixteen integration tests pass (the new transaction specs in particular).

## Notes for review

- Application order: run this PR's migration alongside #98 deployment. If the existing DB has pre-existing duplicate stellar_gist_id rows the UNIQUE constraint cannot be applied; dedupe first.
- Optional follow-ups (not blocking this PR): consolidate IndexerService's double existence check (findByStellarGistId then existsByStellarGistId) into a single check now that the constraint is in place; consider a bounded retry instead of an immediate rethrow when the 23505 recovery lookup returns null.

Closes #98