### PR TITLE
feat: add network effect visualization (#816)

### DIFF
--- a/analytics/components/charts/NetworkEffect.tsx
+++ b/analytics/components/charts/NetworkEffect.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import {
+  calculateValuePerUser,
+  metcalfeLawCurve,
+  detectCriticalMass,
+  calculateGeographicDensity,
+  calculateNetworkStrength,
+} from '../../lib/network-metrics';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+interface NetworkEffectProps {
+  users: number[];
+  activity: number[];
+  timestamps: string[];
+  geographicData?: {
+    locations: Array<{
+      region: string;
+      userCount: number;
+      activityLevel: number;
+    }>;
+  };
+}
+
+export default function NetworkEffect({
+  users,
+  activity,
+  timestamps,
+  geographicData,
+}: NetworkEffectProps) {
+  const [selectedMetric, setSelectedMetric] = useState<'value' | 'metcalfe'>('value');
+
+  const metrics = useMemo(() => {
+    const valuePerUser = calculateValuePerUser(users, activity);
+    const metcalfeValues = metcalfeLawCurve(users);
+    const criticalMassIndex = detectCriticalMass(valuePerUser);
+    const geographicDensity = geographicData
+      ? calculateGeographicDensity(geographicData)
+      : {};
+    const networkStrength = calculateNetworkStrength({
+      valuePerUser,
+      metcalfeValues,
+      criticalMassIndex,
+      geographicDensity,
+    });
+
+    return {
+      valuePerUser,
+      metcalfeValues,
+      criticalMassIndex,
+      geographicDensity,
+      networkStrength,
+    };
+  }, [users, activity, geographicData]);
+
+  const chartData = useMemo(() => {
+    const datasets = [];
+
+    if (selectedMetric === 'value') {
+      datasets.push({
+        label: 'Value per User',
+        data: metrics.valuePerUser,
+        borderColor: 'rgb(75, 192, 192)',
+        backgroundColor: 'rgba(75, 192, 192, 0.5)',
+        tension: 0.3,
+      });
+    } else {
+      datasets.push({
+        label: 'Metcalfe Law Curve',
+        data: metrics.metcalfeValues,
+        borderColor: 'rgb(255, 99, 132)',
+        backgroundColor: 'rgba(255, 99, 132, 0.5)',
+        tension: 0.3,
+      });
+    }
+
+    if (metrics.criticalMassIndex !== null) {
+      datasets.push({
+        label: 'Critical Mass',
+        data: metrics.valuePerUser.map((_, index) =>
+          index === metrics.criticalMassIndex ? metrics.valuePerUser[index] : null
+        ),
+        borderColor: 'rgb(255, 205, 86)',
+        backgroundColor: 'rgba(255, 205, 86, 0.8)',
+        pointRadius: 10,
+        pointHoverRadius: 15,
+        showLine: false,
+      });
+    }
+
+    return {
+      labels: timestamps,
+      datasets,
+    };
+  }, [metrics, selectedMetric, timestamps]);
+
+  const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        position: 'top' as const,
+      },
+      title: {
+        display: true,
+        text: 'Network Effect Visualization',
+      },
+      tooltip: {
+        callbacks: {
+          afterLabel: function (context: any) {
+            if (context.dataset.label === 'Critical Mass') {
+              return 'Inflection Point - Network effect accelerating';
+            }
+            return '';
+          },
+        },
+      },
+    },
+    scales: {
+      y: {
+        display: true,
+        title: {
+          display: true,
+          text: selectedMetric === 'value' ? 'Value per User' : 'Metcalfe Value',
+        },
+      },
+      x: {
+        display: true,
+        title: {
+          display: true,
+          text: 'Time',
+        },
+      },
+    },
+  };
+
+  return (
+    <div style={{ padding: '20px', backgroundColor: '#ffffff', borderRadius: '8px' }}>
+      <div style={{ marginBottom: '20px' }}>
+        <div style={{ display: 'flex', gap: '10px', marginBottom: '10px' }}>
+          <button
+            onClick={() => setSelectedMetric('value')}
+            style={{
+              padding: '8px 16px',
+              backgroundColor: selectedMetric === 'value' ? '#4CAF50' : '#e0e0e0',
+              color: selectedMetric === 'value' ? 'white' : 'black',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: 'pointer',
+            }}
+          >
+            Value per User
+          </button>
+          <button
+            onClick={() => setSelectedMetric('metcalfe')}
+            style={{
+              padding: '8px 16px',
+              backgroundColor: selectedMetric === 'metcalfe' ? '#4CAF50' : '#e0e0e0',
+              color: selectedMetric === 'metcalfe' ? 'white' : 'black',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: 'pointer',
+            }}
+          >
+            Metcalfe Law
+          </button>
+        </div>
+      </div>
+
+      <div style={{ height: '400px', marginBottom: '20px' }}>
+        <Line data={chartData} options={chartOptions} />
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '15px' }}>
+        <div style={{ padding: '15px', backgroundColor: '#f5f5f5', borderRadius: '6px' }}>
+          <h3 style={{ margin: '0 0 10px 0', fontSize: '14px', color: '#666' }}>
+            Network Strength Score
+          </h3>
+          <p style={{ margin: 0, fontSize: '24px', fontWeight: 'bold', color: '#333' }}>
+            {(metrics.networkStrength * 100).toFixed(1)}%
+          </p>
+        </div>
+
+        {metrics.criticalMassIndex !== null && (
+          <div style={{ padding: '15px', backgroundColor: '#fff3cd', borderRadius: '6px' }}>
+            <h3 style={{ margin: '0 0 10px 0', fontSize: '14px', color: '#856404' }}>
+              Critical Mass
+            </h3>
+            <p style={{ margin: 0, fontSize: '14px', color: '#856404' }}>
+              Detected at index {metrics.criticalMassIndex}
+            </p>
+          </div>
+        )}
+
+        {Object.keys(metrics.geographicDensity).length > 0 && (
+          <div style={{ padding: '15px', backgroundColor: '#d1ecf1', borderRadius: '6px' }}>
+            <h3 style={{ margin: '0 0 10px 0', fontSize: '14px', color: '#0c5460' }}>
+              Geographic Coverage
+            </h3>
+            <p style={{ margin: 0, fontSize: '14px', color: '#0c5460' }}>
+              {Object.keys(metrics.geographicDensity).length} regions
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/analytics/lib/network-metrics.ts
+++ b/analytics/lib/network-metrics.ts
@@ -1,0 +1,90 @@
+export interface UserActivity {
+  users: number[];
+  activity: number[];
+  timestamps: string[];
+}
+
+export interface GeographicData {
+  locations: Array<{
+    region: string;
+    userCount: number;
+    activityLevel: number;
+  }>;
+}
+
+export interface NetworkMetrics {
+  valuePerUser: number[];
+  metcalfeValues: number[];
+  criticalMassIndex: number | null;
+  geographicDensity: Record<string, number>;
+  networkStrength: number;
+}
+
+export function calculateValuePerUser(users: number[], activity: number[]): number[] {
+  if (users.length !== activity.length) {
+    throw new Error('Users and activity arrays must have the same length');
+  }
+  
+  return users.map((userCount, index) => {
+    if (userCount === 0) return 0;
+    return activity[index] / userCount;
+  });
+}
+
+export function metcalfeLawCurve(users: number[]): number[] {
+  return users.map(userCount => {
+    return (userCount * (userCount - 1)) / 2;
+  });
+}
+
+export function detectCriticalMass(data: number[]): number | null {
+  if (data.length < 3) return null;
+  
+  let maxGrowthRate = 0;
+  let criticalIndex = null;
+  
+  for (let i = 1; i < data.length - 1; i++) {
+    const growthRate = (data[i] - data[i - 1]) / data[i - 1];
+    const secondDerivative = (data[i + 1] - 2 * data[i] + data[i - 1]);
+    
+    if (growthRate > maxGrowthRate && secondDerivative < 0) {
+      maxGrowthRate = growthRate;
+      criticalIndex = i;
+    }
+  }
+  
+  return criticalIndex;
+}
+
+export function calculateGeographicDensity(data: GeographicData): Record<string, number> {
+  const density: Record<string, number> = {};
+  const totalUsers = data.locations.reduce((sum, loc) => sum + loc.userCount, 0);
+  
+  data.locations.forEach(loc => {
+    if (totalUsers > 0) {
+      density[loc.region] = (loc.userCount / totalUsers) * 100;
+    }
+  });
+  
+  return density;
+}
+
+export function calculateNetworkStrength(metrics: {
+  valuePerUser: number[];
+  metcalfeValues: number[];
+  criticalMassIndex: number | null;
+  geographicDensity: Record<string, number>;
+}): number {
+  const latestValuePerUser = metrics.valuePerUser[metrics.valuePerUser.length - 1] || 0;
+  const latestMetcalfe = metrics.metcalfeValues[metrics.metcalfeValues.length - 1] || 1;
+  
+  const valueRatio = Math.min(latestValuePerUser / (latestMetcalfe / 1000), 1);
+  const criticalMassBonus = metrics.criticalMassIndex !== null ? 0.2 : 0;
+  
+  const densityValues = Object.values(metrics.geographicDensity);
+  const geographicScore = densityValues.length > 0 
+    ? densityValues.reduce((sum, val) => sum + val, 0) / densityValues.length / 100
+    : 0;
+  
+  return Math.min((valueRatio + criticalMassBonus + geographicScore) / 2.2, 1);
+}


### PR DESCRIPTION
## Summary
Adds network effect visualization with Metcalfe law fit, critical mass detection, and geographic density.

## Changes
- Created analytics/lib/network-metrics.ts with value-per-user, Metcalfe law, critical mass, and network strength calculations
- Created analytics/components/charts/NetworkEffect.tsx with interactive line chart

## Testing
- [x] TypeScript compilation passes
- [x] No breaking changes

Closes #816