### PR TITLE
feat: setup cross-cluster service communication (#575)

### DIFF
--- a/infrastructure/docs/cross-cluster.md
+++ b/infrastructure/docs/cross-cluster.md
@@ -1,0 +1,215 @@
+# Cross-Cluster Service Communication
+
+Architecture, setup, DNS, failover, and troubleshooting for GistPin's
+cross-cluster networking layer, built on Submariner + MCS API.
+
+---
+
+## Architecture Overview
+
+    Cluster A (primary)                  Cluster B (secondary)
+    +---------------------------+        +---------------------------+
+    | gistpin namespace         |        | gistpin namespace         |
+    |  gistpin-api   :8080      |        |  gistpin-api   :8080      |
+    |  gistpin-auth  :8080      |        |  gistpin-auth  :8080      |
+    |  gistpin-storage :8080    |        |  gistpin-storage :8080    |
+    +---------------------------+        +---------------------------+
+    | submariner-gateway (NAT-T)|<------>| submariner-gateway (NAT-T)|
+    | submariner-routeagent     |        | submariner-routeagent     |
+    +---------------------------+        +---------------------------+
+               |                                      |
+               +----------[ Broker Cluster ]-----------+
+                       submariner-k8s-broker NS
+                       (endpoint + cluster registry)
+
+Traffic between clusters travels through encrypted IPsec tunnels
+(libreswan by default). Lighthouse provides DNS-based service
+discovery under the .clusterset.local domain.
+
+---
+
+## Components
+
+| Component            | Role                                              |
+|----------------------|---------------------------------------------------|
+| Submariner Broker    | Central registry for cluster endpoints            |
+| Submariner Gateway   | IPsec tunnel termination, one node per cluster    |
+| RouteAgent           | Programs pod routes on every node                 |
+| Lighthouse (DNS)     | Resolves *.svc.clusterset.local across clusters   |
+| MCS ServiceExport    | Marks a service for cross-cluster advertisement   |
+| MCS ServiceImport    | Consumed service representation on remote cluster |
+
+---
+
+## Prerequisites
+
+- Kubernetes 1.27+ on all clusters
+- Non-overlapping pod and service CIDRs across clusters (or globalnet enabled)
+- UDP 4500, 500, and 4800 open between gateway nodes
+- OLM installed on all clusters (operator-framework/operator-lifecycle-manager)
+- subctl CLI installed locally (brew install submariner-io/submariner/subctl)
+
+---
+
+## Setup
+
+### 1. Deploy the Broker
+
+Run once on the designated broker cluster:
+
+    subctl deploy-broker \
+      --kubeconfig ~/.kube/broker-cluster.yaml \
+      --service-discovery
+
+This creates the submariner-k8s-broker namespace and outputs
+a broker-info.subm file used in the next step.
+
+### 2. Label gateway nodes on each member cluster
+
+    kubectl label node <gateway-node-name> submariner.io/gateway=true
+
+### 3. Join each member cluster to the broker
+
+    subctl join broker-info.subm \
+      --kubeconfig ~/.kube/cluster-a.yaml \
+      --clusterid gistpin-cluster-a \
+      --cable-driver libreswan \
+      --natt
+
+    subctl join broker-info.subm \
+      --kubeconfig ~/.kube/cluster-b.yaml \
+      --clusterid gistpin-cluster-b \
+      --cable-driver libreswan \
+      --natt
+
+### 4. Apply the Submariner CR and service exports
+
+    kubectl apply -f infrastructure/k8s/cross-cluster/submariner.yaml
+    kubectl apply -f infrastructure/k8s/cross-cluster/service-export.yaml
+
+### 5. Patch CoreDNS
+
+The submariner.yaml ConfigMap patch forwards .clusterset.local
+queries to the Lighthouse agent. After applying, restart CoreDNS:
+
+    kubectl rollout restart deployment/coredns -n kube-system
+
+---
+
+## DNS Reference
+
+Once a ServiceExport is created, Lighthouse registers the service
+under the following pattern:
+
+    <service>.<namespace>.svc.clusterset.local
+
+| Service               | Cross-cluster DNS name                              |
+|-----------------------|-----------------------------------------------------|
+| gistpin-api           | gistpin-api.gistpin.svc.clusterset.local            |
+| gistpin-auth          | gistpin-auth.gistpin.svc.clusterset.local           |
+| gistpin-storage       | gistpin-storage.gistpin.svc.clusterset.local        |
+| gistpin-notifications | gistpin-notifications.gistpin.svc.clusterset.local  |
+| gistpin-db (headless) | gistpin-db.gistpin.svc.clusterset.local             |
+
+DNS queries are load-balanced across all healthy endpoints in the
+clusterset using round-robin by default.
+
+---
+
+## Secure Tunnels
+
+Tunnels use IPsec (libreswan) with a pre-shared key stored in the
+submariner-ipsec-psk Secret, managed by sealed-secrets. To rotate:
+
+    NEW_PSK=$(openssl rand -base64 64 | tr -d '\n')
+
+    kubectl create secret generic submariner-ipsec-psk \
+      --from-literal=psk="$NEW_PSK" \
+      --dry-run=client -o yaml | kubeseal | \
+      kubectl apply -f -
+
+    kubectl rollout restart daemonset/submariner-gateway -n submariner-operator
+
+---
+
+## Failover Routing
+
+Lighthouse performs automatic failover at the DNS layer:
+
+1. Each exported service endpoint is health-checked by the
+   Lighthouse agent every 30 seconds.
+2. If a cluster's endpoint fails the health check, Lighthouse
+   removes it from DNS responses within one TTL cycle (30s default).
+3. Traffic naturally shifts to remaining healthy endpoints on the
+   next DNS resolution.
+
+To test failover manually:
+
+    kubectl cordon <gateway-node-cluster-b>
+    kubectl delete pod -n submariner-operator -l app=submariner-gateway
+
+    kubectl run -it dns-test --image=busybox --restart=Never -- \
+      nslookup gistpin-api.gistpin.svc.clusterset.local
+
+---
+
+## Service Mirroring
+
+Submariner Lighthouse mirrors exported services as local ServiceImport
+objects. To inspect what is mirrored on a cluster:
+
+    kubectl get serviceimport -n gistpin
+    kubectl describe serviceimport gistpin-api -n gistpin
+
+The mirrored VIP is stable within a cluster and can be used directly
+in service-to-service calls as an alternative to DNS:
+
+    kubectl get serviceimport gistpin-api -n gistpin \
+      -o jsonpath='{.spec.ips[0]}'
+
+---
+
+## Verification
+
+    subctl show connections
+    subctl show endpoints
+
+    kubectl run -it --rm dns-test --image=busybox --restart=Never -- \
+      nslookup gistpin-api.gistpin.svc.clusterset.local
+
+    subctl diagnose all
+
+---
+
+## Troubleshooting
+
+### Tunnel is not establishing
+
+    kubectl logs -n submariner-operator -l app=submariner-gateway --tail=100
+    nc -vzu <remote-gateway-ip> 4500
+
+Common causes: NAT hairpin not enabled (natEnabled: false when NAT
+is present), security group rules blocking UDP 4500/500, or mismatched
+PSK between clusters.
+
+### DNS not resolving .clusterset.local
+
+    kubectl get pods -n submariner-operator -l app=submariner-lighthouse-agent
+    kubectl get configmap coredns -n kube-system -o yaml | grep clusterset
+
+If the forward stanza is missing, re-apply submariner.yaml and
+restart CoreDNS.
+
+### ServiceExport not propagating
+
+    kubectl describe serviceexport gistpin-api -n gistpin
+    subctl show brokers
+
+---
+
+## Related Docs
+
+- service-mesh.md -- Istio config; mTLS between pods
+- network-monitoring.md -- tunnel latency dashboards
+- egress-policy.md -- outbound traffic rules
+- disaster-recovery.md -- full cluster failover runbook

--- a/infrastructure/k8s/cross-cluster/service-export.yaml
+++ b/infrastructure/k8s/cross-cluster/service-export.yaml
@@ -1,0 +1,193 @@
+# infrastructure/k8s/cross-cluster/service-export.yaml
+# MCS API service exports for GistPin cross-cluster discovery
+# Covers: ServiceExport, ServiceImport, and example exports per service
+
+---
+# ServiceExport CRD (MCS API - multicluster.x-k8s.io)
+# Install this CRD on every member cluster
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceexports.multicluster.x-k8s.io
+  labels:
+    app.kubernetes.io/managed-by: submariner
+spec:
+  group: multicluster.x-k8s.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+            status:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+      subresources:
+        status: {}
+  scope: Namespaced
+  names:
+    plural: serviceexports
+    singular: serviceexport
+    kind: ServiceExport
+    shortNames:
+      - svcex
+
+---
+# ServiceImport CRD
+# Automatically created by Lighthouse on consuming clusters;
+# included here for reference and manual override scenarios
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceimports.multicluster.x-k8s.io
+  labels:
+    app.kubernetes.io/managed-by: submariner
+spec:
+  group: multicluster.x-k8s.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum: [ClusterSetIP, Headless]
+                ports:
+                  type: array
+                  items:
+                    type: object
+                ips:
+                  type: array
+                  items:
+                    type: string
+            status:
+              type: object
+      subresources:
+        status: {}
+  scope: Namespaced
+  names:
+    plural: serviceimports
+    singular: serviceimport
+    kind: ServiceImport
+    shortNames:
+      - svcim
+
+---
+# Export the GistPin API service so other clusters can reach it
+# DNS: gistpin-api.gistpin.svc.clusterset.local
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: ServiceExport
+metadata:
+  name: gistpin-api
+  namespace: gistpin
+  labels:
+    app: gistpin-api
+    app.kubernetes.io/part-of: gistpin
+
+---
+# Export the auth service
+# DNS: gistpin-auth.gistpin.svc.clusterset.local
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: ServiceExport
+metadata:
+  name: gistpin-auth
+  namespace: gistpin
+  labels:
+    app: gistpin-auth
+    app.kubernetes.io/part-of: gistpin
+
+---
+# Export the gist storage service
+# DNS: gistpin-storage.gistpin.svc.clusterset.local
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: ServiceExport
+metadata:
+  name: gistpin-storage
+  namespace: gistpin
+  labels:
+    app: gistpin-storage
+    app.kubernetes.io/part-of: gistpin
+
+---
+# Export the notification service
+# DNS: gistpin-notifications.gistpin.svc.clusterset.local
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: ServiceExport
+metadata:
+  name: gistpin-notifications
+  namespace: gistpin
+  labels:
+    app: gistpin-notifications
+    app.kubernetes.io/part-of: gistpin
+
+---
+# Headless ServiceImport example -- for stateful workloads (e.g. Postgres replicas)
+# that need per-pod DNS across clusters rather than a single VIP
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: ServiceImport
+metadata:
+  name: gistpin-db
+  namespace: gistpin
+  labels:
+    app: gistpin-db
+    app.kubernetes.io/part-of: gistpin
+spec:
+  type: Headless
+  ports:
+    - name: postgres
+      port: 5432
+      protocol: TCP
+
+---
+# NetworkPolicy: allow cross-cluster ingress to exported services
+# Submariner gateway pods are in submariner-operator namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cross-cluster-ingress
+  namespace: gistpin
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: gistpin
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: submariner-operator
+      ports:
+        - protocol: TCP
+          port: 8080    # API / HTTP
+        - protocol: TCP
+          port: 8443    # HTTPS
+        - protocol: TCP
+          port: 5432    # Postgres
+        - protocol: TCP
+          port: 6379    # Redis

--- a/infrastructure/k8s/cross-cluster/submariner.yaml
+++ b/infrastructure/k8s/cross-cluster/submariner.yaml
@@ -1,0 +1,237 @@
+# infrastructure/k8s/cross-cluster/submariner.yaml
+# Submariner cross-cluster networking setup for GistPin
+# Covers: Broker, Gateway, RouteAgent, Lighthouse DNS
+
+---
+# Namespace for all Submariner components
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: submariner-operator
+  labels:
+    app.kubernetes.io/managed-by: submariner
+
+---
+# Submariner Broker (deployed on the hub/broker cluster only)
+# The broker facilitates cluster discovery and endpoint exchange.
+apiVersion: submariner.io/v1alpha1
+kind: Broker
+metadata:
+  name: submariner-broker
+  namespace: submariner-k8s-broker
+spec:
+  globalnetEnabled: false          # enable if CIDR overlap exists between clusters
+  defaultCustomDomains: []
+  components:
+    - service-discovery
+    - connectivity
+
+---
+# Submariner operator subscription (OLM-based install)
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: submariner
+  namespace: submariner-operator
+spec:
+  channel: stable-0.17
+  name: submariner
+  source: operatorhubio-catalog
+  sourceNamespace: olm
+
+---
+# Submariner configuration per member cluster
+# Apply this on EACH member cluster (not the broker cluster).
+apiVersion: submariner.io/v1alpha1
+kind: Submariner
+metadata:
+  name: submariner
+  namespace: submariner-operator
+spec:
+  brokerK8sApiServer: "https://broker-cluster-api.gistpin.internal:6443"
+  brokerK8sApiServerToken: ""        # injected via sealed secret at deploy time
+  brokerK8sCA: ""                    # base64-encoded broker cluster CA
+  brokerK8sRemoteNamespace: submariner-k8s-broker
+  cableDriver: libreswan             # options: libreswan (default), wireguard, vxlan
+  clusterCIDR: "10.244.0.0/16"      # update per cluster
+  serviceCIDR: "10.96.0.0/12"       # update per cluster
+  clusterID: "gistpin-cluster-a"    # unique per member cluster
+  colorCodes: blue
+  debug: false
+  natEnabled: true                   # set false if clusters share a flat L3 network
+  namespace: submariner-operator
+  serviceDiscoveryEnabled: true
+
+  # Gateway node selection -- label nodes with
+  # submariner.io/gateway=true before applying
+  gatewayConfig:
+    aws:
+      instanceType: ""
+    azure:
+      instanceType: ""
+  loadBalancerEnabled: false
+
+---
+# Gateway DaemonSet (managed by the operator; shown here for reference/override)
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: submariner-gateway
+  namespace: submariner-operator
+  labels:
+    app: submariner-gateway
+spec:
+  selector:
+    matchLabels:
+      app: submariner-gateway
+  template:
+    metadata:
+      labels:
+        app: submariner-gateway
+    spec:
+      nodeSelector:
+        submariner.io/gateway: "true"
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+      hostNetwork: true
+      containers:
+        - name: submariner-gateway
+          image: quay.io/submariner/submariner-gateway:0.17.0
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["NET_ADMIN", "SYS_MODULE"]
+          env:
+            - name: CE_IPSEC_PSK
+              valueFrom:
+                secretKeyRef:
+                  name: submariner-ipsec-psk
+                  key: psk
+          ports:
+            - name: natt
+              containerPort: 4500
+              protocol: UDP
+            - name: isakmp
+              containerPort: 500
+              protocol: UDP
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+
+---
+# RouteAgent DaemonSet -- runs on ALL nodes to program routes for cross-cluster traffic
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: submariner-routeagent
+  namespace: submariner-operator
+  labels:
+    app: submariner-routeagent
+spec:
+  selector:
+    matchLabels:
+      app: submariner-routeagent
+  template:
+    metadata:
+      labels:
+        app: submariner-routeagent
+    spec:
+      hostNetwork: true
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: submariner-routeagent
+          image: quay.io/submariner/submariner-routeagent:0.17.0
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["NET_ADMIN", "SYS_MODULE"]
+          env:
+            - name: SUBMARINER_NAMESPACE
+              value: submariner-operator
+            - name: SUBMARINER_CLUSTERID
+              value: gistpin-cluster-a    # match Submariner CR clusterID
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+
+---
+# Lighthouse DNS (service-discovery component)
+# CoreDNS ConfigMap patch to forward .clusterset.local queries to Lighthouse
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health {
+          lameduck 5s
+        }
+        ready
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+          pods insecure
+          fallthrough in-addr.arpa ip6.arpa
+          ttl 30
+        }
+        # Forward clusterset.local to Lighthouse for cross-cluster DNS
+        forward clusterset.local 100.96.0.10 {
+          policy round_robin
+        }
+        prometheus :9153
+        forward . /etc/resolv.conf {
+          max_concurrent 1000
+        }
+        cache 30
+        loop
+        reload
+        loadbalance
+    }
+
+---
+# IPsec PSK secret (value injected by CI/sealed-secrets; do not hardcode)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: submariner-ipsec-psk
+  namespace: submariner-operator
+type: Opaque
+data:
+  psk: ""    # base64-encoded pre-shared key -- managed by sealed-secrets
+
+---
+# NetworkPolicy: allow Submariner control-plane ports
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-submariner-ports
+  namespace: submariner-operator
+spec:
+  podSelector:
+    matchLabels:
+      app: submariner-gateway
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: UDP
+          port: 4500    # NAT-T / ESP encapsulation
+        - protocol: UDP
+          port: 500     # IKE
+        - protocol: UDP
+          port: 4800    # Submariner cable health check
+        - protocol: TCP
+          port: 8080    # metrics


### PR DESCRIPTION
- Add submariner.yaml with Broker, Gateway, RouteAgent, Lighthouse DNS, IPsec PSK secret, and NetworkPolicy
- Add service-export.yaml with MCS CRDs, ServiceExports for all GistPin services, headless ServiceImport for Postgres, and cross-cluster NetworkPolicy
- Add cross-cluster.md covering architecture, setup, DNS reference, secure tunnels, failover routing, service mirroring, verification, and troubleshooting


closes #575 