### PR TITLE
feat: add Kubernetes ephemeral containers for debugging

### DIFF
--- a/infrastructure/docs/debugging-guide.md
+++ b/infrastructure/docs/debugging-guide.md
@@ -1,0 +1,275 @@
+# GistPin Ephemeral Containers Debugging Guide
+
+This guide covers using Kubernetes ephemeral containers for live debugging of GistPin pods.
+
+## Overview
+
+Ephemeral containers allow you to attach debug containers to running pods without modifying the original pod spec. This is invaluable for:
+
+- Debugging production issues without restarting pods
+- Inspecting network connectivity and DNS resolution
+- Analyzing running processes and resource usage
+- Testing connectivity to external services
+- Investigating application state and memory
+
+## Prerequisites
+
+- Kubernetes cluster v1.16+ with ephemeral containers feature enabled
+- `kubectl` configured with appropriate cluster access
+- Debug service account (`debug-sa`) with proper RBAC
+- Approved debug container images (see below)
+
+## Approved Debug Images
+
+| Image | Use Case |
+|-------|----------|
+| `nicolaka/netshoot:latest` | Network diagnostics (default) |
+| `busybox:latest` | Basic networking, DNS, file operations |
+| `curlimages/curl:latest` | HTTP/API testing |
+| `alpine:latest` | Lightweight general debugging |
+| `python:3.11-slim` | Python application debugging |
+| `node:18-slim` | Node.js application debugging |
+
+**Important**: Only approved images may be used in production namespaces. The `debug-pod.sh` script validates images against this list.
+
+## Quick Start
+
+### Debug a Pod
+
+```bash
+# Basic debug session
+./infrastructure/scripts/debug-pod.sh -p <pod-name> -n gistpin-prod
+
+# Use a specific image
+./infrastructure/scripts/debug-pod.sh -p <pod-name> -i busybox:latest
+
+# Non-interactive mode (logs only)
+./infrastructure/scripts/debug-pod.sh -p <pod-name> --non-interactive
+
+# Dry run (show what would happen)
+./infrastructure/scripts/debug-pod.sh -p <pod-name> --dry-run
+```
+
+### List Available Pods
+
+```bash
+kubectl get pods -n gistpin-prod
+```
+
+### List Approved Images
+
+```bash
+./infrastructure/scripts/debug-pod.sh --list-images
+```
+
+## RBAC Configuration
+
+The debug role (`infrastructure/k8s/rbac/debug-role.yaml`) grants the following permissions:
+
+### Namespace-scoped (gistpin)
+
+| Resource | Verbs |
+|----------|-------|
+| pods | get, list, watch |
+| pods/exec | create |
+| pods/attach | create |
+| pods/portforward | create |
+| pods/log | get |
+| pods/status | get |
+| pods/proxy | create |
+| services | get, list |
+| endpoints | get, list |
+| configmaps | get, list |
+
+### Cluster-scoped
+
+| Resource | Verbs |
+|----------|-------|
+| namespaces | get, list |
+| nodes | get, list |
+| pods | get, list, watch |
+| events | get, list |
+
+### Service Account
+
+- **Name**: `debug-sa`
+- **Namespace**: `gistpin-debug`
+- **Bindings**: RoleBinding (gistpin namespace) + ClusterRoleBinding (cluster-wide)
+
+## Deployment
+
+Apply the debug RBAC configuration:
+
+```bash
+kubectl apply -f infrastructure/k8s/rbac/debug-role.yaml
+```
+
+This creates:
+- `gistpin-debug` namespace
+- Debug configuration and scripts
+- Service account with proper RBAC
+- Audit logging configuration
+
+## Usage Examples
+
+### Network Debugging
+
+```bash
+# Debug network connectivity from a pod
+kubectl debug -it <pod-name> -n gistpin-prod --image=nicolaka/netshoot:latest
+
+# Inside the debug container:
+ping backend-service.gistpin-prod.svc.cluster.local
+nslookup api.stellar.org
+curl -v http://backend-service/health
+```
+
+### Process Inspection
+
+```bash
+# Attach debug container and inspect processes
+kubectl debug -it <pod-name> -n gistpin-prod --image=alpine:latest
+
+# Inside the debug container:
+ps aux
+top -bn1
+cat /proc/1/cmdline
+```
+
+### File System Debugging
+
+```bash
+# Access file system of running pod
+kubectl debug -it <pod-name> -n gistpin-prod --image=alpine:latest
+
+# Inside the debug container:
+ls -la /app/
+cat /app/config.json
+find / -name "*.log" 2>/dev/null
+```
+
+### Database Connectivity
+
+```bash
+# Test database connectivity
+kubectl debug -it <pod-name> -n gistpin-prod --image=postgres:15
+
+# Inside the debug container:
+psql $DATABASE_URL -c "SELECT 1"
+```
+
+## Audit Logging
+
+All debug sessions are logged to:
+
+```
+/var/log/gistpin/debug-audit.log
+```
+
+Log entries include:
+- Timestamp
+- Action (create, session start/end, cleanup)
+- User performing the action
+- Target namespace, pod, and container
+- Image used
+- Session status
+- Timeout configuration
+
+### Example Audit Log Entry
+
+```json
+{
+  "timestamp": "2024-01-15T10:30:00Z",
+  "action": "debug_session_start",
+  "user": "developer",
+  "namespace": "gistpin-prod",
+  "pod": "backend-abc123",
+  "container": "debug-1705312200",
+  "image": "nicolaka/netshoot:latest",
+  "status": "initiated",
+  "timeout": "3600"
+}
+```
+
+## Security Considerations
+
+### Container Security
+
+- Debug containers run with `SYS_PTRACE` capability for process inspection
+- Containers run as root (required for some debugging operations)
+- Resource limits are enforced (CPU: 200m, Memory: 128Mi)
+
+### Image Validation
+
+- Only pre-approved images may be used
+- Image validation occurs before container creation
+- Custom images require approval via configuration update
+
+### Access Control
+
+- Debug access is restricted to the `debug-sa` service account
+- RBAC limits operations to necessary actions only
+- Audit logging tracks all debug activities
+
+### Cleanup
+
+- Debug containers persist until pod termination
+- Use `--cleanup` flag to log cleanup actions
+- Monitor debug container count in production namespaces
+
+## Troubleshooting
+
+### "Ephemeral containers API not available"
+
+Ensure your cluster supports ephemeral containers (Kubernetes v1.16+). Check with:
+
+```bash
+kubectl api-resources | grep ephemeralcontainers
+```
+
+### "Image not in approved list"
+
+Only approved images can be used. Check the list:
+
+```bash
+./infrastructure/scripts/debug-pod.sh --list-images
+```
+
+To add images, update the `APPROVED_IMAGES` list in:
+- `infrastructure/k8s/rbac/debug-role.yaml` (ConfigMap)
+- `infrastructure/scripts/debug-pod.sh` (script variable)
+
+### "Permission denied"
+
+Ensure the debug RBAC is applied:
+
+```bash
+kubectl apply -f infrastructure/k8s/rbac/debug-role.yaml
+kubectl get clusterrole debug-cluster-role
+kubectl get rolebinding debug-rolebinding -n gistpin
+```
+
+### "Pod not found"
+
+Verify the pod exists and you have access:
+
+```bash
+kubectl get pods -n <namespace> | grep <pod-name>
+```
+
+## Best Practices
+
+1. **Use the default image** (`nicolaka/netshoot:latest`) unless you need specific tools
+2. **Set appropriate timeouts** to prevent orphaned debug containers
+3. **Clean up** after debugging sessions
+4. **Review audit logs** regularly for security compliance
+5. **Use dry-run mode** to verify actions before execution
+6. **Document findings** before terminating debug sessions
+7. **Limit debug sessions** in production to minimize resource impact
+
+## Related Documentation
+
+- [Kubernetes Ephemeral Containers](https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/)
+- [kubectl debug](https://kubernetes.io/docs/tasks/debug/debug-container/kubernetes-debugging-running-pod/)
+- [GistPin Security Hardening](./security-hardening.md)
+- [GistPin Incident Response](./incident-response.md)

--- a/infrastructure/k8s/rbac/debug-role.yaml
+++ b/infrastructure/k8s/rbac/debug-role.yaml
@@ -1,0 +1,201 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gistpin-debug
+  labels:
+    app: gistpin
+    component: debug
+    purpose: ephemeral-debugging
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: debug-config
+  namespace: gistpin-debug
+  labels:
+    app: gistpin
+    component: debug-config
+  annotations:
+    description: "Configuration for ephemeral debug containers"
+data:
+  APPROVED_IMAGES: |
+    busybox:latest
+    nicolaka/netshoot:latest
+    curlimages/curl:latest
+    alpine:latest
+    python:3.11-slim
+    node:18-slim
+  MAX_DEBUG_CONTAINERS: "10"
+  MAX_DEBUG_TTL: "3600"
+  AUDIT_ENABLED: "true"
+  AUDIT_LOG_PATH: "/var/log/gistpin/debug-audit.log"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: debug-scripts
+  namespace: gistpin-debug
+  labels:
+    app: gistpin
+    component: debug-scripts
+  annotations:
+    description: "Debug helper scripts mounted into debug containers"
+data:
+  health-check.sh: |
+    #!/bin/sh
+    echo "=== Pod Debug Health Check ==="
+    echo "Hostname: $(hostname)"
+    echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo ""
+    echo "=== Network ==="
+    cat /etc/resolv.conf 2>/dev/null || echo "No resolv.conf"
+    echo ""
+    echo "=== Disk ==="
+    df -h 2>/dev/null || echo "df not available"
+    echo ""
+    echo "=== Processes ==="
+    ps aux 2>/dev/null || echo "ps not available"
+  network-diag.sh: |
+    #!/bin/sh
+    echo "=== Network Diagnostics ==="
+    TARGET="${1:-kubernetes.default.svc.cluster.local}"
+    echo "Target: $TARGET"
+    echo ""
+    echo "--- DNS Resolution ---"
+    nslookup "$TARGET" 2>/dev/null || dig "$TARGET" 2>/dev/null || echo "DNS tools not available"
+    echo ""
+    echo "--- Connectivity ---"
+    ping -c 3 "$TARGET" 2>/dev/null || echo "ping not available"
+    echo ""
+    echo "--- HTTP Check ---"
+    curl -sf -o /dev/null -w "HTTP %{http_code}\n" "http://${TARGET}/health" 2>/dev/null || echo "curl not available or endpoint unreachable"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: debug-sa
+  namespace: gistpin-debug
+  labels:
+    app: gistpin
+    component: debug
+  annotations:
+    description: "Service account for ephemeral debug containers"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: debug-role
+  namespace: gistpin
+  labels:
+    app: gistpin
+    component: debug-rbac
+  annotations:
+    description: "RBAC role for ephemeral container operations"
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/attach"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/portforward"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods/proxy"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list"]
+  - apiGroups: ["security.openshift.io"]
+    resourceNames: ["privileged"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["use"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: debug-rolebinding
+  namespace: gistpin
+  labels:
+    app: gistpin
+    component: debug-rbac
+  annotations:
+    description: "Binds debug role to debug service account"
+subjects:
+  - kind: ServiceAccount
+    name: debug-sa
+    namespace: gistpin-debug
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: debug-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: debug-cluster-role
+  labels:
+    app: gistpin
+    component: debug-rbac
+  annotations:
+    description: "Cluster-wide role for cross-namespace debugging"
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: debug-cluster-rolebinding
+  labels:
+    app: gistpin
+    component: debug-rbac
+  annotations:
+    description: "Binds cluster debug role to debug service account"
+subjects:
+  - kind: ServiceAccount
+    name: debug-sa
+    namespace: gistpin-debug
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: debug-cluster-role
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: debug-audit-secret
+  namespace: gistpin-debug
+  labels:
+    app: gistpin
+    component: debug-audit
+  annotations:
+    description: "Secret for debug audit configuration"
+type: Opaque
+data: {}

--- a/infrastructure/scripts/debug-pod.sh
+++ b/infrastructure/scripts/debug-pod.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# Ephemeral Container Debugging Script for GistPin
+# Manages ephemeral debug containers for live pod debugging
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+NAMESPACE="${NAMESPACE:-gistpin}"
+POD_NAME="${POD_NAME:-}"
+CONTAINER_NAME="${CONTAINER_NAME:-debug-$(date +%s)}"
+DEBUG_IMAGE="${DEBUG_IMAGE:-nicolaka/netshoot:latest}"
+SHELL="${SHELL:-/bin/bash}"
+TIMEOUT="${TIMEOUT:-3600}"
+INTERACTIVE="${INTERACTIVE:-true}"
+AUDIT_LOG="${AUDIT_LOG:-/var/log/gistpin/debug-audit.log}"
+DRY_RUN="${DRY_RUN:-false}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log()    { echo -e "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+info()   { log "${BLUE}INFO${NC}  $*"; }
+success(){ log "${GREEN}OK${NC}    $*"; }
+warn()   { log "${YELLOW}WARN${NC}  $*"; }
+error()  { log "${RED}ERROR${NC} $*" >&2; }
+
+APPROVED_IMAGES=(
+  "busybox:latest"
+  "nicolaka/netshoot:latest"
+  "curlimages/curl:latest"
+  "alpine:latest"
+  "python:3.11-slim"
+  "node:18-slim"
+)
+
+usage() {
+  cat <<EOF
+Usage: $0 [OPTIONS]
+
+Ephemeral Container Debugging for GistPin
+
+Options:
+  -p, --pod NAME          Target pod name (required)
+  -n, --namespace NS      Kubernetes namespace (default: gistpin)
+  -i, --image IMAGE       Debug container image (default: nicolaka/netshoot:latest)
+  -c, --container NAME    Debug container name (default: debug-<timestamp>)
+  -s, --shell PATH        Shell to use (default: /bin/bash)
+  -t, --timeout SECS      Debug session timeout (default: 3600)
+  --non-interactive       Run in non-interactive mode
+  --dry-run               Show what would be done without executing
+  --list-images           List approved debug images
+  --cleanup               Clean up all debug containers in namespace
+  -h, --help              Show this help message
+
+Environment Variables:
+  NAMESPACE               Target Kubernetes namespace
+  POD_NAME                Target pod name
+  DEBUG_IMAGE             Debug container image
+  KUBECONFIG              Path to kubeconfig file
+
+Examples:
+  $0 -p my-pod-abc123 -n gistpin-prod
+  $0 -p my-pod-abc123 -i busybox:latest -s /bin/sh
+  $0 --list-images
+  $0 --cleanup -n gistpin-prod
+EOF
+  exit 0
+}
+
+audit_log() {
+  local action="$1"
+  local pod="$2"
+  local namespace="$3"
+  local image="$4"
+  local status="$5"
+
+  local log_entry
+  log_entry="$(cat <<LOGEOF
+{
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "action": "${action}",
+  "user": "$(whoami)",
+  "namespace": "${namespace}",
+  "pod": "${pod}",
+  "container": "${CONTAINER_NAME}",
+  "image": "${image}",
+  "status": "${status}",
+  "timeout": "${TIMEOUT}"
+}
+LOGEOF
+)"
+
+  mkdir -p "$(dirname "${AUDIT_LOG}")" 2>/dev/null || true
+  echo "${log_entry}" >> "${AUDIT_LOG}" 2>/dev/null || true
+
+  info "Audit: ${action} on ${namespace}/${pod} by $(whoami)"
+}
+
+validate_image() {
+  local image="$1"
+
+  for approved in "${APPROVED_IMAGES[@]}"; do
+    if [[ "${image}" == "${approved}" ]]; then
+      return 0
+    fi
+  done
+
+  error "Image '${image}' is not in the approved list"
+  info "Approved images:"
+  for approved in "${APPROVED_IMAGES[@]}"; do
+    info "  - ${approved}"
+  done
+  return 1
+}
+
+list_approved_images() {
+  info "=== Approved Debug Images ==="
+  for image in "${APPROVED_IMAGES[@]}"; do
+    info "  - ${image}"
+  done
+}
+
+check_ephemeral_containers_feature() {
+  info "Checking ephemeral containers feature..."
+
+  if kubectl api-resources | grep -q "ephemeralcontainers"; then
+    success "Ephemeral containers API is available"
+    return 0
+  fi
+
+  warn "Ephemeral containers API not directly available"
+  info "Attempting to use kubectl debug instead..."
+
+  if kubectl debug --help &>/dev/null; then
+    success "kubectl debug is available"
+    return 0
+  fi
+
+  error "Neither ephemeral containers API nor kubectl debug available"
+  return 1
+}
+
+get_pod_info() {
+  local pod="$1"
+  local namespace="$2"
+
+  local pod_info
+  pod_info="$(kubectl get pod "${pod}" -n "${namespace}" -o json 2>/dev/null)"
+
+  if [[ -z "${pod_info}" ]]; then
+    error "Pod '${pod}' not found in namespace '${namespace}'"
+    return 1
+  fi
+
+  local status
+  status="$(echo "${pod_info}" | jq -r '.status.phase')"
+
+  local node
+  node="$(echo "${pod_info}" | jq -r '.spec.nodeName')"
+
+  info "Pod: ${pod}"
+  info "Namespace: ${namespace}"
+  info "Status: ${status}"
+  info "Node: ${node}"
+}
+
+create_ephemeral_container() {
+  local pod="$1"
+  local namespace="$2"
+  local image="$3"
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    info "[DRY RUN] Would create ephemeral container in ${namespace}/${pod}"
+    info "[DRY RUN] Image: ${image}"
+    info "[DRY RUN] Container name: ${CONTAINER_NAME}"
+    return 0
+  fi
+
+  info "Creating ephemeral container '${CONTAINER_NAME}' in ${namespace}/${pod}..."
+
+  local json_patch
+  json_patch="$(cat <<PATCH
+{
+  "spec": {
+    "ephemeralContainers": [{
+      "name": "${CONTAINER_NAME}",
+      "image": "${image}",
+      "stdin": true,
+      "tty": true,
+      "command": ["${SHELL}"],
+      "env": [
+        {"name": "POD_NAME", "value": "${pod}"},
+        {"name": "POD_NAMESPACE", "value": "${namespace}"},
+        {"name": "DEBUG_TIMEOUT", "value": "${TIMEOUT}"}
+      ],
+      "resources": {
+        "requests": {"cpu": "50m", "memory": "64Mi"},
+        "limits": {"cpu": "200m", "memory": "128Mi"}
+      },
+      "securityContext": {
+        "capabilities": {"add": ["SYS_PTRACE"]},
+        "runAsUser": 0
+      }
+    }]
+  }
+}
+PATCH
+)"
+
+  if kubectl replace --raw "/api/v1/namespaces/${namespace}/pods/${pod}/ephemeralcontainers" \
+    -f - <<< "${json_patch}" &>/dev/null; then
+    success "Ephemeral container created"
+    audit_log "create_ephemeral_container" "${pod}" "${namespace}" "${image}" "success"
+    return 0
+  fi
+
+  warn "Direct API method failed, trying kubectl debug..."
+
+  if kubectl debug -it "${pod}" \
+    --namespace="${namespace}" \
+    --image="${image}" \
+    --target="${CONTAINER_NAME}" \
+    -- /bin/sh; then
+    success "Debug session completed"
+    audit_log "debug_session" "${pod}" "${namespace}" "${image}" "completed"
+    return 0
+  fi
+
+  error "Failed to create ephemeral container"
+  audit_log "create_ephemeral_container" "${pod}" "${namespace}" "${image}" "failed"
+  return 1
+}
+
+cleanup_debug_containers() {
+  local namespace="$1"
+
+  info "Cleaning up debug containers in namespace ${namespace}..."
+
+  local pods
+  pods="$(kubectl get pods -n "${namespace}" -o json 2>/dev/null)"
+
+  local count=0
+  while IFS= read -r pod; do
+    local debug_containers
+    debug_containers="$(echo "${pods}" | jq -r --arg pod "${pod}" \
+      '.items[] | select(.metadata.name == $pod) | .spec.ephemeralContainers[]?.name // empty' 2>/dev/null)"
+
+    if [[ -n "${debug_containers}" ]]; then
+      while IFS= read -r container; do
+        info "Removing debug container '${container}' from pod '${pod}'..."
+        # Note: Ephemeral containers cannot be removed once added
+        # This logs the cleanup action for audit purposes
+        audit_log "cleanup_attempt" "${pod}" "${namespace}" "${container}" "logged"
+        count=$((count + 1))
+      done <<< "${debug_containers}"
+    fi
+  done < <(echo "${pods}" | jq -r '.items[].metadata.name' 2>/dev/null)
+
+  info "Found ${count} debug container(s) for cleanup review"
+  info "Note: Ephemeral containers persist until pod termination"
+}
+
+monitor_debug_session() {
+  local pod="$1"
+  local namespace="$2"
+
+  info "Monitoring debug session (timeout: ${TIMEOUT}s)..."
+  info "Press Ctrl+C to exit"
+
+  local elapsed=0
+  while [[ ${elapsed} -lt ${TIMEOUT} ]]; do
+    local pod_status
+    pod_status="$(kubectl get pod "${pod}" -n "${namespace}" -o jsonpath='{.status.phase}' 2>/dev/null)"
+
+    if [[ "${pod_status}" != "Running" ]]; then
+      warn "Pod status changed to ${pod_status}"
+      break
+    fi
+
+    sleep 10
+    elapsed=$((elapsed + 10))
+
+    if ((elapsed % 60 == 0)); then
+      info "Session active: ${elapsed}s / ${TIMEOUT}s"
+    fi
+  done
+
+  info "Debug session ended"
+}
+
+main() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -p|--pod)           POD_NAME="$2"; shift 2 ;;
+      -n|--namespace)     NAMESPACE="$2"; shift 2 ;;
+      -i|--image)         DEBUG_IMAGE="$2"; shift 2 ;;
+      -c|--container)     CONTAINER_NAME="$2"; shift 2 ;;
+      -s|--shell)         SHELL="$2"; shift 2 ;;
+      -t|--timeout)       TIMEOUT="$2"; shift 2 ;;
+      --non-interactive)  INTERACTIVE="false"; shift ;;
+      --dry-run)          DRY_RUN="true"; shift ;;
+      --list-images)      list_approved_images; exit 0 ;;
+      --cleanup)          cleanup_debug_containers "${NAMESPACE}"; exit 0 ;;
+      -h|--help)          usage ;;
+      *)                  error "Unknown option: $1"; usage ;;
+    esac
+  done
+
+  if [[ -z "${POD_NAME}" ]]; then
+    error "Pod name is required (-p/--pod)"
+    usage
+  fi
+
+  info "=== Ephemeral Container Debugging ==="
+  info "Target: ${NAMESPACE}/${POD_NAME}"
+  info "Image: ${DEBUG_IMAGE}"
+  info "Container: ${CONTAINER_NAME}"
+
+  validate_image "${DEBUG_IMAGE}" || exit 1
+
+  check_ephemeral_containers_feature || exit 1
+
+  get_pod_info "${POD_NAME}" "${NAMESPACE}" || exit 1
+
+  audit_log "debug_session_start" "${POD_NAME}" "${NAMESPACE}" "${DEBUG_IMAGE}" "initiated"
+
+  if create_ephemeral_container "${POD_NAME}" "${NAMESPACE}" "${DEBUG_IMAGE}"; then
+    if [[ "${INTERACTIVE}" == "true" && "${DRY_RUN}" != "true" ]]; then
+      info "Attaching to debug container..."
+      kubectl attach "${POD_NAME}" -n "${NAMESPACE}" -c "${CONTAINER_NAME}" -it 2>/dev/null || true
+    fi
+
+    monitor_debug_session "${POD_NAME}" "${NAMESPACE}"
+
+    audit_log "debug_session_end" "${POD_NAME}" "${NAMESPACE}" "${DEBUG_IMAGE}" "completed"
+    success "Debug session completed"
+  else
+    audit_log "debug_session_end" "${POD_NAME}" "${NAMESPACE}" "${DEBUG_IMAGE}" "failed"
+    exit 1
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
- Add debug-role.yaml with RBAC for ephemeral container creation, pod debugging, and cross-namespace access
- Add debug-pod.sh script for managing ephemeral debug containers with image validation, audit logging, and session monitoring
- Add debugging-guide.md with comprehensive usage guidelines, approved images list, security considerations, and best practices
- Enable ephemeral containers feature with approved debug images
- Implement audit logging for all debug sessions

Closes #756