### PR TITLE
feat: version API endpoints under /v1

### DIFF
--- a/Backend/src/gists/gists.controller.ts
+++ b/Backend/src/gists/gists.controller.ts
@@ -6,7 +6,7 @@ import { CreateGistDto } from './dto/create-gist.dto';
 import { QueryGistsDto } from './dto/query-gists.dto';
 
 @ApiTags('gists')
-@Controller('gists')
+@Controller({ path: 'gists', version: '1' })
 export class GistsController {
   constructor(private readonly gistsService: GistsService) {}
 

--- a/Backend/src/health/health.controller.ts
+++ b/Backend/src/health/health.controller.ts
@@ -16,7 +16,7 @@ interface HealthResponse {
   };
 }
 
-@Controller('health')
+@Controller({ path: 'health', version: '1' })
 export class HealthController {
   constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
 

--- a/Backend/src/main.ts
+++ b/Backend/src/main.ts
@@ -4,11 +4,13 @@ import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { AppModule } from './app.module';
+import { ValidationPipe, VersioningType } from '@nestjs/common';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
   app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
+  app.enableVersioning({ type: VersioningType.URI });
 
   // Issue 78 — CORS
   const allowedOrigins = process.env.CORS_ORIGINS
@@ -33,15 +35,15 @@ async function bootstrap() {
   // Logging
   app.useGlobalInterceptors(new LoggingInterceptor());
 
-  // Issue 77 — Swagger
   const swaggerConfig = new DocumentBuilder()
-    .setTitle('Gist API')
-    .setDescription('Anonymous hyperlocal messaging on Stellar')
-    .setVersion('0.1.0')
-    .build();
+  .setTitle('Gist API')
+  .setDescription('Anonymous hyperlocal messaging on Stellar')
+  .setVersion('1.0')
+  .addServer('/v1', 'Version 1')
+  .build();
 
-  const document = SwaggerModule.createDocument(app, swaggerConfig);
-  SwaggerModule.setup('api/docs', app, document);
+const document = SwaggerModule.createDocument(app, swaggerConfig);
+SwaggerModule.setup('v1/docs', app, document);
 
   await app.listen(process.env.PORT ?? 3000);
   console.log(`Gist API running on port ${process.env.PORT ?? 3000}`);


### PR DESCRIPTION
Closes #92

## Changes
- Enable URI versioning (`VersioningType.URI`) in `main.ts`
- `GistsController` and `HealthController` versioned to `v1`
- Swagger moved from `/api/docs` → `/v1/docs`, version updated to `1.0`, server set to `/v1`
- Removed duplicate `/health` route from `AppController`

## Route changes
| Before | After |
|---|---|
| `POST /gists` | `POST /v1/gists` |
| `GET /gists` | `GET /v1/gists` |
| `GET /gists/:id` | `GET /v1/gists/:id` |
| `GET /health` | `GET /v1/health` |
| `GET /api/docs` | `GET /v1/docs` |