### PR TITLE
fix: add graceful shutdown handling

### DIFF
--- a/Backend/src/app.module.ts
+++ b/Backend/src/app.module.ts
@@ -10,8 +10,10 @@ import { SorobanModule } from './soroban/soroban.module';
 import { GistsModule } from './gists/gists.module';
 import { HealthModule } from './health/health.module';
 import { MetricsModule } from './metrics/metrics.module';
+import { ShutdownModule } from './common/shutdown/shutdown.module';
 import { envValidationSchema } from './config/env.validation';
 import { CorrelationIdMiddleware } from './common/middleware/correlation-id.middleware';
+import { InFlightRequestMiddleware } from './common/shutdown/in-flight.middleware';
 import { buildWinstonOptions } from './common/logger/winston.config';
 
 @Module({
@@ -47,6 +49,7 @@ import { buildWinstonOptions } from './common/logger/winston.config';
     GistsModule,
     HealthModule,
     MetricsModule,
+    ShutdownModule,
   ],
   providers: [
     {
@@ -57,6 +60,10 @@ import { buildWinstonOptions } from './common/logger/winston.config';
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer.apply(CorrelationIdMiddleware).forRoutes('*');
+    // In-flight-request middleware must run before correlation-id so that
+    // every response (including 404s) is counted toward the drain window.
+    consumer
+      .apply(InFlightRequestMiddleware, CorrelationIdMiddleware)
+      .forRoutes('*');
   }
 }

--- a/Backend/src/common/shutdown/in-flight-tracker.service.spec.ts
+++ b/Backend/src/common/shutdown/in-flight-tracker.service.spec.ts
@@ -1,0 +1,57 @@
+import { InFlightRequestTracker } from './in-flight-tracker.service';
+
+describe('InFlightRequestTracker', () => {
+  let tracker: InFlightRequestTracker;
+
+  beforeEach(() => {
+    tracker = new InFlightRequestTracker();
+  });
+
+  describe('start/end/active', () => {
+    it('starts at zero', () => {
+      expect(tracker.active).toBe(0);
+    });
+
+    it('increments on start', () => {
+      tracker.start();
+      expect(tracker.active).toBe(1);
+      tracker.start();
+      tracker.start();
+      expect(tracker.active).toBe(3);
+    });
+
+    it('decrements on end', () => {
+      tracker.start();
+      tracker.start();
+      tracker.end();
+      expect(tracker.active).toBe(1);
+      tracker.end();
+      expect(tracker.active).toBe(0);
+    });
+
+    it('floors at zero when end is called more times than start', () => {
+      tracker.end();
+      expect(tracker.active).toBe(0);
+      tracker.end();
+      tracker.end();
+      expect(tracker.active).toBe(0);
+    });
+  });
+
+  describe('reset', () => {
+    it('returns to zero regardless of state', () => {
+      tracker.start();
+      tracker.start();
+      tracker.reset();
+      expect(tracker.active).toBe(0);
+    });
+  });
+
+  describe('logActive', () => {
+    it('does not throw (logger is silent in test env)', () => {
+      tracker.start();
+      tracker.logActive('test-context');
+      expect(tracker.active).toBe(1);
+    });
+  });
+});

--- a/Backend/src/common/shutdown/in-flight-tracker.service.ts
+++ b/Backend/src/common/shutdown/in-flight-tracker.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+/**
+ * Tracks the number of in-flight HTTP requests in the process so that the
+ * shutdown sequence can wait for them to drain before closing connections.
+ *
+ * The tracker is a process-wide singleton: middleware increments on entry,
+ * and decrements when the underlying HTTP response finishes or the
+ * connection closes prematurely.
+ */
+@Injectable()
+export class InFlightRequestTracker {
+  private readonly logger = new Logger(InFlightRequestTracker.name);
+  private count = 0;
+
+  /** Begin tracking one request. */
+  start(): void {
+    this.count += 1;
+  }
+
+  /**
+   * End tracking one request. Uses a floor of zero so that a stray `end`
+   * (e.g. on a response that finished before its middleware mounted in
+   * test harnesses) cannot drive the counter negative.
+   */
+  end(): void {
+    this.count = Math.max(0, this.count - 1);
+  }
+
+  /** Current number of in-flight requests. */
+  get active(): number {
+    return this.count;
+  }
+
+  /** Reset to zero — used in tests only. */
+  reset(): void {
+    this.count = 0;
+  }
+
+  /** Log the current count at debug level — used by shutdown polling. */
+  logActive(context = 'inflight'): void {
+    this.logger.debug(`[${context}] active=${this.count}`);
+  }
+}

--- a/Backend/src/common/shutdown/in-flight.middleware.spec.ts
+++ b/Backend/src/common/shutdown/in-flight.middleware.spec.ts
@@ -1,0 +1,97 @@
+import { EventEmitter } from 'events';
+import { InFlightRequestMiddleware } from './in-flight.middleware';
+import { InFlightRequestTracker } from './in-flight-tracker.service';
+
+/**
+ * Minimal Express-compatible Request/Response stand-ins that satisfy the
+ * surface area touched by the middleware. Response is an EventEmitter
+ * that we mutate to simulate `finish` and `close` events.
+ */
+function makeReqRes(): {
+  req: Record<string, unknown>;
+  res: EventEmitter & { off: EventEmitter['off'] };
+  next: jest.Mock;
+} {
+  return {
+    req: { method: 'GET', url: '/' },
+    res: new EventEmitter(),
+    next: jest.fn(),
+  };
+}
+
+describe('InFlightRequestMiddleware', () => {
+  let tracker: InFlightRequestTracker;
+  let middleware: InFlightRequestMiddleware;
+
+  beforeEach(() => {
+    tracker = new InFlightRequestTracker();
+    middleware = new InFlightRequestMiddleware(tracker);
+  });
+
+  it('increments the tracker on entry and calls next()', () => {
+    const { res, next } = makeReqRes();
+    middleware.use({} as never, res as never, next);
+    expect(tracker.active).toBe(1);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('decrements the tracker exactly once when res emits `finish`', () => {
+    const { res, next } = makeReqRes();
+    middleware.use({} as never, res as never, next);
+    expect(tracker.active).toBe(1);
+
+    res.emit('finish');
+    expect(tracker.active).toBe(0);
+
+    // Subsequent emissions must be no-ops — listeners are removed.
+    res.emit('finish');
+    res.emit('finish');
+    expect(tracker.active).toBe(0);
+  });
+
+  it('decrements the tracker when res emits `close` (e.g. aborted request)', () => {
+    const { res, next } = makeReqRes();
+    middleware.use({} as never, res as never, next);
+    expect(tracker.active).toBe(1);
+
+    res.emit('close');
+    expect(tracker.active).toBe(0);
+  });
+
+  it('only decrements once even if both `finish` and `close` fire', () => {
+    const { res, next } = makeReqRes();
+    middleware.use({} as never, res as never, next);
+    expect(tracker.active).toBe(1);
+
+    res.emit('finish');
+    expect(tracker.active).toBe(0);
+
+    // If `close` arrives after `finish`, no negative overshoot.
+    res.emit('close');
+    expect(tracker.active).toBe(0);
+  });
+
+  it('floors at zero if `close` fires before `finish` (defensive)', () => {
+    const { res, next } = makeReqRes();
+    middleware.use({} as never, res as never, next);
+    expect(tracker.active).toBe(1);
+
+    res.emit('close');
+    res.emit('finish');
+    expect(tracker.active).toBe(0);
+  });
+
+  it('tracks multiple concurrent requests independently', () => {
+    const r1 = makeReqRes();
+    const r2 = makeReqRes();
+    middleware.use(r1.req as never, r1.res as never, r1.next);
+    middleware.use(r2.req as never, r2.res as never, r2.next);
+    expect(tracker.active).toBe(2);
+
+    r1.res.emit('finish');
+    expect(tracker.active).toBe(1);
+
+    r2.res.emit('close');
+    expect(tracker.active).toBe(0);
+  });
+});

--- a/Backend/src/common/shutdown/in-flight.middleware.ts
+++ b/Backend/src/common/shutdown/in-flight.middleware.ts
@@ -1,0 +1,33 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { InFlightRequestTracker } from './in-flight-tracker.service';
+
+/**
+ * Express middleware that increments the shared in-flight counter on entry
+ * and decrements it when the response finishes or the underlying connection
+ * closes prematurely. The counter is consumed by `ShutdownService` so that
+ * the process does not tear down DB connections or HTTP sockets while
+ * requests are still being served.
+ *
+ * Registered globally (see `AppModule.configure`) so it covers every route
+ * including `/health` and any unmatched paths.
+ */
+@Injectable()
+export class InFlightRequestMiddleware implements NestMiddleware {
+  constructor(private readonly tracker: InFlightRequestTracker) {}
+
+  use(_req: Request, res: Response, next: NextFunction): void {
+    this.tracker.start();
+
+    const release = () => {
+      res.off('finish', release);
+      res.off('close', release);
+      this.tracker.end();
+    };
+
+    res.on('finish', release);
+    res.on('close', release);
+
+    next();
+  }
+}

--- a/Backend/src/common/shutdown/shutdown.module.ts
+++ b/Backend/src/common/shutdown/shutdown.module.ts
@@ -1,0 +1,29 @@
+import { Module } from '@nestjs/common';
+import { InFlightRequestTracker } from './in-flight-tracker.service';
+import { InFlightRequestMiddleware } from './in-flight.middleware';
+
+/**
+ * # ShutdownModule
+ *
+ * Provides the in-flight request tracker and the Express middleware that
+ * feeds it.
+ *
+ * ## Why `ShutdownService` is NOT registered here
+ *
+ * `ShutdownService` depends on the running `INestApplication` instance,
+ * which is only available after `NestFactory.create()` finishes and the
+ * application context has been initialised. Resolving it through DI would
+ * either require a custom factory provider or an `APP_INITIALIZER` hook.
+ * Instead the service is instantiated manually in `main.ts` and cached
+ * for the lifetime of the process. Registration here would be misleading
+ * because nothing in `main.ts` resolves it from the container.
+ *
+ * If you need to consume `ShutdownService` from another Nest provider,
+ * expose it from `main.ts` as a custom token (e.g. `app.get(SHUTDOWN_SERVICE_TOKEN)`)
+ * after instantiating it.
+ */
+@Module({
+  providers: [InFlightRequestTracker, InFlightRequestMiddleware],
+  exports: [InFlightRequestTracker, InFlightRequestMiddleware],
+})
+export class ShutdownModule {}

--- a/Backend/src/common/shutdown/shutdown.service.spec.ts
+++ b/Backend/src/common/shutdown/shutdown.service.spec.ts
@@ -1,0 +1,135 @@
+import { ShutdownService } from './shutdown.service';
+import { InFlightRequestTracker } from './in-flight-tracker.service';
+import type { ConfigService } from '@nestjs/config';
+import type { INestApplication } from '@nestjs/common';
+import type { Server } from 'http';
+import { EventEmitter } from 'events';
+
+class FakeTracker extends InFlightRequestTracker {
+  public setActive(value: number): void {
+    if (value > this.active) {
+      for (let i = this.active; i < value; i += 1) this.start();
+    } else if (value < this.active) {
+      for (let i = this.active; i > value; i -= 1) this.end();
+    }
+  }
+}
+
+/**
+ * Build a fake http.Server-shaped object whose `close(cb)` resolves once
+ * `tracker.active === 0` (mimicking Node's behaviour when sockets drain).
+ */
+function makeHttpServer(tracker: FakeTracker): Server {
+  const ee = new EventEmitter();
+  const server = ee as unknown as Server;
+  server.close = (cb?: (err?: Error) => void): void => {
+    if (tracker.active === 0) {
+      cb?.();
+      return;
+    }
+    const interval = setInterval(() => {
+      if (tracker.active === 0) {
+        clearInterval(interval);
+        cb?.();
+      }
+    }, 5);
+  };
+  return server;
+}
+
+describe('ShutdownService', () => {
+  let tracker: FakeTracker;
+  let config: ConfigService;
+  let httpServer: Server & EventEmitter;
+  let app: INestApplication;
+  let service: ShutdownService;
+  let originalExit: typeof process.exit;
+
+  beforeEach(() => {
+    tracker = new FakeTracker();
+    httpServer = makeHttpServer(tracker) as Server & EventEmitter;
+
+    config = {
+      get: jest.fn().mockImplementation((key: string, defaultValue?: number) => {
+        if (key === 'SHUTDOWN_TIMEOUT_MS') return 200;
+        return defaultValue;
+      }),
+    } as unknown as ConfigService;
+
+    app = {
+      getHttpServer: () => httpServer,
+      close: jest.fn().mockResolvedValue(undefined),
+    } as unknown as INestApplication;
+
+    service = new ShutdownService(app, tracker, config);
+
+    // Stub process.exit so the success path doesn't terminate the test runner.
+    originalExit = process.exit;
+    process.exit = jest.fn() as never;
+  });
+
+  afterEach(() => {
+    process.exit = originalExit;
+  });
+
+  it('calls httpServer.close and app.close when a signal arrives', async () => {
+    const closeSpy = jest.spyOn(httpServer, 'close');
+    tracker.setActive(0);
+
+    await service.handleSignal('SIGTERM');
+
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    expect(app.close).toHaveBeenCalledTimes(1);
+    expect(process.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('waits for in-flight requests to drain before closing the app', async () => {
+    tracker.setActive(2);
+
+    // Drain in the background; verify app.close hasn't been called yet.
+    setTimeout(() => tracker.setActive(0), 30);
+
+    await service.handleSignal('SIGTERM');
+
+    expect(app.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('still closes the app when the timeout is exceeded', async () => {
+    tracker.setActive(10); // never drained
+
+    await service.handleSignal('SIGTERM');
+
+    expect(app.close).toHaveBeenCalledTimes(1);
+    // Failure path: do NOT exit cleanly, let the platform supervisor handle it.
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent: a second signal is logged and ignored', async () => {
+    tracker.setActive(0);
+
+    await service.handleSignal('SIGTERM');
+    await service.handleSignal('SIGINT');
+
+    expect(app.close).toHaveBeenCalledTimes(1);
+    expect(process.exit).toHaveBeenCalledTimes(1);
+  });
+
+  it('still calls app.close when there is no HTTP server attached', async () => {
+    (app as unknown as { getHttpServer: () => unknown }).getHttpServer = (): never => {
+      throw new Error('no http server');
+    };
+
+    await service.handleSignal('SIGTERM');
+
+    expect(app.close).toHaveBeenCalledTimes(1);
+    expect(process.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('does not call process.exit when app.close throws', async () => {
+    tracker.setActive(0);
+    (app.close as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+
+    await expect(service.handleSignal('SIGTERM')).resolves.toBeUndefined();
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+});

--- a/Backend/src/common/shutdown/shutdown.service.ts
+++ b/Backend/src/common/shutdown/shutdown.service.ts
@@ -1,0 +1,157 @@
+import { Logger, INestApplication } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { Server } from 'http';
+import { InFlightRequestTracker } from './in-flight-tracker.service';
+
+/**
+ * Orchestrates graceful shutdown for the GistPin API.
+ *
+ * On SIGTERM / SIGINT the service:
+ *  1. Marks the process as shutting down so repeat signals are no-ops.
+ *  2. Stops the HTTP server from accepting new connections.
+ *  3. Polls the in-flight request tracker until it reaches zero OR
+ *     `SHUTDOWN_TIMEOUT_MS` elapses (whichever happens first).
+ *  4. Closes the Nest application, which triggers
+ *     `beforeApplicationShutdown` and `onModuleDestroy` hooks so that
+ *     the TypeORM DataSource, metrics exporters, the indexer poll loop,
+ *     and other long-lived resources wind down cleanly.
+ *  5. Calls `process.exit(0)` on the success path so the event loop is
+ *     guaranteed to terminate even if a stray timer leaked.
+ *
+ * This class is *not* a Nest provider: `INestApplication` cannot be
+ * resolved through DI before the application context exists. Instead it
+ * is instantiated manually in `main.ts` after `NestFactory.create()` and
+ * passed concrete references to the app, the in-flight tracker, and the
+ * config service.
+ */
+export class ShutdownService {
+  private readonly logger = new Logger(ShutdownService.name);
+  private shuttingDown = false;
+  private readonly pollIntervalMs = 250;
+
+  constructor(
+    private readonly app: INestApplication,
+    private readonly tracker: InFlightRequestTracker,
+    private readonly configService: ConfigService,
+  ) {}
+
+  /**
+   * Handle a termination signal. Safe to call multiple times: subsequent
+   * calls are logged and ignored so that a second SIGTERM (e.g. from
+   * Kubernetes after the grace period) does not corrupt state.
+   */
+  async handleSignal(signal: NodeJS.Signals): Promise<void> {
+    if (this.shuttingDown) {
+      this.logger.warn(`Already shutting down — ignoring ${signal}`);
+      return;
+    }
+    this.shuttingDown = true;
+
+    const timeoutMs = this.configService.get<number>('SHUTDOWN_TIMEOUT_MS', 25_000);
+    const start = Date.now();
+
+    this.logger.log(
+      `Received ${signal} — beginning graceful shutdown (timeout=${timeoutMs}ms)`,
+    );
+
+    let cleanShutdown = true;
+
+    try {
+      await this.drainHttpServer(timeoutMs, start);
+    } catch (err) {
+      cleanShutdown = false;
+      this.logger.error(
+        `Drain step failed: ${(err as Error).message}`,
+        (err as Error).stack,
+      );
+    }
+
+    try {
+      await this.closeApp(start);
+    } catch (err) {
+      cleanShutdown = false;
+      this.logger.error(
+        `App close failed: ${(err as Error).message}`,
+        (err as Error).stack,
+      );
+    }
+
+    this.logger.log(`Shutdown complete in ${Date.now() - start}ms`);
+
+    // Only force exit on the success path — if shutdown errored, leave
+    // the platform's supervisor (K8s, systemd) to terminte us so we get
+    // crash visibility rather than masking the underlying error.
+    if (cleanShutdown) {
+      process.exit(0);
+    }
+  }
+
+  /** Test-only hook: reset internal guard so the service can be re-used. */
+  resetForTesting(): void {
+    this.shuttingDown = false;
+  }
+
+  private async drainHttpServer(timeoutMs: number, start: number): Promise<void> {
+    const httpServer = this.tryGetHttpServer();
+    if (!httpServer) {
+      this.logger.debug('No HTTP server attached — skipping drain step');
+      return;
+    }
+
+    // `server.close()` resolves once every open socket has ended. We
+    // promisify the callback form so we can race it against a bounded
+    // tracker-poll loop. The tracker is the source of truth for "are we
+    // still serving requests?" because Node may not report server.close
+    // immediately when keep-alive sockets are involved.
+    const closePromise = new Promise<void>((resolve) => {
+      httpServer.close((err) => {
+        if (err && err.message !== 'Server is not running.') {
+          this.logger.error(`HTTP server close error: ${err.message}`);
+        }
+        resolve();
+      });
+    });
+
+    while (this.tracker.active > 0 && Date.now() - start < timeoutMs) {
+      const elapsed = Date.now() - start;
+      this.logger.log(
+        `Waiting for ${this.tracker.active} in-flight request(s)... (elapsed ${elapsed}ms)`,
+      );
+      await this.sleep(this.pollIntervalMs);
+    }
+
+    if (this.tracker.active > 0) {
+      this.logger.warn(
+        `Shutdown timeout reached — ${this.tracker.active} request(s) still in-flight after ${timeoutMs}ms`,
+      );
+    } else {
+      this.logger.log(`All in-flight requests drained (elapsed ${Date.now() - start}ms)`);
+    }
+
+    // Best-effort: cap the wait for server.close() at the remaining
+    // time-budget so we never exceed the configured timeout.
+    const remainingMs = Math.max(0, timeoutMs - (Date.now() - start));
+    await Promise.race([closePromise, this.sleep(remainingMs)]);
+  }
+
+  private async closeApp(start: number): Promise<void> {
+    await this.app.close();
+    this.logger.log(`Nest app closed (elapsed ${Date.now() - start}ms)`);
+  }
+
+  private tryGetHttpServer(): Server | null {
+    try {
+      const maybeServer = this.app.getHttpServer();
+      if (maybeServer && typeof (maybeServer as Server).close === 'function') {
+        return maybeServer as Server;
+      }
+    } catch {
+      return null;
+    }
+    return null;
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/Backend/src/config/env.validation.ts
+++ b/Backend/src/config/env.validation.ts
@@ -41,4 +41,7 @@ export const envValidationSchema = Joi.object({
 
   // Logging
   LOG_DIR: Joi.string().default('logs'),
+
+  // Graceful shutdown — bound for in-flight request drain
+  SHUTDOWN_TIMEOUT_MS: Joi.number().integer().min(0).default(25000),
 });

--- a/Backend/src/main.ts
+++ b/Backend/src/main.ts
@@ -1,10 +1,13 @@
 import 'reflect-metadata';
 import { NestFactory } from '@nestjs/core';
+import { ConfigService } from '@nestjs/config';
 import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { AppModule } from './app.module';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
+import { InFlightRequestTracker } from './common/shutdown/in-flight-tracker.service';
+import { ShutdownService } from './common/shutdown/shutdown.service';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
@@ -43,9 +46,29 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, swaggerConfig);
   SwaggerModule.setup('api/docs', app, document);
 
+  // Issue 99 — graceful shutdown handling.
+  // ShutdownService depends on the running INestApplication so it cannot
+  // be resolved through DI; instantiate it explicitly with refs fetched
+  // from the container, then register signal handlers.
+  // NOTE: we deliberately do NOT call `app.enableShutdownHooks()` here —
+  // it would register its own SIGTERM/SIGINT handlers that call
+  // `app.close()`, duplicating the work ShutdownService already does.
+  const tracker = app.get(InFlightRequestTracker);
+  const configService = app.get(ConfigService);
+  const shutdownService = new ShutdownService(app, tracker, configService);
+
+  const handle = (signal: NodeJS.Signals): void => {
+    void shutdownService.handleSignal(signal);
+  };
+  process.on('SIGTERM', handle);
+  process.on('SIGINT', handle);
+
   await app.listen(process.env.PORT ?? 3000);
   console.log(`Gist API running on port ${process.env.PORT ?? 3000}`);
   console.log(`Swagger docs → http://localhost:${process.env.PORT ?? 3000}/api/docs`);
+  console.log(
+    `Graceful shutdown armed (SHUTDOWN_TIMEOUT_MS=${configService.get<number>('SHUTDOWN_TIMEOUT_MS', 25000)})`,
+  );
 }
 
 void bootstrap();


### PR DESCRIPTION
## Summary
Implements clean termination for the GistPin API: SIGTERM/SIGINT
handlers now stop accepting new HTTP connections, wait for in-flight
requests to drain (bounded by a configurable timeout), then close
the Nest application so TypeORM, the indexer poll loop, and other
lifecycle-bound resources wind down cleanly before the process exits.

## Changes
- `Backend/src/common/shutdown/shutdown.service.ts` (new) — orchestrates
  the shutdown sequence. Plain class instantiated manually in
  `main.ts` because `INestApplication` cannot be resolved through DI
  before the application context exists.
- `Backend/src/common/shutdown/in-flight-tracker.service.ts` (new) —
  singleton counter shared by the middleware and the shutdown service.
- `Backend/src/common/shutdown/in-flight.middleware.ts` (new) —
  Express middleware that increments the tracker at request entry and
  decrements on `res.finish` / `res.close`.
- `Backend/src/common/shutdown/shutdown.module.ts` (new) — provides
  the tracker + middleware. `ShutdownService` is intentionally NOT
  registered here (see file docstring).
- `Backend/src/main.ts` — resolves the tracker + config from the
  container, constructs `ShutdownService`, and registers SIGTERM /
  SIGINT handlers that delegate to it.
- `Backend/src/app.module.ts` — imports `ShutdownModule` and registers
  `InFlightRequestMiddleware` ahead of `CorrelationIdMiddleware` so
  every response (including 404s) is counted toward the drain window.
- `Backend/src/config/env.validation.ts` — adds
  `SHUTDOWN_TIMEOUT_MS` (default 25000) so operators can tune the
  drain budget per environment.
- Spec coverage (no real DB required):
  - `in-flight-tracker.service.spec.ts` — start / end / floor at zero,
    reset, logging.
  - `in-flight.middleware.spec.ts` — increment on entry, decrement on
    `finish` and `close`, listener removal so double-fires do not
    overshoot, multi-request independence.
  - `shutdown.service.spec.ts` — signal handling, drain waiting, hard
    timeout fallback, idempotency, missing HTTP server, app.close
    failure, and the success-path `process.exit(0)` invocation.

## Testing
- All new unit tests are designed to run without a Postgres connection
  (the `ShutdownService` uses an injected `INestApplication` mock and
  a fake HTTP server).
- Manual end-to-end smoke: `kill -TERM <pid>` while a long-poll
  request is in flight should report the in-flight count, drain, then
  log "Nest app closed" and exit 0.

Closes #99