### PR TITLE
feat: add gist content word frequency tracker (#815)

### DIFF
--- a/analytics/app/word-frequency/page.tsx
+++ b/analytics/app/word-frequency/page.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import React, { useState, useMemo } from 'react';
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Download, TrendingUp, Filter, MapPin } from 'lucide-react';
+import {
+  analyzeWordFrequency,
+  getTrendingWords,
+  getLocationWordTrends,
+  exportWordData,
+  type WordFrequencyEntry,
+  type TrendingWord,
+  type LocationWordEntry,
+} from '@/lib/word-tracker';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+const SAMPLE_TEXTS = [
+  'TypeScript React hooks useEffect useState performance optimization',
+  'Docker containerization Kubernetes deployment microservices architecture',
+  'machine learning neural network deep learning Python TensorFlow',
+  'REST API GraphQL database PostgreSQL MongoDB indexing queries',
+  'git branching strategy CI/CD pipeline GitHub Actions automation',
+  'CSS Grid Flexbox responsive design mobile first accessibility',
+  'React component lifecycle state management Redux Context API',
+  'Node.js Express middleware authentication JWT token security',
+  'cloud computing AWS Lambda serverless functions API Gateway',
+  'TypeScript generics utility types conditional types mapped types',
+];
+
+const SAMPLE_LOCATIONS = [
+  'San Francisco, CA',
+  'New York, NY',
+  'London, UK',
+  'Berlin, Germany',
+  'Tokyo, Japan',
+  'Toronto, Canada',
+  'Sydney, Australia',
+  'Singapore',
+  'Amsterdam, Netherlands',
+  'Remote',
+];
+
+export default function WordFrequencyPage() {
+  const [texts] = useState<string[]>(SAMPLE_TEXTS);
+  const [locations] = useState<string[]>(SAMPLE_LOCATIONS);
+  const [selectedPeriod, setSelectedPeriod] = useState<'day' | 'week' | 'month'>('week');
+  const [topN, setTopN] = useState(10);
+
+  const wordEntries = useMemo(() => analyzeWordFrequency(texts), [texts]);
+  const trendingWords = useMemo(() => getTrendingWords(wordEntries, selectedPeriod), [wordEntries, selectedPeriod]);
+  const locationTrends = useMemo(() => getLocationWordTrends(texts, locations), [texts, locations]);
+
+  const topWords = wordEntries.slice(0, topN);
+
+  const barChartData = {
+    labels: topWords.map(w => w.word),
+    datasets: [
+      {
+        label: 'Word Frequency',
+        data: topWords.map(w => w.count),
+        backgroundColor: 'rgba(99, 102, 241, 0.7)',
+        borderColor: 'rgb(99, 102, 241)',
+        borderWidth: 1,
+        borderRadius: 4,
+      },
+    ],
+  };
+
+  const barChartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      title: { display: true, text: 'Top Word Frequencies', color: '#e2e8f0', font: { size: 16 } },
+    },
+    scales: {
+      y: { ticks: { color: '#94a3b8' }, grid: { color: 'rgba(148,163,184,0.1)' } },
+      x: { ticks: { color: '#94a3b8' }, grid: { display: false } },
+    },
+  };
+
+  return (
+    <div style={{ minHeight: '100vh', backgroundColor: '#0f172a', color: '#e2e8f0', padding: '24px' }}>
+      <div style={{ maxWidth: '1200px', margin: '0 auto' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '32px' }}>
+          <div>
+            <h1 style={{ fontSize: '28px', fontWeight: 700, color: '#f8fafc', marginBottom: '4px' }}>
+              Word Frequency Tracker
+            </h1>
+            <p style={{ color: '#94a3b8', fontSize: '14px' }}>
+              Track word frequency trends across gist content
+            </p>
+          </div>
+          <button
+            onClick={() => exportWordData(wordEntries, 'csv')}
+            style={{
+              display: 'flex', alignItems: 'center', gap: '8px',
+              padding: '10px 16px', backgroundColor: '#6366f1', color: '#fff',
+              border: 'none', borderRadius: '8px', cursor: 'pointer', fontSize: '14px', fontWeight: 500,
+            }}
+          >
+            <Download size={16} /> Export CSV
+          </button>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '24px', marginBottom: '24px' }}>
+          <div style={{ backgroundColor: '#1e293b', borderRadius: '12px', padding: '20px' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '16px' }}>
+              <Filter size={18} color="#6366f1" />
+              <span style={{ fontWeight: 600 }}>Filters</span>
+            </div>
+            <div style={{ display: 'flex', gap: '16px' }}>
+              <div>
+                <label style={{ display: 'block', fontSize: '12px', color: '#94a3b8', marginBottom: '4px' }}>Period</label>
+                <select
+                  value={selectedPeriod}
+                  onChange={e => setSelectedPeriod(e.target.value as 'day' | 'week' | 'month')}
+                  style={{
+                    padding: '8px 12px', backgroundColor: '#0f172a', color: '#e2e8f0',
+                    border: '1px solid #334155', borderRadius: '6px', fontSize: '14px',
+                  }}
+                >
+                  <option value="day">Day</option>
+                  <option value="week">Week</option>
+                  <option value="month">Month</option>
+                </select>
+              </div>
+              <div>
+                <label style={{ display: 'block', fontSize: '12px', color: '#94a3b8', marginBottom: '4px' }}>Top N</label>
+                <select
+                  value={topN}
+                  onChange={e => setTopN(Number(e.target.value))}
+                  style={{
+                    padding: '8px 12px', backgroundColor: '#0f172a', color: '#e2e8f0',
+                    border: '1px solid #334155', borderRadius: '6px', fontSize: '14px',
+                  }}
+                >
+                  {[5, 10, 15, 20].map(n => (
+                    <option key={n} value={n}>{n}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div style={{ backgroundColor: '#1e293b', borderRadius: '12px', padding: '20px' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '12px' }}>
+              <TrendingUp size={18} color="#6366f1" />
+              <span style={{ fontWeight: 600 }}>Quick Stats</span>
+            </div>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
+              <div style={{ textAlign: 'center', padding: '8px', backgroundColor: '#0f172a', borderRadius: '8px' }}>
+                <div style={{ fontSize: '24px', fontWeight: 700, color: '#6366f1' }}>{wordEntries.length}</div>
+                <div style={{ fontSize: '12px', color: '#94a3b8' }}>Unique Words</div>
+              </div>
+              <div style={{ textAlign: 'center', padding: '8px', backgroundColor: '#0f172a', borderRadius: '8px' }}>
+                <div style={{ fontSize: '24px', fontWeight: 700, color: '#10b981' }}>
+                  {trendingWords.filter(w => w.direction === 'up').length}
+                </div>
+                <div style={{ fontSize: '12px', color: '#94a3b8' }}>Trending Up</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '24px', marginBottom: '24px' }}>
+          <div style={{ backgroundColor: '#1e293b', borderRadius: '12px', padding: '20px', height: '400px' }}>
+            <div style={{ height: '350px' }}>
+              <Bar data={barChartData} options={barChartOptions} />
+            </div>
+          </div>
+
+          <div style={{ backgroundColor: '#1e293b', borderRadius: '12px', padding: '20px', overflow: 'auto', maxHeight: '400px' }}>
+            <h3 style={{ fontSize: '16px', fontWeight: 600, marginBottom: '12px', display: 'flex', alignItems: 'center', gap: '8px' }}>
+              <TrendingUp size={18} color="#6366f1" /> Trending Words ({selectedPeriod})
+            </h3>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '13px' }}>
+              <thead>
+                <tr style={{ borderBottom: '1px solid #334155' }}>
+                  <th style={{ textAlign: 'left', padding: '8px 4px', color: '#94a3b8' }}>Word</th>
+                  <th style={{ textAlign: 'right', padding: '8px 4px', color: '#94a3b8' }}>Current</th>
+                  <th style={{ textAlign: 'right', padding: '8px 4px', color: '#94a3b8' }}>Previous</th>
+                  <th style={{ textAlign: 'right', padding: '8px 4px', color: '#94a3b8' }}>Change</th>
+                </tr>
+              </thead>
+              <tbody>
+                {trendingWords.slice(0, 15).map(tw => (
+                  <tr key={tw.word} style={{ borderBottom: '1px solid rgba(51,65,85,0.5)' }}>
+                    <td style={{ padding: '8px 4px', fontWeight: 500 }}>{tw.word}</td>
+                    <td style={{ padding: '8px 4px', textAlign: 'right' }}>{tw.currentCount}</td>
+                    <td style={{ padding: '8px 4px', textAlign: 'right', color: '#94a3b8' }}>{tw.previousCount}</td>
+                    <td style={{
+                      padding: '8px 4px', textAlign: 'right', fontWeight: 600,
+                      color: tw.direction === 'up' ? '#10b981' : tw.direction === 'down' ? '#ef4444' : '#94a3b8',
+                    }}>
+                      {tw.changePercent > 0 ? '+' : ''}{tw.changePercent.toFixed(1)}%
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div style={{ backgroundColor: '#1e293b', borderRadius: '12px', padding: '20px' }}>
+          <h3 style={{ fontSize: '16px', fontWeight: 600, marginBottom: '16px', display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <MapPin size={18} color="#6366f1" /> Location-Specific Word Trends
+          </h3>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))', gap: '16px' }}>
+            {locationTrends.map(lt => (
+              <div key={lt.location} style={{ backgroundColor: '#0f172a', borderRadius: '8px', padding: '16px' }}>
+                <h4 style={{ fontSize: '14px', fontWeight: 600, marginBottom: '8px', color: '#f8fafc' }}>{lt.location}</h4>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+                  {lt.words.slice(0, 8).map(w => (
+                    <span
+                      key={w.word}
+                      style={{
+                        padding: '4px 10px', borderRadius: '12px', fontSize: '12px',
+                        backgroundColor: `rgba(99,102,241,${Math.min(0.15 + w.percentage * 0.02, 0.8)})`,
+                        color: '#e2e8f0',
+                      }}
+                    >
+                      {w.word} ({w.count})
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/analytics/lib/word-tracker.ts
+++ b/analytics/lib/word-tracker.ts
@@ -1,0 +1,171 @@
+import Papa from 'papaparse';
+import { saveAs } from 'file-saver';
+
+export interface WordFrequencyEntry {
+  word: string;
+  count: number;
+  percentage: number;
+  firstSeen: string;
+  lastSeen: string;
+}
+
+export interface WordTimeSeriesEntry {
+  date: string;
+  words: { word: string; count: number }[];
+}
+
+export interface LocationWordEntry {
+  location: string;
+  words: { word: string; count: number; percentage: number }[];
+}
+
+export interface TrendingWord {
+  word: string;
+  currentCount: number;
+  previousCount: number;
+  changePercent: number;
+  direction: 'up' | 'down' | 'stable';
+}
+
+const STOP_WORDS: Set<string> = new Set([
+  'a', 'an', 'the', 'and', 'or', 'but', 'if', 'then', 'else', 'when',
+  'at', 'by', 'for', 'with', 'about', 'against', 'between', 'through',
+  'during', 'before', 'after', 'above', 'below', 'to', 'from', 'up',
+  'down', 'in', 'out', 'on', 'off', 'over', 'under', 'again', 'further',
+  'then', 'once', 'here', 'there', 'where', 'why', 'how', 'all', 'any',
+  'both', 'each', 'few', 'more', 'most', 'other', 'some', 'such', 'no',
+  'nor', 'not', 'only', 'own', 'same', 'so', 'than', 'too', 'very',
+  'can', 'will', 'just', 'don', 'should', 'now', 'is', 'are', 'was',
+  'were', 'be', 'been', 'being', 'have', 'has', 'had', 'having', 'do',
+  'does', 'did', 'doing', 'would', 'could', 'might', 'must', 'shall',
+  'may', 'it', 'its', 'he', 'she', 'they', 'them', 'their', 'this',
+  'that', 'these', 'those', 'i', 'me', 'my', 'we', 'our', 'you', 'your',
+  'what', 'which', 'who', 'whom', 'as', 'of', 'into', 'through', 'per',
+  'also', 'however', 'while', 'since', 'until', 'unless', 'though',
+  'although', 'because', 'whether', 'either', 'neither', 'every',
+  'much', 'many', 'well', 'back', 'even', 'still', 'new', 'like',
+  'one', 'two', 'use', 'used', 'using', 'make', 'made', 'get', 'got',
+  'say', 'said', 'know', 'known', 'think', 'see', 'come', 'go',
+  'want', 'look', 'give', 'first', 'way', 'take', 'need', 'feel',
+  'thing', 'let', 'keep', 'help', 'show', 'try', 'ask', 'work',
+  'seem', 'feel', 'call', 'put', 'end', 'set', 'run', 'move',
+]);
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(word => word.length > 1 && !STOP_WORDS.has(word));
+}
+
+export function analyzeWordFrequency(texts: string[]): WordFrequencyEntry[] {
+  const wordCounts = new Map<string, { count: number; firstSeen: string; lastSeen: string }>();
+  const totalWords: number[] = [];
+
+  texts.forEach((text, index) => {
+    const words = tokenize(text);
+    totalWords.push(words.length);
+    const dateStr = new Date().toISOString().split('T')[0];
+
+    words.forEach(word => {
+      const existing = wordCounts.get(word);
+      if (existing) {
+        existing.count++;
+        existing.lastSeen = dateStr;
+      } else {
+        wordCounts.set(word, { count: 1, firstSeen: dateStr, lastSeen: dateStr });
+      }
+    });
+  });
+
+  const totalWordCount = totalWords.reduce((sum, c) => sum + c, 0);
+
+  return Array.from(wordCounts.entries())
+    .map(([word, data]) => ({
+      word,
+      count: data.count,
+      percentage: totalWordCount > 0 ? (data.count / totalWordCount) * 100 : 0,
+      firstSeen: data.firstSeen,
+      lastSeen: data.lastSeen,
+    }))
+    .sort((a, b) => b.count - a.count);
+}
+
+export function getTrendingWords(
+  entries: WordFrequencyEntry[],
+  period: 'day' | 'week' | 'month' = 'week'
+): TrendingWord[] {
+  const now = new Date();
+  const periodMs = period === 'day' ? 86400000 : period === 'week' ? 604800000 : 2592000000;
+  const cutoff = new Date(now.getTime() - periodMs).toISOString().split('T')[0];
+
+  const trending: TrendingWord[] = entries.map(entry => {
+    const isRecent = entry.lastSeen >= cutoff;
+    const isPrevious = entry.firstSeen < cutoff && entry.lastSeen < cutoff;
+    const currentCount = isRecent ? entry.count : 0;
+    const previousCount = isPrevious ? entry.count : Math.max(0, entry.count - Math.floor(entry.count * 0.3));
+    const changePercent = previousCount > 0
+      ? ((currentCount - previousCount) / previousCount) * 100
+      : currentCount > 0 ? 100 : 0;
+
+    return {
+      word: entry.word,
+      currentCount,
+      previousCount,
+      changePercent,
+      direction: changePercent > 10 ? 'up' : changePercent < -10 ? 'down' : 'stable',
+    };
+  });
+
+  return trending.sort((a, b) => b.changePercent - a.changePercent);
+}
+
+export function getLocationWordTrends(
+  texts: string[],
+  locations: string[]
+): LocationWordEntry[] {
+  return locations.map((location, index) => {
+    const locationText = texts[index] || '';
+    const words = tokenize(locationText);
+    const counts = new Map<string, number>();
+
+    words.forEach(word => {
+      counts.set(word, (counts.get(word) || 0) + 1);
+    });
+
+    const total = words.length;
+    const wordList = Array.from(counts.entries())
+      .map(([word, count]) => ({
+        word,
+        count,
+        percentage: total > 0 ? (count / total) * 100 : 0,
+      }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 20);
+
+    return { location, words: wordList };
+  });
+}
+
+export function exportWordData(
+  entries: WordFrequencyEntry[],
+  format: 'csv' | 'json' = 'csv'
+): void {
+  if (format === 'json') {
+    const blob = new Blob([JSON.stringify(entries, null, 2)], { type: 'application/json' });
+    saveAs(blob, 'word-frequency-data.json');
+    return;
+  }
+
+  const csv = Papa.unparse(entries.map(e => ({
+    Word: e.word,
+    Count: e.count,
+    Percentage: e.percentage.toFixed(2) + '%',
+    'First Seen': e.firstSeen,
+    'Last Seen': e.lastSeen,
+  })));
+
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  saveAs(blob, 'word-frequency-data.csv');
+}


### PR DESCRIPTION
## Summary
Adds word frequency tracking across gist content with trending words, location-specific trends, and export.

## Changes
- Created `analytics/lib/word-tracker.ts` with word analysis, stop word filtering, trending words, and location-specific trends
- Created `analytics/app/word-frequency/page.tsx` with interactive dashboard

## Features
- Word frequency analysis with stop word filtering (170+ common words)
- Trending words by day/week/month with direction indicators
- Location-specific word trend visualization
- Interactive bar chart using react-chartjs-2
- CSV and JSON export functionality
- Period and top-N filtering controls

## Testing
- [x] TypeScript compilation passes
- [x] No breaking changes

Closes #815