### PR TITLE
feat: add GET /gists/count endpoint (#609)

### DIFF
--- a/Backend/src/gists/dto/query-gists.dto.ts
+++ b/Backend/src/gists/dto/query-gists.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsLatitude, IsLongitude, IsOptional, IsNumber, Min, Max, IsString } from 'class-validator';
-import { Type } from 'class-transformer';
+import { IsLatitude, IsLongitude, IsOptional, IsNumber, Min, Max, IsString, IsBoolean, MaxLength } from 'class-validator';
+import { Type, Transform } from 'class-transformer';
 
 export class QueryGistsDto {
   @ApiProperty({ description: 'Latitude to search from', example: 9.0579 })
@@ -50,4 +50,13 @@ export class QueryGistsDto {
   @IsString()
   @MaxLength(80)
   authorAddress?: string;
+
+  @ApiPropertyOptional({
+    description: 'When true, count endpoint returns breakdown by location_cell',
+    example: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => value === 'true' || value === true)
+  breakdown?: boolean;
 }

--- a/Backend/src/gists/gist.repository.ts
+++ b/Backend/src/gists/gist.repository.ts
@@ -170,4 +170,35 @@ export class GistRepository {
     );
     return parseInt(row.cnt, 10) > 0;
   }
+
+  async countNearby(lat: number, lon: number, radiusMeters: number): Promise<number> {
+    const [row] = await this.dataSource.query<Array<{ count: string }>>(
+      `SELECT COUNT(*) AS count FROM gists
+       WHERE ST_DWithin(
+         location::geography,
+         ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography,
+         $3
+       ) AND expires_at > NOW()`,
+      [lon, lat, radiusMeters],
+    );
+    return parseInt(row.count, 10);
+  }
+
+  async countNearbyByCell(
+    lat: number,
+    lon: number,
+    radiusMeters: number,
+  ): Promise<Array<{ cell: string; count: number }>> {
+    const rows = await this.dataSource.query<Array<{ location_cell: string; count: string }>>(
+      `SELECT location_cell, COUNT(*) AS count FROM gists
+       WHERE ST_DWithin(
+         location::geography,
+         ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography,
+         $3
+       ) AND expires_at > NOW()
+       GROUP BY location_cell ORDER BY count DESC`,
+      [lon, lat, radiusMeters],
+    );
+    return rows.map((r) => ({ cell: r.location_cell, count: parseInt(r.count, 10) }));
+  }
 }

--- a/Backend/src/gists/gists.controller.ts
+++ b/Backend/src/gists/gists.controller.ts
@@ -32,6 +32,13 @@ export class GistsController {
     return this.gistsService.findNearby(query);
   }
 
+  @Get('count')
+  @SkipThrottle()
+  @ApiOperation({ summary: 'Count active gists within a radius' })
+  countNearby(@Query() query: QueryGistsDto) {
+    return this.gistsService.countNearby(query);
+  }
+
   @Get(':id')
   @SkipThrottle()
   @ApiOperation({ summary: 'Get a single gist by ID' })

--- a/Backend/src/gists/gists.service.ts
+++ b/Backend/src/gists/gists.service.ts
@@ -117,4 +117,16 @@ export class GistsService {
     }
     return gist;
   }
+
+  async countNearby(
+    query: QueryGistsDto,
+  ): Promise<{ count: number; radius: number; lat: number; lon: number; breakdown?: Array<{ cell: string; count: number }> }> {
+    const { lat, lon, radius = 500, breakdown } = query;
+    const count = await this.gistRepository.countNearby(lat, lon, radius);
+    if (breakdown) {
+      const cells = await this.gistRepository.countNearbyByCell(lat, lon, radius);
+      return { count, radius, lat, lon, breakdown: cells };
+    }
+    return { count, radius, lat, lon };
+  }
 }


### PR DESCRIPTION
## Summary
Implements [#609](https://github.com/PinSpace-Org/GistPin/issues/610) — adds a lightweight `GET /gists/count` endpoint that returns the number of active non-expired gists within a radius.

## Changes
- **GistRepository**: Added `countNearby` (total count) and `countNearbyByCell` (grouped by H3 cell) methods using ST_DWithin with `expires_at > NOW()` filter
- **GistsService**: Added `countNearby` method returning `{ count, radius, lat, lon }` or with optional `breakdown` array
- **GistsController**: Added `GET count` route **before** `GET :id` to avoid NestJS route conflict; decorated with `@SkipThrottle()`
- **QueryGistsDto**: Added optional `breakdown` boolean field

## Tested
- Route order verified: `count` registered before `:id`
- Expired gists excluded via `expires_at > NOW()` in SQL
- No throttling applied (`@SkipThrottle()`)
- Breakdown param correctly triggers grouped SQL query

Closes #609