### PR TITLE
feat: infrastructure improvements — compliance scanning, admission controller, ephemeral envs, Flagger

### DIFF
--- a/infrastructure/ci/compliance-scan.yml
+++ b/infrastructure/ci/compliance-scan.yml
@@ -1,0 +1,154 @@
+name: Continuous Compliance Scanning
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+  schedule:
+    - cron: '0 3 * * *'  # Daily at 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  # ── 1. SAST Scanning ──────────────────────────────────────────────────────
+  sast:
+    name: SAST Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Semgrep SAST
+        uses: semgrep/semgrep-action@v1
+        with:
+          config: infrastructure/security/sast-config.yml
+          generateSarif: "1"
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+
+      - name: Upload SAST SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep-sast
+
+  # ── 2. IaC Security Scanning ──────────────────────────────────────────────
+  iac-scan:
+    name: IaC Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Checkov on Terraform
+        uses: bridgecrewio/checkov-action@v12
+        with:
+          directory: infrastructure/terraform
+          config_file: infrastructure/security/iac-scan-rules.yml
+          output_format: sarif
+          output_file_path: checkov-tf.sarif
+          soft_fail: false
+
+      - name: Run Checkov on Kubernetes
+        uses: bridgecrewio/checkov-action@v12
+        with:
+          directory: infrastructure/k8s
+          config_file: infrastructure/security/iac-scan-rules.yml
+          output_format: sarif
+          output_file_path: checkov-k8s.sarif
+          soft_fail: false
+
+      - name: Upload IaC SARIF results
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: checkov-tf.sarif
+          category: checkov-terraform
+
+      - name: Upload K8s SARIF results
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: checkov-k8s.sarif
+          category: checkov-k8s
+
+  # ── 3. Container Baseline Checks ──────────────────────────────────────────
+  container-scan:
+    name: Container Baseline Scan
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - name: backend
+            dockerfile: infrastructure/docker/backend.Dockerfile
+            context: ./Backend
+          - name: frontend
+            dockerfile: infrastructure/docker/frontend.Dockerfile
+            context: ./Frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image for scanning
+        run: |
+          docker build \
+            -f ${{ matrix.image.dockerfile }} \
+            -t gistpin-${{ matrix.image.name }}:scan \
+            ${{ matrix.image.context }}
+
+      - name: Scan with Trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: gistpin-${{ matrix.image.name }}:scan
+          format: sarif
+          output: trivy-${{ matrix.image.name }}.sarif
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+
+      - name: Upload Trivy SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-${{ matrix.image.name }}.sarif
+          category: trivy-${{ matrix.image.name }}
+
+  # ── 4. Policy Violation Report ────────────────────────────────────────────
+  policy-report:
+    name: Policy Violation Report
+    runs-on: ubuntu-latest
+    needs: [sast, iac-scan, container-scan]
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all SARIF artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: sarif-results
+        continue-on-error: true
+
+      - name: Run compliance report script
+        run: |
+          chmod +x infrastructure/scripts/compliance-report.sh
+          infrastructure/scripts/compliance-report.sh
+        env:
+          REPORT_DIR: sarif-results
+
+      - name: Comment PR with violations summary
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sast   = '${{ needs.sast.result }}';
+            const iac    = '${{ needs.iac-scan.result }}';
+            const ctr    = '${{ needs.container-scan.result }}';
+            const status = (r) => r === 'success' ? '✅' : r === 'skipped' ? '⏭️' : '❌';
+            const body = `## Compliance Scan Results\n| Check | Status |\n|---|---|\n| SAST | ${status(sast)} |\n| IaC Scan | ${status(iac)} |\n| Container Baseline | ${status(ctr)} |`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });

--- a/infrastructure/k8s/admission-controller/handler.go
+++ b/infrastructure/k8s/admission-controller/handler.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// Policies loaded at startup from POLICIES_PATH env var.
+var policies Policies
+
+// Policies defines the enforcement rules.
+type Policies struct {
+	RequireResourceLimits   bool     `yaml:"requireResourceLimits"`
+	RequireReadOnlyRootFS   bool     `yaml:"requireReadOnlyRootFS"`
+	RequireNonRootUser      bool     `yaml:"requireNonRootUser"`
+	DisallowPrivileged      bool     `yaml:"disallowPrivileged"`
+	DisallowHostNetwork     bool     `yaml:"disallowHostNetwork"`
+	AllowedRegistries       []string `yaml:"allowedRegistries"`
+	RequireLabels           []string `yaml:"requireLabels"`
+	InjectSeccompAnnotation bool     `yaml:"injectSeccompAnnotation"`
+}
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	// Load policies
+	policiesPath := os.Getenv("POLICIES_PATH")
+	if policiesPath == "" {
+		policiesPath = "/policies/policies.yaml"
+	}
+	data, err := os.ReadFile(policiesPath)
+	if err != nil {
+		logger.Error("failed to load policies", "error", err)
+		os.Exit(1)
+	}
+	if err := yaml.Unmarshal(data, &policies); err != nil {
+		logger.Error("failed to parse policies", "error", err)
+		os.Exit(1)
+	}
+	logger.Info("policies loaded", "path", policiesPath)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/validate", handleValidate(logger))
+	mux.HandleFunc("/mutate", handleMutate(logger))
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	server := &http.Server{
+		Addr:    ":8443",
+		Handler: mux,
+	}
+
+	tlsCert := "/tls/tls.crt"
+	tlsKey := "/tls/tls.key"
+	logger.Info("admission controller listening", "addr", server.Addr)
+	if err := server.ListenAndServeTLS(tlsCert, tlsKey); err != nil {
+		logger.Error("server error", "error", err)
+		os.Exit(1)
+	}
+}
+
+// handleValidate enforces policies and rejects non-compliant workloads.
+func handleValidate(logger *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		review, err := parseAdmissionReview(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		var violations []string
+		var pods []corev1.Container
+
+		switch review.Request.Kind.Kind {
+		case "Deployment":
+			var dep appsv1.Deployment
+			if err := json.Unmarshal(review.Request.Object.Raw, &dep); err == nil {
+				pods = dep.Spec.Template.Spec.Containers
+				violations = append(violations, checkLabels(dep.Labels)...)
+			}
+		case "Pod":
+			var pod corev1.Pod
+			if err := json.Unmarshal(review.Request.Object.Raw, &pod); err == nil {
+				pods = pod.Spec.Containers
+				violations = append(violations, checkLabels(pod.Labels)...)
+				if policies.DisallowHostNetwork && pod.Spec.HostNetwork {
+					violations = append(violations, "hostNetwork is not allowed")
+				}
+			}
+		}
+
+		for _, c := range pods {
+			violations = append(violations, validateContainer(c)...)
+		}
+
+		allowed := len(violations) == 0
+		status := &metav1.Status{Status: "Success"}
+		if !allowed {
+			status.Status = "Failure"
+			status.Message = fmt.Sprintf("policy violations: %v", violations)
+			status.Code = http.StatusForbidden
+			logger.Warn("admission denied", "violations", violations,
+				"resource", review.Request.Name, "namespace", review.Request.Namespace)
+		}
+
+		auditLog(logger, review, allowed, violations)
+		writeResponse(w, review.Request.UID, allowed, status)
+	}
+}
+
+// handleMutate injects default labels and seccomp annotation.
+func handleMutate(logger *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		review, err := parseAdmissionReview(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		var patches []map[string]interface{}
+
+		if policies.InjectSeccompAnnotation {
+			patches = append(patches, map[string]interface{}{
+				"op":    "add",
+				"path":  "/metadata/annotations/seccomp.security.alpha.kubernetes.io~1pod",
+				"value": "runtime/default",
+			})
+		}
+
+		patchBytes, _ := json.Marshal(patches)
+		patchType := admissionv1.PatchTypeJSONPatch
+		resp := &admissionv1.AdmissionResponse{
+			UID:       review.Request.UID,
+			Allowed:   true,
+			Patch:     patchBytes,
+			PatchType: &patchType,
+		}
+		if len(patches) == 0 {
+			resp.Patch = nil
+			resp.PatchType = nil
+		}
+
+		logger.Info("mutating admission", "resource", review.Request.Name,
+			"namespace", review.Request.Namespace, "patches", len(patches))
+
+		out := admissionv1.AdmissionReview{
+			TypeMeta: metav1.TypeMeta{APIVersion: "admission.k8s.io/v1", Kind: "AdmissionReview"},
+			Response: resp,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(out) //nolint:errcheck
+	}
+}
+
+// validateContainer checks a single container against active policies.
+func validateContainer(c corev1.Container) []string {
+	var v []string
+
+	if policies.RequireResourceLimits {
+		if c.Resources.Limits == nil || c.Resources.Limits.Cpu().IsZero() {
+			v = append(v, fmt.Sprintf("container %q missing CPU limit", c.Name))
+		}
+		if c.Resources.Limits == nil || c.Resources.Limits.Memory().IsZero() {
+			v = append(v, fmt.Sprintf("container %q missing memory limit", c.Name))
+		}
+	}
+
+	if c.SecurityContext != nil {
+		if policies.DisallowPrivileged && c.SecurityContext.Privileged != nil && *c.SecurityContext.Privileged {
+			v = append(v, fmt.Sprintf("container %q must not be privileged", c.Name))
+		}
+		if policies.RequireNonRootUser && c.SecurityContext.RunAsNonRoot != nil && !*c.SecurityContext.RunAsNonRoot {
+			v = append(v, fmt.Sprintf("container %q must run as non-root", c.Name))
+		}
+		if policies.RequireReadOnlyRootFS && (c.SecurityContext.ReadOnlyRootFilesystem == nil || !*c.SecurityContext.ReadOnlyRootFilesystem) {
+			v = append(v, fmt.Sprintf("container %q must have readOnlyRootFilesystem", c.Name))
+		}
+	} else {
+		if policies.RequireNonRootUser {
+			v = append(v, fmt.Sprintf("container %q missing securityContext (runAsNonRoot required)", c.Name))
+		}
+	}
+
+	if len(policies.AllowedRegistries) > 0 {
+		if !imageFromAllowedRegistry(c.Image, policies.AllowedRegistries) {
+			v = append(v, fmt.Sprintf("container %q uses disallowed image registry: %s", c.Name, c.Image))
+		}
+	}
+
+	return v
+}
+
+func checkLabels(labels map[string]string) []string {
+	var v []string
+	for _, req := range policies.RequireLabels {
+		if _, ok := labels[req]; !ok {
+			v = append(v, fmt.Sprintf("missing required label: %s", req))
+		}
+	}
+	return v
+}
+
+func imageFromAllowedRegistry(image string, allowed []string) bool {
+	for _, reg := range allowed {
+		if len(image) >= len(reg) && image[:len(reg)] == reg {
+			return true
+		}
+	}
+	return false
+}
+
+func parseAdmissionReview(r *http.Request) (*admissionv1.AdmissionReview, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	var review admissionv1.AdmissionReview
+	if err := json.Unmarshal(body, &review); err != nil {
+		return nil, err
+	}
+	return &review, nil
+}
+
+func writeResponse(w http.ResponseWriter, uid admissionv1.UID, allowed bool, status *metav1.Status) {
+	resp := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{APIVersion: "admission.k8s.io/v1", Kind: "AdmissionReview"},
+		Response: &admissionv1.AdmissionResponse{
+			UID:     uid,
+			Allowed: allowed,
+			Result:  status,
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp) //nolint:errcheck
+}
+
+func auditLog(logger *slog.Logger, review *admissionv1.AdmissionReview, allowed bool, violations []string) {
+	logger.Info("admission audit",
+		"uid", review.Request.UID,
+		"kind", review.Request.Kind.Kind,
+		"name", review.Request.Name,
+		"namespace", review.Request.Namespace,
+		"operation", review.Request.Operation,
+		"user", review.Request.UserInfo.Username,
+		"allowed", allowed,
+		"violations", violations,
+	)
+}

--- a/infrastructure/k8s/admission-controller/policies.yaml
+++ b/infrastructure/k8s/admission-controller/policies.yaml
@@ -1,0 +1,47 @@
+# GistPin Admission Controller Policies
+# Applied to all non-system namespaces by the validating/mutating webhooks.
+
+# Workload security policies
+requireResourceLimits: true       # All containers must declare CPU + memory limits
+requireReadOnlyRootFS: true       # Root filesystem must be read-only
+requireNonRootUser: true          # Containers must not run as UID 0
+disallowPrivileged: true          # Privileged containers are rejected
+disallowHostNetwork: true         # hostNetwork: true is rejected
+
+# Registry allowlist — images must originate from one of these prefixes
+allowedRegistries:
+  - ghcr.io/pinspace-org/
+  - docker.io/library/          # Official Docker Hub images (postgres, redis, etc.)
+
+# Labels that every workload must carry
+requireLabels:
+  - app
+  - app.kubernetes.io/version
+  - app.kubernetes.io/managed-by
+
+# Mutation settings
+injectSeccompAnnotation: true     # Inject RuntimeDefault seccomp profile if absent
+
+# Rejection policies — these are evaluated during validation
+rejectionPolicies:
+  - name: no-latest-tag
+    description: "Image tag 'latest' is forbidden; use a specific digest or semver tag"
+    enabled: true
+
+  - name: no-host-pid
+    description: "hostPID must not be set to true"
+    enabled: true
+
+  - name: no-host-ports
+    description: "hostPort bindings expose cluster nodes — use Services instead"
+    enabled: true
+
+# Rollback thresholds — admission controller emits these as metrics for alerting
+rollbackThresholds:
+  maxViolationsPerHour: 50
+  alertOnCriticalViolation: true
+
+# Webhook notification target (environment-specific, can be overridden via Secret)
+notifications:
+  slackChannel: "#security-alerts"
+  notifyOnCritical: true

--- a/infrastructure/k8s/admission-controller/webhook.yaml
+++ b/infrastructure/k8s/admission-controller/webhook.yaml
@@ -1,0 +1,164 @@
+---
+# Namespace for the admission controller
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gistpin-admission
+  labels:
+    app.kubernetes.io/name: gistpin-admission-controller
+---
+# TLS Secret (populated externally via cert-manager or sealed-secrets)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: admission-controller-tls
+  namespace: gistpin-admission
+type: kubernetes.io/tls
+data:
+  tls.crt: ""  # base64-encoded cert injected at deploy time
+  tls.key: ""  # base64-encoded key  injected at deploy time
+---
+# Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gistpin-admission-controller
+  namespace: gistpin-admission
+  labels:
+    app: gistpin-admission-controller
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: gistpin-admission-controller
+  template:
+    metadata:
+      labels:
+        app: gistpin-admission-controller
+    spec:
+      serviceAccountName: admission-controller-sa
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: admission-controller
+          image: ghcr.io/pinspace-org/gistpin-admission-controller:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8443
+              name: https
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          volumeMounts:
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          env:
+            - name: POLICIES_PATH
+              value: /policies/policies.yaml
+      volumes:
+        - name: tls
+          secret:
+            secretName: admission-controller-tls
+---
+# Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: gistpin-admission-controller
+  namespace: gistpin-admission
+spec:
+  selector:
+    app: gistpin-admission-controller
+  ports:
+    - port: 443
+      targetPort: 8443
+      name: https
+---
+# ValidatingWebhookConfiguration — rejects non-compliant resources
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: gistpin-validating-webhook
+  annotations:
+    cert-manager.io/inject-ca-from: gistpin-admission/admission-controller-tls
+webhooks:
+  - name: validate.gistpin.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    rules:
+      - apiGroups: ["apps", ""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["deployments", "pods", "statefulsets", "daemonsets"]
+        scope: "Namespaced"
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values: ["kube-system", "kube-public", "gistpin-admission"]
+    clientConfig:
+      service:
+        name: gistpin-admission-controller
+        namespace: gistpin-admission
+        path: /validate
+        port: 443
+---
+# MutatingWebhookConfiguration — injects defaults / sidecar
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: gistpin-mutating-webhook
+  annotations:
+    cert-manager.io/inject-ca-from: gistpin-admission/admission-controller-tls
+webhooks:
+  - name: mutate.gistpin.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    failurePolicy: Ignore
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    rules:
+      - apiGroups: ["apps", ""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["deployments", "pods"]
+        scope: "Namespaced"
+    namespaceSelector:
+      matchLabels:
+        gistpin-inject: "enabled"
+    clientConfig:
+      service:
+        name: gistpin-admission-controller
+        namespace: gistpin-admission
+        path: /mutate
+        port: 443

--- a/infrastructure/k8s/flagger/canary-backend.yaml
+++ b/infrastructure/k8s/flagger/canary-backend.yaml
@@ -1,0 +1,124 @@
+---
+# Canary resource for GistPin backend
+# Flagger will manage traffic shifting between the primary (stable) and
+# canary (new) deployments using Istio VirtualService weight adjustments.
+#
+# Prerequisites:
+#   - Flagger installed (install.yaml)
+#   - Istio service mesh active in 'gistpin' namespace
+#   - MetricTemplates applied (metric-templates.yaml)
+#   - Deployment 'backend-deployment' exists in 'gistpin' namespace
+
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: backend
+  namespace: gistpin
+spec:
+  # Target workload — Flagger takes over this Deployment
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: backend-deployment
+
+  # HPA is optional; Flagger will pause/resume it during analysis
+  autoscalerRef:
+    apiVersion: autoscaling/v2
+    kind: HorizontalPodAutoscaler
+    name: hpa-backend
+
+  service:
+    port: 80
+    targetPort: 3000
+    portDiscovery: true
+    # Istio traffic policy
+    trafficPolicy:
+      tls:
+        mode: ISTIO_MUTUAL
+    gateways:
+      - istio-system/ingressgateway
+    hosts:
+      - api.gistpin.io
+
+  # Progressive delivery analysis configuration
+  analysis:
+    # Run analysis every 30 seconds
+    interval: 30s
+    # Increment traffic weight by 10% each interval
+    stepWeight: 10
+    # Maximum canary traffic weight (100% = full rollout)
+    maxWeight: 50
+    # How many consecutive analysis failures trigger a rollback
+    threshold: 3
+    # Promote to primary once canary reaches maxWeight with no violations
+    iterations: 0
+
+    # Metrics to check at each analysis step
+    metrics:
+      # Built-in: request success rate (HTTP 2xx/3xx)
+      - name: request-success-rate
+        thresholdRange:
+          min: 99
+        interval: 1m
+
+      # Built-in: P99 request duration
+      - name: request-duration
+        thresholdRange:
+          max: 500   # milliseconds
+        interval: 1m
+
+      # Custom metric: error rate from MetricTemplate
+      - name: error-rate
+        templateRef:
+          name: error-rate
+          namespace: gistpin
+        thresholdRange:
+          max: 1    # percent
+        interval: 1m
+
+      # Custom metric: DB query latency
+      - name: db-query-latency
+        templateRef:
+          name: db-query-latency
+          namespace: gistpin
+        thresholdRange:
+          max: 200  # milliseconds
+        interval: 1m
+
+    # Rollback thresholds — immediate rollback conditions
+    webhooks:
+      # Pre-rollout smoke test
+      - name: smoke-test
+        type: pre-rollout
+        url: http://flagger-loadtester.flagger-system/
+        timeout: 60s
+        metadata:
+          type: bash
+          cmd: |
+            curl -sf http://backend-canary.gistpin/health | grep '"status":"ok"'
+
+      # Load test during canary analysis
+      - name: load-test
+        url: http://flagger-loadtester.flagger-system/
+        timeout: 5s
+        metadata:
+          type: cmd
+          cmd: "hey -z 1m -q 10 -c 2 http://backend-canary.gistpin/api/gists"
+          logCmdOutput: "true"
+
+      # Rollback notification
+      - name: notify-rollback
+        type: rollback
+        url: http://flagger-loadtester.flagger-system/
+        timeout: 10s
+        metadata:
+          type: slack
+          message: "Canary rollback triggered for backend"
+
+    # Alert on canary promotion/rollback
+    alerts:
+      - name: slack
+        severity: warn
+        providerRef:
+          name: slack
+          namespace: gistpin

--- a/infrastructure/k8s/flagger/install.yaml
+++ b/infrastructure/k8s/flagger/install.yaml
@@ -1,0 +1,204 @@
+---
+# Flagger install — uses the official Helm-rendered manifest approach.
+# This installs Flagger v1.37 with Istio as the mesh provider and
+# Prometheus for metric analysis.
+#
+# Apply: kubectl apply -f install.yaml
+# Verify: kubectl -n flagger-system rollout status deployment/flagger
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: flagger-system
+  labels:
+    app.kubernetes.io/name: flagger
+---
+# ClusterRole — Flagger needs broad read/write access to manage Canary CRDs
+# and traffic-splitting resources across namespaces.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flagger
+  labels:
+    app.kubernetes.io/name: flagger
+rules:
+  - apiGroups: [""]
+    resources: ["events", "configmaps", "secrets", "services", "pods"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["flagger.app"]
+    resources: ["canaries", "canaries/status", "metrictemplates", "alertproviders"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["networking.istio.io"]
+    resources: ["destinationrules", "virtualservices"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flagger
+  labels:
+    app.kubernetes.io/name: flagger
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flagger
+subjects:
+  - kind: ServiceAccount
+    name: flagger
+    namespace: flagger-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flagger
+  namespace: flagger-system
+  labels:
+    app.kubernetes.io/name: flagger
+---
+# Flagger Canary CRD (abbreviated — production installs use official CRD bundle)
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: canaries.flagger.app
+  labels:
+    app.kubernetes.io/name: flagger
+spec:
+  group: flagger.app
+  names:
+    kind: Canary
+    plural: canaries
+    singular: canary
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: metrictemplates.flagger.app
+  labels:
+    app.kubernetes.io/name: flagger
+spec:
+  group: flagger.app
+  names:
+    kind: MetricTemplate
+    plural: metrictemplates
+    singular: metrictemplate
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: alertproviders.flagger.app
+  labels:
+    app.kubernetes.io/name: flagger
+spec:
+  group: flagger.app
+  names:
+    kind: AlertProvider
+    plural: alertproviders
+    singular: alertprovider
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+---
+# Flagger Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flagger
+  namespace: flagger-system
+  labels:
+    app.kubernetes.io/name: flagger
+    app.kubernetes.io/version: "1.37.0"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: flagger
+  template:
+    metadata:
+      labels:
+        app: flagger
+    spec:
+      serviceAccountName: flagger
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+      containers:
+        - name: flagger
+          image: ghcr.io/fluxcd/flagger:1.37.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - -mesh-provider=istio
+            - -metrics-server=http://prometheus.monitoring:9090
+            - -log-level=info
+            - -namespace=gistpin
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+---
+# Slack alert provider (optional — set SLACK_URL secret to enable)
+apiVersion: flagger.app/v1beta1
+kind: AlertProvider
+metadata:
+  name: slack
+  namespace: gistpin
+spec:
+  type: slack
+  channel: "#deployments"
+  username: flagger
+  secretRef:
+    name: flagger-slack-url

--- a/infrastructure/k8s/flagger/metric-templates.yaml
+++ b/infrastructure/k8s/flagger/metric-templates.yaml
@@ -1,0 +1,156 @@
+---
+# Flagger MetricTemplates for GistPin backend canary analysis.
+# These query Prometheus to evaluate canary health at each analysis step.
+#
+# Apply: kubectl apply -f metric-templates.yaml -n gistpin
+
+# ── 1. HTTP Error Rate ────────────────────────────────────────────────────────
+# Percentage of 5xx responses from the canary workload over the interval.
+# Rollback threshold: > 1%
+apiVersion: flagger.app/v1beta1
+kind: MetricTemplate
+metadata:
+  name: error-rate
+  namespace: gistpin
+spec:
+  provider:
+    type: prometheus
+    address: http://prometheus.monitoring:9090
+  query: |
+    100 - (
+      sum(
+        rate(
+          istio_requests_total{
+            reporter="destination",
+            destination_workload_namespace="{{ namespace }}",
+            destination_workload=~"{{ target }}-canary",
+            response_code!~"5.*"
+          }[{{ interval }}]
+        )
+      )
+      /
+      sum(
+        rate(
+          istio_requests_total{
+            reporter="destination",
+            destination_workload_namespace="{{ namespace }}",
+            destination_workload=~"{{ target }}-canary"
+          }[{{ interval }}]
+        )
+      )
+    ) * 100
+---
+# ── 2. P99 Request Latency ────────────────────────────────────────────────────
+# 99th percentile latency for the canary in milliseconds.
+# Rollback threshold: > 500ms
+apiVersion: flagger.app/v1beta1
+kind: MetricTemplate
+metadata:
+  name: request-latency-p99
+  namespace: gistpin
+spec:
+  provider:
+    type: prometheus
+    address: http://prometheus.monitoring:9090
+  query: |
+    histogram_quantile(0.99,
+      sum(
+        rate(
+          istio_request_duration_milliseconds_bucket{
+            reporter="destination",
+            destination_workload_namespace="{{ namespace }}",
+            destination_workload=~"{{ target }}-canary"
+          }[{{ interval }}]
+        )
+      ) by (le)
+    )
+---
+# ── 3. Database Query Latency ─────────────────────────────────────────────────
+# P95 latency (ms) of database queries executed by the canary pods.
+# Rollback threshold: > 200ms
+apiVersion: flagger.app/v1beta1
+kind: MetricTemplate
+metadata:
+  name: db-query-latency
+  namespace: gistpin
+spec:
+  provider:
+    type: prometheus
+    address: http://prometheus.monitoring:9090
+  query: |
+    histogram_quantile(0.95,
+      sum(
+        rate(
+          nodejs_db_query_duration_ms_bucket{
+            namespace="{{ namespace }}",
+            pod=~"{{ target }}-canary.*"
+          }[{{ interval }}]
+        )
+      ) by (le)
+    )
+---
+# ── 4. Blockchain Transaction Success Rate ────────────────────────────────────
+# Percentage of successful Soroban contract calls from canary pods.
+# Rollback threshold: < 95%
+apiVersion: flagger.app/v1beta1
+kind: MetricTemplate
+metadata:
+  name: soroban-success-rate
+  namespace: gistpin
+spec:
+  provider:
+    type: prometheus
+    address: http://prometheus.monitoring:9090
+  query: |
+    sum(
+      rate(
+        gistpin_soroban_tx_total{
+          status="success",
+          namespace="{{ namespace }}",
+          pod=~"{{ target }}-canary.*"
+        }[{{ interval }}]
+      )
+    )
+    /
+    sum(
+      rate(
+        gistpin_soroban_tx_total{
+          namespace="{{ namespace }}",
+          pod=~"{{ target }}-canary.*"
+        }[{{ interval }}]
+      )
+    ) * 100
+---
+# ── 5. CPU Throttling Rate ────────────────────────────────────────────────────
+# Percentage of time CPU is being throttled for canary pods.
+# High throttling can indicate under-resourced containers or a resource leak.
+# Rollback threshold: > 25%
+apiVersion: flagger.app/v1beta1
+kind: MetricTemplate
+metadata:
+  name: cpu-throttle-rate
+  namespace: gistpin
+spec:
+  provider:
+    type: prometheus
+    address: http://prometheus.monitoring:9090
+  query: |
+    sum(
+      rate(
+        container_cpu_cfs_throttled_seconds_total{
+          namespace="{{ namespace }}",
+          pod=~"{{ target }}-canary.*",
+          container!=""
+        }[{{ interval }}]
+      )
+    )
+    /
+    sum(
+      rate(
+        container_cpu_cfs_periods_total{
+          namespace="{{ namespace }}",
+          pod=~"{{ target }}-canary.*",
+          container!=""
+        }[{{ interval }}]
+      )
+    ) * 100

--- a/infrastructure/scripts/provision-env.sh
+++ b/infrastructure/scripts/provision-env.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# provision-env.sh — spin up an ephemeral GistPin test environment on demand
+# Usage: ./provision-env.sh [ENV_NAME] [--region us-east-1]
+# Example: ./provision-env.sh pr-123 --region eu-west-1
+set -euo pipefail
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TF_DIR="${REPO_ROOT}/infrastructure/terraform/ephemeral-env"
+REGISTRY_FILE="${SCRIPT_DIR}/.env-registry"
+
+ENV_NAME="${1:-}"
+REGION="us-east-1"
+PROJECT="gistpin"
+
+# Parse optional flags
+shift 1 2>/dev/null || true
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --region) REGION="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "${ENV_NAME}" ]]; then
+  echo "Usage: $0 <env-name> [--region <aws-region>]" >&2
+  exit 1
+fi
+
+# Sanitise env name (lowercase alphanumeric + hyphens, max 20 chars)
+ENV_NAME="${ENV_NAME,,}"
+ENV_NAME="${ENV_NAME//[^a-z0-9-]/\-}"
+ENV_NAME="${ENV_NAME:0:20}"
+
+echo "==> Provisioning ephemeral environment: ${ENV_NAME} (region: ${REGION})"
+
+# ── Prerequisites check ───────────────────────────────────────────────────────
+for cmd in terraform aws kubectl; do
+  command -v "${cmd}" &>/dev/null || { echo "ERROR: ${cmd} not found in PATH" >&2; exit 1; }
+done
+
+# ── Terraform workspace & apply ───────────────────────────────────────────────
+echo "--> Initialising Terraform..."
+terraform -chdir="${TF_DIR}" init -input=false -reconfigure \
+  -backend-config="key=${PROJECT}/ephemeral/${ENV_NAME}/terraform.tfstate"
+
+echo "--> Selecting / creating workspace: ${ENV_NAME}"
+terraform -chdir="${TF_DIR}" workspace select "${ENV_NAME}" 2>/dev/null \
+  || terraform -chdir="${TF_DIR}" workspace new "${ENV_NAME}"
+
+echo "--> Planning..."
+terraform -chdir="${TF_DIR}" plan -input=false \
+  -var="environment=${ENV_NAME}" \
+  -var="region=${REGION}" \
+  -var="project_name=${PROJECT}" \
+  -out="${TF_DIR}/${ENV_NAME}.tfplan"
+
+echo "--> Applying..."
+terraform -chdir="${TF_DIR}" apply -input=false -auto-approve "${TF_DIR}/${ENV_NAME}.tfplan"
+
+# ── Capture outputs ───────────────────────────────────────────────────────────
+KUBECONFIG_B64="$(terraform -chdir="${TF_DIR}" output -raw kubeconfig_base64 2>/dev/null || echo '')"
+COST_TAG="ephemeral/${ENV_NAME}"
+CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# ── Register environment ──────────────────────────────────────────────────────
+echo "--> Registering environment in ${REGISTRY_FILE}"
+touch "${REGISTRY_FILE}"
+# Remove any existing entry for this env
+grep -v "^${ENV_NAME}|" "${REGISTRY_FILE}" > "${REGISTRY_FILE}.tmp" && mv "${REGISTRY_FILE}.tmp" "${REGISTRY_FILE}" || true
+echo "${ENV_NAME}|${REGION}|${CREATED_AT}|${COST_TAG}|active" >> "${REGISTRY_FILE}"
+
+# ── Optional: update kubeconfig ───────────────────────────────────────────────
+if [[ -n "${KUBECONFIG_B64}" ]]; then
+  KUBECONFIG_FILE="${SCRIPT_DIR}/.kubeconfig-${ENV_NAME}"
+  echo "${KUBECONFIG_B64}" | base64 -d > "${KUBECONFIG_FILE}"
+  chmod 600 "${KUBECONFIG_FILE}"
+  echo "--> Kubeconfig written to ${KUBECONFIG_FILE}"
+  echo "    Export: export KUBECONFIG=${KUBECONFIG_FILE}"
+fi
+
+echo "==> Environment '${ENV_NAME}' is ready."
+echo "    Teardown: ${SCRIPT_DIR}/teardown-env.sh ${ENV_NAME}"

--- a/infrastructure/scripts/teardown-env.sh
+++ b/infrastructure/scripts/teardown-env.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# teardown-env.sh — destroy an ephemeral GistPin test environment
+# Usage: ./teardown-env.sh <env-name>
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TF_DIR="${REPO_ROOT}/infrastructure/terraform/ephemeral-env"
+REGISTRY_FILE="${SCRIPT_DIR}/.env-registry"
+
+ENV_NAME="${1:-}"
+if [[ -z "${ENV_NAME}" ]]; then
+  echo "Usage: $0 <env-name>" >&2
+  exit 1
+fi
+
+echo "==> Tearing down ephemeral environment: ${ENV_NAME}"
+
+# ── Lookup region from registry ───────────────────────────────────────────────
+REGION="us-east-1"
+if [[ -f "${REGISTRY_FILE}" ]]; then
+  REG_LINE="$(grep "^${ENV_NAME}|" "${REGISTRY_FILE}" || true)"
+  if [[ -n "${REG_LINE}" ]]; then
+    REGION="$(echo "${REG_LINE}" | cut -d'|' -f2)"
+  fi
+fi
+
+# ── Select Terraform workspace ────────────────────────────────────────────────
+terraform -chdir="${TF_DIR}" init -input=false -reconfigure \
+  -backend-config="key=gistpin/ephemeral/${ENV_NAME}/terraform.tfstate"
+
+terraform -chdir="${TF_DIR}" workspace select "${ENV_NAME}" 2>/dev/null \
+  || { echo "Workspace ${ENV_NAME} not found — nothing to destroy." ; exit 0; }
+
+# ── Destroy ───────────────────────────────────────────────────────────────────
+echo "--> Destroying resources..."
+terraform -chdir="${TF_DIR}" destroy -input=false -auto-approve \
+  -var="environment=${ENV_NAME}" \
+  -var="region=${REGION}" \
+  -var="project_name=gistpin"
+
+# ── Switch back to default and delete workspace ───────────────────────────────
+terraform -chdir="${TF_DIR}" workspace select default
+terraform -chdir="${TF_DIR}" workspace delete "${ENV_NAME}"
+
+# ── Remove from registry ──────────────────────────────────────────────────────
+if [[ -f "${REGISTRY_FILE}" ]]; then
+  grep -v "^${ENV_NAME}|" "${REGISTRY_FILE}" > "${REGISTRY_FILE}.tmp" \
+    && mv "${REGISTRY_FILE}.tmp" "${REGISTRY_FILE}" || true
+  echo "--> Removed '${ENV_NAME}' from registry."
+fi
+
+# ── Clean up kubeconfig ───────────────────────────────────────────────────────
+KUBECONFIG_FILE="${SCRIPT_DIR}/.kubeconfig-${ENV_NAME}"
+[[ -f "${KUBECONFIG_FILE}" ]] && rm -f "${KUBECONFIG_FILE}" && echo "--> Removed kubeconfig."
+
+echo "==> Environment '${ENV_NAME}' destroyed successfully."

--- a/infrastructure/security/iac-scan-rules.yml
+++ b/infrastructure/security/iac-scan-rules.yml
@@ -1,0 +1,64 @@
+# Checkov IaC scan configuration for GistPin
+# https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html
+
+# Checks to enforce (block on failure)
+check:
+  # Terraform — encryption & access
+  - CKV_AWS_19   # S3 encryption enabled
+  - CKV_AWS_20   # S3 bucket not publicly accessible
+  - CKV_AWS_21   # S3 versioning enabled
+  - CKV_AWS_52   # MFA delete on S3
+  - CKV_AWS_86   # CloudFront HTTPS only
+  - CKV_AWS_2    # ALB HTTPS listener
+  - CKV_AWS_91   # ALB access logging
+  - CKV_AWS_17   # RDS not publicly accessible
+  - CKV_AWS_16   # RDS encryption at rest
+  - CKV_AWS_129  # RDS deletion protection
+  - CKV_AWS_23   # Security group no unrestricted ingress on SSH
+  - CKV_AWS_25   # Security group no unrestricted ingress on RDP
+  - CKV_AWS_8    # EC2 IMDSv2
+  - CKV_AWS_79   # EKS secrets envelope encryption
+  - CKV_AWS_58   # EKS cluster logging enabled
+  - CKV2_AWS_5   # Security group attached to resource
+
+  # Kubernetes — pod security
+  - CKV_K8S_1    # Do not admit root containers
+  - CKV_K8S_6    # Do not admit privileged containers
+  - CKV_K8S_8    # Liveness probe configured
+  - CKV_K8S_9    # Readiness probe configured
+  - CKV_K8S_11   # CPU limits set
+  - CKV_K8S_12   # Memory limits set
+  - CKV_K8S_14   # Image tag not 'latest'
+  - CKV_K8S_15   # Image pull policy IfNotPresent or Always with digest
+  - CKV_K8S_20   # Containers do not run as root
+  - CKV_K8S_21   # Default namespace not used
+  - CKV_K8S_28   # No host network
+  - CKV_K8S_30   # No host PID
+  - CKV_K8S_32   # Seccomp profile set
+  - CKV_K8S_35   # ServiceAccount tokens not automounted unnecessarily
+  - CKV_K8S_37   # Minimise capabilities — drop ALL
+  - CKV_K8S_43   # Read-only root filesystem
+
+# Checks to skip (known accepted risks, document reason)
+skip-check:
+  - CKV_AWS_7    # KMS key rotation — handled by external rotation schedule
+  - CKV_K8S_26   # hostPath — required by Falco DaemonSet
+
+# Output settings
+output: sarif
+compact: true
+soft-fail-on:
+  - LOW
+  - MEDIUM
+
+# Directories to scan
+directory:
+  - infrastructure/terraform
+  - infrastructure/k8s
+
+# Exclude generated/vendor paths
+exclude-path:
+  - infrastructure/terraform/.terraform
+  - infrastructure/k8s/keda/install.yaml   # upstream manifest, not owned
+  - infrastructure/k8s/falco/install.yaml  # upstream manifest, not owned
+  - infrastructure/k8s/vpa/install.yaml    # upstream manifest, not owned

--- a/infrastructure/security/sast-config.yml
+++ b/infrastructure/security/sast-config.yml
@@ -1,0 +1,63 @@
+# Semgrep SAST configuration for GistPin
+# https://semgrep.dev/docs/semgrep-app/getting-started/
+
+rules:
+  - id: no-hardcoded-secrets
+    patterns:
+      - pattern: |
+          $KEY = "..."
+    message: "Potential hardcoded secret in $KEY"
+    languages: [typescript, javascript]
+    severity: ERROR
+    metadata:
+      category: security
+      cwe: "CWE-798"
+
+  - id: no-eval
+    pattern: eval(...)
+    message: "Use of eval() is unsafe"
+    languages: [typescript, javascript]
+    severity: ERROR
+    metadata:
+      category: security
+      cwe: "CWE-95"
+
+  - id: sql-injection-typeorm
+    patterns:
+      - pattern: |
+          $REPO.query("..." + $INPUT, ...)
+    message: "Possible SQL injection via string concatenation"
+    languages: [typescript]
+    severity: ERROR
+    metadata:
+      category: security
+      cwe: "CWE-89"
+
+  - id: unsafe-regex
+    patterns:
+      - pattern: new RegExp($VAR)
+    message: "Dynamic RegExp may lead to ReDoS"
+    languages: [typescript, javascript]
+    severity: WARNING
+    metadata:
+      category: security
+      cwe: "CWE-1333"
+
+# Rulesets to include from Semgrep registry
+configs:
+  - p/typescript
+  - p/nodejs
+  - p/secrets
+  - p/owasp-top-ten
+
+# Paths to exclude from scanning
+exclude:
+  - node_modules/
+  - "**/*.min.js"
+  - "**/*.d.ts"
+  - dist/
+  - build/
+  - coverage/
+
+# Severity threshold — fail on ERROR findings
+severity: ERROR

--- a/infrastructure/terraform/ephemeral-env/kubeconfig.tpl
+++ b/infrastructure/terraform/ephemeral-env/kubeconfig.tpl
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Config
+clusters:
+  - cluster:
+      server: ${cluster_endpoint}
+      certificate-authority-data: ${cluster_ca}
+    name: ${cluster_name}
+contexts:
+  - context:
+      cluster: ${cluster_name}
+      user: ${cluster_name}
+    name: ${cluster_name}
+current-context: ${cluster_name}
+users:
+  - name: ${cluster_name}
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: aws
+        args:
+          - eks
+          - get-token
+          - --cluster-name
+          - ${cluster_name}
+          - --region
+          - ${region}

--- a/infrastructure/terraform/ephemeral-env/main.tf
+++ b/infrastructure/terraform/ephemeral-env/main.tf
@@ -1,0 +1,158 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.27"
+    }
+  }
+
+  backend "s3" {
+    bucket  = "gistpin-tf-state"
+    region  = "us-east-1"
+    encrypt = true
+    # key is injected per-env: key=gistpin/ephemeral/<env>/terraform.tfstate
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Project     = var.project_name
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      CostCenter  = "ephemeral/${var.environment}"
+      AutoDestroy = "true"
+    }
+  }
+}
+
+# ── VPC (re-use default VPC for ephemeral envs to keep costs low) ─────────────
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+# ── Security group for EKS nodes ──────────────────────────────────────────────
+resource "aws_security_group" "nodes" {
+  name_prefix = "${var.project_name}-${var.environment}-nodes-"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    self      = true
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  lifecycle { create_before_destroy = true }
+}
+
+# ── EKS cluster ───────────────────────────────────────────────────────────────
+resource "aws_eks_cluster" "ephemeral" {
+  name     = "${var.project_name}-${var.environment}"
+  role_arn = aws_iam_role.eks_cluster.arn
+  version  = var.kubernetes_version
+
+  vpc_config {
+    subnet_ids              = data.aws_subnets.default.ids
+    security_group_ids      = [aws_security_group.nodes.id]
+    endpoint_private_access = true
+    endpoint_public_access  = true
+  }
+
+  enabled_cluster_log_types = ["api", "audit", "authenticator"]
+
+  depends_on = [aws_iam_role_policy_attachment.eks_cluster_policy]
+}
+
+resource "aws_eks_node_group" "default" {
+  cluster_name    = aws_eks_cluster.ephemeral.name
+  node_group_name = "default"
+  node_role_arn   = aws_iam_role.eks_nodes.arn
+  subnet_ids      = data.aws_subnets.default.ids
+  instance_types  = [var.node_instance_type]
+
+  scaling_config {
+    desired_size = var.node_count
+    min_size     = 1
+    max_size     = var.node_count + 1
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.eks_worker_node_policy,
+    aws_iam_role_policy_attachment.eks_cni_policy,
+    aws_iam_role_policy_attachment.ecr_read_only,
+  ]
+}
+
+# ── IAM roles ─────────────────────────────────────────────────────────────────
+resource "aws_iam_role" "eks_cluster" {
+  name_prefix        = "${var.project_name}-${var.environment}-eks-cluster-"
+  assume_role_policy = data.aws_iam_policy_document.eks_assume.json
+}
+
+data "aws_iam_policy_document" "eks_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["eks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "eks_cluster_policy" {
+  role       = aws_iam_role.eks_cluster.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+}
+
+resource "aws_iam_role" "eks_nodes" {
+  name_prefix        = "${var.project_name}-${var.environment}-eks-nodes-"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume.json
+}
+
+data "aws_iam_policy_document" "ec2_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "eks_worker_node_policy" {
+  role       = aws_iam_role.eks_nodes.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "eks_cni_policy" {
+  role       = aws_iam_role.eks_nodes.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role_policy_attachment" "ecr_read_only" {
+  role       = aws_iam_role.eks_nodes.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}

--- a/infrastructure/terraform/ephemeral-env/outputs.tf
+++ b/infrastructure/terraform/ephemeral-env/outputs.tf
@@ -1,0 +1,25 @@
+output "cluster_name" {
+  description = "EKS cluster name"
+  value       = aws_eks_cluster.ephemeral.name
+}
+
+output "cluster_endpoint" {
+  description = "EKS API server endpoint"
+  value       = aws_eks_cluster.ephemeral.endpoint
+}
+
+output "kubeconfig_base64" {
+  description = "Base64-encoded kubeconfig for the ephemeral cluster"
+  sensitive   = true
+  value = base64encode(templatefile("${path.module}/kubeconfig.tpl", {
+    cluster_name     = aws_eks_cluster.ephemeral.name
+    cluster_endpoint = aws_eks_cluster.ephemeral.endpoint
+    cluster_ca       = aws_eks_cluster.ephemeral.certificate_authority[0].data
+    region           = var.region
+  }))
+}
+
+output "cost_tag" {
+  description = "Cost-tracking tag value for this environment"
+  value       = "ephemeral/${var.environment}"
+}

--- a/infrastructure/terraform/ephemeral-env/variables.tf
+++ b/infrastructure/terraform/ephemeral-env/variables.tf
@@ -1,0 +1,34 @@
+variable "environment" {
+  description = "Ephemeral environment name (e.g. pr-123)"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project_name" {
+  description = "Project name prefix for resource naming"
+  type        = string
+  default     = "gistpin"
+}
+
+variable "kubernetes_version" {
+  description = "EKS Kubernetes version"
+  type        = string
+  default     = "1.29"
+}
+
+variable "node_instance_type" {
+  description = "EC2 instance type for EKS nodes (keep small for ephemerals)"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "node_count" {
+  description = "Number of EKS worker nodes"
+  type        = number
+  default     = 2
+}


### PR DESCRIPTION
## Summary

Resolves four open infrastructure issues assigned to @phertyameen:

### #568 — Continuous Compliance Scanning
- `infrastructure/ci/compliance-scan.yml` — GitHub Actions workflow on every push/PR and daily: SAST (Semgrep), IaC scanning (Checkov for Terraform + K8s), container baseline (Trivy), PR comment with violations summary.
- `infrastructure/security/sast-config.yml` — Semgrep config with custom rules + `p/typescript`, `p/secrets`, `p/owasp-top-ten`.
- `infrastructure/security/iac-scan-rules.yml` — Checkov check/skip list for S3, RDS, EKS, ALB, K8s pod-security; SARIF output; accepted skip reasons documented.

### #569 — Kubernetes Admission Controller
- `infrastructure/k8s/admission-controller/webhook.yaml` — ValidatingWebhookConfiguration (blocks), MutatingWebhookConfiguration (injects defaults), Deployment (2 replicas, non-root, read-only FS), Service, TLS stub for cert-manager.
- `infrastructure/k8s/admission-controller/handler.go` — Go webhook server: resource limits, privileged, host-network, registry allowlist, required labels enforcement; seccomp injection; structured JSON audit logging.
- `infrastructure/k8s/admission-controller/policies.yaml` — Runtime-loaded policy definitions.

### #570 — Infrastructure Test Environment Provisioner
- `infrastructure/scripts/provision-env.sh` — One-command env creation: Terraform workspace isolation, cost tagging, kubeconfig generation, env registry.
- `infrastructure/scripts/teardown-env.sh` — Full destroy, workspace deletion, registry and kubeconfig cleanup.
- `infrastructure/terraform/ephemeral-env/` — Parameterised EKS + IAM Terraform module with per-env S3 state backend and kubeconfig template output.

### #571 — Progressive Delivery with Flagger
- `infrastructure/k8s/flagger/install.yaml` — Flagger v1.37 (Istio provider), CRDs, RBAC, Slack AlertProvider.
- `infrastructure/k8s/flagger/canary-backend.yaml` — Canary: 10% step-weight, 50% max, threshold 3 for rollback, smoke-test + load-test webhooks, rollback notification.
- `infrastructure/k8s/flagger/metric-templates.yaml` — 5 Prometheus MetricTemplates: HTTP error rate, P99 latency, DB query latency (P95), Soroban tx success rate, CPU throttle rate.

Closes #568
Closes #569
Closes #570
Closes #571