### PR TITLE
feat(contracts): Wave 1 completion — moderation, author edit/delete, tests, deploy (#878-881)

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -51,10 +51,21 @@ Each gist record tracks:
 
 | Method | Returns | Description |
 |---|---|---|
+| `initialize(admin)` | `Result<(), GistError>` | Set the moderator address. Callable **once**, at deploy time |
+| `get_admin()` | `Option<Address>` | The configured moderator, if initialized |
 | `post_gist(author, location_cell, content_hash, ttl_secs)` | `Result<u64, GistError>` | Register a new gist; returns its `gist_id` |
-| `get_gist(gist_id)` | `Option<Gist>` | Retrieve a gist record by id (expired records are still returned) |
-| `is_active(gist_id)` | `bool` | Whether the gist exists and has not expired |
+| `get_gist(gist_id)` | `Option<Gist>` | Retrieve a gist record by id (expired/hidden records are still returned) |
+| `is_active(gist_id)` | `bool` | Exists, not expired, and not hidden |
 | `list_gists_by_cell(location_cell, cursor, limit)` | `Vec<Gist>` | Paginated list of **active** gists in a cell |
+| `edit_gist(gist_id, new_content_hash)` | `Result<(), GistError>` | Replace the content pointer — **author only** |
+| `delete_gist(gist_id)` | `Result<(), GistError>` | Delete your own gist — **author only** |
+| `hide_gist(gist_id)` | `Result<(), GistError>` | Soft-hide a gist — **moderator only** |
+| `unhide_gist(gist_id)` | `Result<(), GistError>` | Reverse a hide — **moderator only** |
+| `remove_gist(gist_id)` | `Result<(), GistError>` | Permanently delete — **moderator only** |
+| `report_gist(gist_id)` | `Result<u32, GistError>` | Flag for off-chain review (anyone); returns the new count |
+| `report_count(gist_id)` | `u32` | Reports filed against a gist |
+
+Posting works without `initialize`; only moderator actions require it.
 
 ### Authorship
 
@@ -78,6 +89,15 @@ Each gist record tracks:
 Expired gists are excluded from `list_gists_by_cell` but remain retrievable via
 `get_gist`; use `is_active` to test expiry.
 
+### Moderation & ownership
+
+| Action | Who | Effect |
+|---|---|---|
+| `edit_gist` / `delete_gist` | the gist's **author** (`require_auth`) | Anonymous gists are immutable — no provable owner |
+| `hide_gist` / `unhide_gist` | **moderator** (`require_auth`) | Soft, reversible. Excluded from listings; still returned by `get_gist` with `hidden = true`, so moderation stays auditable |
+| `remove_gist` | **moderator** (`require_auth`) | Permanent and irreversible — prefer `hide_gist` unless the content must not persist |
+| `report_gist` | anyone | Advisory only; never hides content on its own |
+
 ### Errors
 
 | Error | Code | Raised when |
@@ -85,6 +105,14 @@ Expired gists are excluded from `list_gists_by_cell` but remain retrievable via
 | `TtlZero` | 1 | `ttl_secs` is `0` |
 | `TtlTooLong` | 2 | `ttl_secs` exceeds the 7-day maximum |
 | `CooldownActive` | 3 | The author posted in this cell < 60s ago |
+| `NotFound` | 4 | No gist exists with that id |
+| `NotAuthorized` | 5 | Caller is neither the author nor the moderator |
+| `AlreadyInitialized` | 6 | `initialize` was called twice |
+| `NotInitialized` | 7 | A moderator action ran before `initialize` |
+| `AnonymousImmutable` | 8 | Edit/delete attempted on an anonymous gist |
+
+Authorization failures surface as a **trapped `require_auth`** (a panic), not a
+`GistError` — that is Soroban's standard behaviour.
 
 ### Pagination
 
@@ -94,14 +122,56 @@ gists. `cursor` is a zero-based **offset into that index** (not a gist id).
 
 ### Events
 
-`post_gist` publishes a single canonical event that off-chain indexers
-(the backend) subscribe to. **Keep this in sync with the backend's
-`GIST_POSTED_EVENT` constant.**
+Every state change publishes an event with a single `Symbol` topic (the event
+name) so off-chain indexers can reconcile. **Keep `gist_posted` in sync with the
+backend's `GIST_POSTED_EVENT` constant.**
 
-| Field | Value |
-|---|---|
-| Topic (event name) | `gist_posted` (a `Symbol`) |
-| Data payload | the full `Gist` record (`gist_id`, `author`, `location_cell`, `content_hash`, `created_at`, `expires_at`) |
+| Topic | Data payload | Emitted by |
+|---|---|---|
+| `gist_posted` | the full `Gist` record | `post_gist` |
+| `gist_edited` | the updated `Gist` record | `edit_gist` |
+| `gist_deleted` | `gist_id: u64` | `delete_gist` |
+| `gist_hidden` | `gist_id: u64` | `hide_gist` |
+| `gist_unhidden` | `gist_id: u64` | `unhide_gist` |
+| `gist_removed` | `gist_id: u64` | `remove_gist` |
+| `gist_reported` | `(gist_id: u64, count: u32)` | `report_gist` |
+
+The `Gist` record carries `gist_id`, `author`, `location_cell`, `content_hash`,
+`created_at`, `expires_at`, `hidden`.
+
+---
+
+## Deployment
+
+Build, deploy and initialize on testnet:
+
+```bash
+./scripts/deploy-testnet.sh <identity> [admin-address]
+```
+
+The script runs the tests, builds the release WASM, deploys, and calls
+`initialize` to set the moderator. Prerequisites (Rust wasm32 target, the
+Stellar CLI, and a funded identity) are listed at the top of the script.
+
+### Deployments
+
+| Network | Contract ID | Moderator |
+|---|---|---|
+| testnet | _not yet deployed_ | — |
+
+> Record the contract id here after deploying, then set
+> `CONTRACT_ID_GIST_REGISTRY` in the backend environment to take it out of
+> mock mode.
+
+### Backend integration checklist (Wave 2)
+
+- [ ] Set `CONTRACT_ID_GIST_REGISTRY` to the deployed id.
+- [ ] Update `soroban.service.ts` — `post_gist` now takes a 4th argument
+      (`ttl_secs: Option<u64>`) and returns a `Result`.
+- [ ] `list_gists_by_cell`'s `cursor` is a **`u32` offset into the cell index**,
+      no longer a gist id.
+- [ ] Decode the `Gist` payload's new `expires_at` and `hidden` fields.
+- [ ] Subscribe to the moderation/edit events above, not just `gist_posted`.
 
 ---
 

--- a/contracts/scripts/deploy-testnet.sh
+++ b/contracts/scripts/deploy-testnet.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Build, deploy and initialize GistRegistry on the Stellar testnet.
+#
+# Prerequisites:
+#   - Rust with the wasm32 target:  rustup target add wasm32-unknown-unknown
+#   - Stellar CLI:                  cargo install --locked stellar-cli --features opt
+#   - A funded testnet identity:    stellar keys generate --global <name> --network testnet
+#                                   stellar keys fund <name> --network testnet
+#
+# Usage:
+#   ./scripts/deploy-testnet.sh <identity> [admin-address]
+#
+#   <identity>       stellar CLI identity used to sign the deploy (required)
+#   [admin-address]  moderator address passed to initialize().
+#                    Defaults to the deploying identity's own address.
+#
+# Example:
+#   ./scripts/deploy-testnet.sh my-key
+#
+set -euo pipefail
+
+NETWORK="testnet"
+IDENTITY="${1:-}"
+if [[ -z "$IDENTITY" ]]; then
+  echo "error: missing <identity>." >&2
+  echo "usage: $0 <identity> [admin-address]" >&2
+  exit 1
+fi
+
+cd "$(dirname "$0")/.."
+
+WASM="target/wasm32-unknown-unknown/release/gistpin_contracts.wasm"
+
+echo "==> Running tests"
+cargo test
+
+echo "==> Building WASM (release)"
+cargo build --target wasm32-unknown-unknown --release
+
+echo "==> Optimizing"
+stellar contract optimize --wasm "$WASM" || echo "(optimize unavailable — deploying unoptimized)"
+OPTIMIZED="target/wasm32-unknown-unknown/release/gistpin_contracts.optimized.wasm"
+[[ -f "$OPTIMIZED" ]] || OPTIMIZED="$WASM"
+
+echo "==> Deploying to $NETWORK"
+CONTRACT_ID=$(stellar contract deploy \
+  --wasm "$OPTIMIZED" \
+  --source "$IDENTITY" \
+  --network "$NETWORK")
+
+echo "==> Deployed: $CONTRACT_ID"
+
+ADMIN="${2:-$(stellar keys address "$IDENTITY")}"
+echo "==> Initializing moderator: $ADMIN"
+stellar contract invoke \
+  --id "$CONTRACT_ID" \
+  --source "$IDENTITY" \
+  --network "$NETWORK" \
+  -- initialize --admin "$ADMIN"
+
+cat <<EOF
+
+------------------------------------------------------------------
+Deployment complete.
+
+  Contract ID : $CONTRACT_ID
+  Moderator   : $ADMIN
+  Network     : $NETWORK
+
+Next steps:
+  1. Record the contract id in contracts/README.md (Deployments table).
+  2. Set it in the backend environment:
+       CONTRACT_ID_GIST_REGISTRY=$CONTRACT_ID
+     This takes the backend out of mock mode (see Backend/.env.example).
+------------------------------------------------------------------
+EOF

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -29,6 +29,18 @@ pub enum GistError {
     TtlTooLong = 2,
     /// This author posted in this cell less than `COOLDOWN_SECS` ago.
     CooldownActive = 3,
+    /// No gist exists with the given id.
+    NotFound = 4,
+    /// The caller is not permitted to perform this action (not the gist's
+    /// author, or not the moderator).
+    NotAuthorized = 5,
+    /// `initialize` has already been called.
+    AlreadyInitialized = 6,
+    /// A moderator action was attempted before `initialize`.
+    NotInitialized = 7,
+    /// Anonymous gists have no provable owner, so they cannot be edited or
+    /// deleted by users — only moderated.
+    AnonymousImmutable = 8,
 }
 
 // ---------------------------------------------------------------------------
@@ -45,6 +57,9 @@ pub struct Gist {
     pub created_at: u64,
     /// Ledger timestamp after which this gist is considered expired.
     pub expires_at: u64,
+    /// Set by a moderator to soft-hide the gist. Hidden gists are excluded
+    /// from listings but remain retrievable via `get_gist`.
+    pub hidden: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -60,6 +75,10 @@ pub enum DataKey {
     CellIndex(String),
     /// Last post timestamp for an (author, cell) pair — drives the cooldown.
     LastPost(Address, String),
+    /// The moderator address, set once via `initialize`.
+    Admin,
+    /// Number of reports filed against a gist (advisory, for off-chain review).
+    Reports(u64),
 }
 
 const GIST_COUNT: Symbol = symbol_short!("GCOUNT");
@@ -133,6 +152,7 @@ impl GistRegistry {
             content_hash,
             created_at: now,
             expires_at,
+            hidden: false,
         };
 
         env.storage().persistent().set(&DataKey::Gist(gist_id), &gist);
@@ -163,14 +183,15 @@ impl GistRegistry {
         env.storage().persistent().get(&DataKey::Gist(gist_id))
     }
 
-    /// Whether a gist exists and has not yet expired.
+    /// Whether a gist exists, has not expired, and has not been hidden by a
+    /// moderator.
     pub fn is_active(env: Env, gist_id: u64) -> bool {
         match env
             .storage()
             .persistent()
             .get::<DataKey, Gist>(&DataKey::Gist(gist_id))
         {
-            Some(gist) => env.ledger().timestamp() < gist.expires_at,
+            Some(gist) => !gist.hidden && env.ledger().timestamp() < gist.expires_at,
             None => false,
         }
     }
@@ -203,7 +224,7 @@ impl GistRegistry {
                     .persistent()
                     .get::<DataKey, Gist>(&DataKey::Gist(id))
                 {
-                    if now < gist.expires_at {
+                    if !gist.hidden && now < gist.expires_at {
                         results.push_back(gist);
                         count += 1;
                     }
@@ -213,6 +234,157 @@ impl GistRegistry {
         }
 
         results
+    }
+
+    // -----------------------------------------------------------------------
+    // Moderation (#878)
+    // -----------------------------------------------------------------------
+
+    /// Set the moderator address. Callable exactly once, at deploy time.
+    ///
+    /// Posting works without initialization; only moderator actions require it.
+    pub fn initialize(env: Env, admin: Address) -> Result<(), GistError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(GistError::AlreadyInitialized);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    /// The configured moderator, if `initialize` has been called.
+    pub fn get_admin(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::Admin)
+    }
+
+    /// Soft-hide a gist. Moderator only.
+    ///
+    /// Hidden gists are excluded from `list_gists_by_cell` and report
+    /// `is_active == false`, but remain retrievable via `get_gist` (with
+    /// `hidden == true`) so moderation stays auditable. Reversible via
+    /// [`Self::unhide_gist`].
+    pub fn hide_gist(env: Env, gist_id: u64) -> Result<(), GistError> {
+        Self::require_admin(&env)?;
+        Self::set_hidden(&env, gist_id, true)?;
+        env.events()
+            .publish((Symbol::new(&env, "gist_hidden"),), gist_id);
+        Ok(())
+    }
+
+    /// Reverse a previous [`Self::hide_gist`]. Moderator only.
+    pub fn unhide_gist(env: Env, gist_id: u64) -> Result<(), GistError> {
+        Self::require_admin(&env)?;
+        Self::set_hidden(&env, gist_id, false)?;
+        env.events()
+            .publish((Symbol::new(&env, "gist_unhidden"),), gist_id);
+        Ok(())
+    }
+
+    /// Permanently delete a gist. Moderator only.
+    ///
+    /// Prefer [`Self::hide_gist`] unless the content must not persist —
+    /// removal is irreversible and leaves no record beyond the event.
+    pub fn remove_gist(env: Env, gist_id: u64) -> Result<(), GistError> {
+        Self::require_admin(&env)?;
+        if !env.storage().persistent().has(&DataKey::Gist(gist_id)) {
+            return Err(GistError::NotFound);
+        }
+        env.storage().persistent().remove(&DataKey::Gist(gist_id));
+        env.events()
+            .publish((Symbol::new(&env, "gist_removed"),), gist_id);
+        Ok(())
+    }
+
+    /// Flag a gist for off-chain review. Callable by anyone; advisory only —
+    /// it never hides content on its own.
+    pub fn report_gist(env: Env, gist_id: u64) -> Result<u32, GistError> {
+        if !env.storage().persistent().has(&DataKey::Gist(gist_id)) {
+            return Err(GistError::NotFound);
+        }
+        let key = DataKey::Reports(gist_id);
+        let count: u32 = env.storage().persistent().get(&key).unwrap_or(0) + 1;
+        env.storage().persistent().set(&key, &count);
+        env.events()
+            .publish((Symbol::new(&env, "gist_reported"),), (gist_id, count));
+        Ok(count)
+    }
+
+    /// Number of reports filed against a gist.
+    pub fn report_count(env: Env, gist_id: u64) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Reports(gist_id))
+            .unwrap_or(0)
+    }
+
+    // -----------------------------------------------------------------------
+    // Author edit / delete (#879)
+    // -----------------------------------------------------------------------
+
+    /// Replace a gist's content pointer. Original author only.
+    ///
+    /// Anonymous gists cannot be edited — there is no provable owner.
+    pub fn edit_gist(env: Env, gist_id: u64, new_content_hash: String) -> Result<(), GistError> {
+        let mut gist = Self::load_authored(&env, gist_id)?;
+        gist.content_hash = new_content_hash;
+        env.storage().persistent().set(&DataKey::Gist(gist_id), &gist);
+        env.events()
+            .publish((Symbol::new(&env, "gist_edited"),), gist);
+        Ok(())
+    }
+
+    /// Delete your own gist. Original author only.
+    ///
+    /// Anonymous gists cannot be deleted by users — only moderated.
+    pub fn delete_gist(env: Env, gist_id: u64) -> Result<(), GistError> {
+        Self::load_authored(&env, gist_id)?;
+        env.storage().persistent().remove(&DataKey::Gist(gist_id));
+        env.events()
+            .publish((Symbol::new(&env, "gist_deleted"),), gist_id);
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    /// Require that the call is authorized by the configured moderator.
+    fn require_admin(env: &Env) -> Result<(), GistError> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(GistError::NotInitialized)?;
+        admin.require_auth();
+        Ok(())
+    }
+
+    /// Load a gist, requiring that the call is authorized by its author.
+    fn load_authored(env: &Env, gist_id: u64) -> Result<Gist, GistError> {
+        let gist: Gist = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Gist(gist_id))
+            .ok_or(GistError::NotFound)?;
+
+        match gist.author.clone() {
+            // A different address cannot pass this: the transaction must carry
+            // an authorization entry for the stored author.
+            Some(author) => author.require_auth(),
+            None => return Err(GistError::AnonymousImmutable),
+        }
+        Ok(gist)
+    }
+
+    /// Set the `hidden` flag on an existing gist.
+    fn set_hidden(env: &Env, gist_id: u64, hidden: bool) -> Result<(), GistError> {
+        let mut gist: Gist = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Gist(gist_id))
+            .ok_or(GistError::NotFound)?;
+        gist.hidden = hidden;
+        env.storage().persistent().set(&DataKey::Gist(gist_id), &gist);
+        Ok(())
     }
 }
 
@@ -473,5 +645,242 @@ mod tests {
         let client = setup(&env);
 
         assert_eq!(client.list_gists_by_cell(&cell(&env, "nope"), &0, &10).len(), 0);
+    }
+
+    // -- initialization / moderator (#878) -----------------------------------
+
+    #[test]
+    fn initialize_sets_the_admin_once() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup(&env);
+        let admin = Address::generate(&env);
+
+        assert!(client.get_admin().is_none());
+        client.initialize(&admin);
+        assert_eq!(client.get_admin(), Some(admin.clone()));
+
+        assert_eq!(
+            client.try_initialize(&admin),
+            Err(Ok(GistError::AlreadyInitialized))
+        );
+    }
+
+    #[test]
+    fn moderation_before_initialize_is_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup(&env);
+
+        let id = client.post_gist(&None, &cell(&env, "r3gx"), &cell(&env, "Qm1"), &None);
+
+        assert_eq!(
+            client.try_hide_gist(&id),
+            Err(Ok(GistError::NotInitialized))
+        );
+    }
+
+    #[test]
+    fn moderator_can_hide_and_unhide_a_gist() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup(&env);
+        client.initialize(&Address::generate(&env));
+
+        let location = cell(&env, "r3gx");
+        let id = client.post_gist(&None, &location, &cell(&env, "Qm1"), &None);
+        assert!(client.is_active(&id));
+
+        client.hide_gist(&id);
+
+        // excluded from listings and inactive, but still auditable
+        assert_eq!(client.list_gists_by_cell(&location, &0, &10).len(), 0);
+        assert!(!client.is_active(&id));
+        let gist = client.get_gist(&id).expect("hidden gist is still retrievable");
+        assert!(gist.hidden);
+
+        client.unhide_gist(&id);
+        assert!(client.is_active(&id));
+        assert_eq!(client.list_gists_by_cell(&location, &0, &10).len(), 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn hiding_without_moderator_authorization_is_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup(&env);
+        client.initialize(&Address::generate(&env));
+        let id = client.post_gist(&None, &cell(&env, "r3gx"), &cell(&env, "Qm1"), &None);
+
+        // Drop the mocked authorizations: the admin's require_auth can no
+        // longer be satisfied, so moderation must fail.
+        env.set_auths(&[]);
+        client.hide_gist(&id);
+    }
+
+    #[test]
+    fn moderator_can_remove_a_gist_permanently() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup(&env);
+        client.initialize(&Address::generate(&env));
+
+        let location = cell(&env, "r3gx");
+        let id = client.post_gist(&None, &location, &cell(&env, "Qm1"), &None);
+
+        client.remove_gist(&id);
+
+        assert!(client.get_gist(&id).is_none());
+        assert!(!client.is_active(&id));
+        assert_eq!(client.list_gists_by_cell(&location, &0, &10).len(), 0);
+        // removing again reports NotFound
+        assert_eq!(client.try_remove_gist(&id), Err(Ok(GistError::NotFound)));
+    }
+
+    #[test]
+    fn moderating_an_unknown_gist_reports_not_found() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup(&env);
+        client.initialize(&Address::generate(&env));
+
+        assert_eq!(client.try_hide_gist(&999), Err(Ok(GistError::NotFound)));
+    }
+
+    // -- reporting (#878, advisory) -----------------------------------------
+
+    #[test]
+    fn anyone_can_report_and_reports_accumulate() {
+        let env = Env::default();
+        let client = setup(&env);
+
+        let location = cell(&env, "r3gx");
+        let id = client.post_gist(&None, &location, &cell(&env, "Qm1"), &None);
+
+        assert_eq!(client.report_count(&id), 0);
+        assert_eq!(client.report_gist(&id), 1);
+        assert_eq!(client.report_gist(&id), 2);
+        assert_eq!(client.report_count(&id), 2);
+
+        // reporting is advisory — it must not hide the gist on its own
+        assert!(client.is_active(&id));
+        assert_eq!(client.list_gists_by_cell(&location, &0, &10).len(), 1);
+
+        assert_eq!(client.try_report_gist(&999), Err(Ok(GistError::NotFound)));
+    }
+
+    // -- author edit / delete (#879) ----------------------------------------
+
+    #[test]
+    fn author_can_edit_their_own_gist() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup(&env);
+
+        let author = Address::generate(&env);
+        let id = client.post_gist(
+            &Some(author),
+            &cell(&env, "r3gx"),
+            &cell(&env, "QmOld"),
+            &None,
+        );
+
+        client.edit_gist(&id, &cell(&env, "QmNew"));
+
+        let gist = client.get_gist(&id).unwrap();
+        assert_eq!(gist.content_hash, cell(&env, "QmNew"));
+        // metadata is preserved
+        assert_eq!(gist.gist_id, id);
+    }
+
+    #[test]
+    fn author_can_delete_their_own_gist() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup(&env);
+
+        let author = Address::generate(&env);
+        let location = cell(&env, "r3gx");
+        let id = client.post_gist(&Some(author), &location, &cell(&env, "Qm1"), &None);
+
+        client.delete_gist(&id);
+
+        assert!(client.get_gist(&id).is_none());
+        assert_eq!(client.list_gists_by_cell(&location, &0, &10).len(), 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn a_different_address_cannot_edit_someone_elses_gist() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup(&env);
+
+        let author = Address::generate(&env);
+        let id = client.post_gist(
+            &Some(author),
+            &cell(&env, "r3gx"),
+            &cell(&env, "QmOld"),
+            &None,
+        );
+
+        // Without the author's authorization the edit must be rejected.
+        env.set_auths(&[]);
+        client.edit_gist(&id, &cell(&env, "QmHijacked"));
+    }
+
+    #[test]
+    fn anonymous_gists_cannot_be_edited_or_deleted() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup(&env);
+
+        let id = client.post_gist(&None, &cell(&env, "r3gx"), &cell(&env, "Qm1"), &None);
+
+        assert_eq!(
+            client.try_edit_gist(&id, &cell(&env, "QmNew")),
+            Err(Ok(GistError::AnonymousImmutable))
+        );
+        assert_eq!(
+            client.try_delete_gist(&id),
+            Err(Ok(GistError::AnonymousImmutable))
+        );
+    }
+
+    #[test]
+    fn editing_an_unknown_gist_reports_not_found() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup(&env);
+
+        assert_eq!(
+            client.try_edit_gist(&999, &cell(&env, "QmNew")),
+            Err(Ok(GistError::NotFound))
+        );
+        assert_eq!(client.try_delete_gist(&999), Err(Ok(GistError::NotFound)));
+    }
+
+    // -- interaction between features ---------------------------------------
+
+    #[test]
+    fn moderation_and_expiry_are_independent() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup(&env);
+        client.initialize(&Address::generate(&env));
+        env.ledger().set_timestamp(1_000);
+
+        let location = cell(&env, "r3gx");
+        let id = client.post_gist(&None, &location, &cell(&env, "Qm1"), &Some(100u64));
+
+        client.hide_gist(&id);
+        assert!(!client.is_active(&id));
+
+        // unhiding an expired gist does not resurrect it
+        env.ledger().set_timestamp(1_000 + 500);
+        client.unhide_gist(&id);
+        assert!(!client.is_active(&id));
+        assert_eq!(client.list_gists_by_cell(&location, &0, &10).len(), 0);
     }
 }


### PR DESCRIPTION
## Summary
Completes **Wave 1** on top of the authorship/expiry/cooldown foundation from
#887: moderation, author edit/delete, full test coverage, and deploy tooling.

## Changes

### #878 — Moderation with access control
- `initialize(admin)` sets the moderator **once**, at deploy time. Posting still
  works without initialization; only moderator actions require it.
- `hide_gist` / `unhide_gist` — **soft, reversible**. Hidden gists are excluded
  from `list_gists_by_cell` and report `is_active == false`, but `get_gist` still
  returns them with `hidden = true`, so moderation stays **auditable**.
- `remove_gist` — permanent deletion, for content that must not persist.
- All three `require_auth` on the moderator; a non-moderator cannot call them.
- `report_gist` — anyone can flag a gist for off-chain review. **Advisory only**:
  it never hides content on its own.

### #879 — Author edit / delete
- `edit_gist(gist_id, new_content_hash)` and `delete_gist(gist_id)` `require_auth`
  on the **stored author**, so a different address cannot touch someone's gist.
- Anonymous gists have no provable owner, so they're rejected with
  `AnonymousImmutable` — they can only be moderated.

### #880 — Test coverage
**26 tests, all passing** — every rule plus its rejection path:
forged author rejected · TTL bounds · cooldown hit/expiry/other-cell ·
expired excluded from listings · pagination · moderator hide/unhide/remove ·
non-moderator rejected · uninitialized rejected · not-found paths ·
author edit/delete · third-party edit rejected · anonymous immutability ·
moderation-vs-expiry interaction.

### #881 — Deploy tooling & integration spec
- `scripts/deploy-testnet.sh` — tests, builds the release WASM, deploys, and
  calls `initialize`, then prints the contract id and next steps.
- `README.md` documents the full ABI, all **7 events**, the 8 error codes,
  moderation/ownership rules, a Deployments table, and a **Wave 2 backend
  integration checklist**.

## Verification
- `cargo test` — **26 passed, 0 failed**.
- `cargo build` — **0 warnings**.
- Deploy script syntax-checked (`bash -n`).

## Not done — needs you
**The actual testnet deployment.** It requires a funded Stellar keypair and
network access, and the toolchain here has no `rustup` to add the
`wasm32-unknown-unknown` target, so the release-WASM build is also unverified.
Run `./scripts/deploy-testnet.sh <identity>` and record the contract id in the
README's Deployments table. Everything else for #881 is in place.

## Downstream note (Wave 2)
`post_gist` takes a 4th arg (`ttl_secs`) and returns a `Result`; `cursor` is now
a `u32` offset into the cell index; the `Gist` payload gained `expires_at` and
`hidden`; and there are 6 new events beyond `gist_posted`. The backend's
`soroban.service.ts` still calls the old 3-arg form — harmless while it runs in
mock mode. The README has the full checklist.

Closes #878
Closes #879
Closes #880
Closes #881
