### PR TITLE
feat: add pre-deploy infrastructure dependency health checks (#754)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ cilium
 
 # OS / editor
 .DS_Store
+
+# Dependency health check reports (generated locally/in CI, not committed)
+infrastructure/ci/reports/

--- a/infrastructure/ci/pre-deploy-checks.yml
+++ b/infrastructure/ci/pre-deploy-checks.yml
@@ -1,0 +1,105 @@
+name: Pre-Deploy Dependency Health Checks
+
+# Reusable gate that every deploy pipeline (deploy-dev.yml, deploy-staging.yml,
+# deploy-production.yml) calls before touching the target environment. Blocks
+# the deploy if a critical dependency (database, Soroban RPC) is unhealthy.
+#
+# Called from another workflow like:
+#
+#   jobs:
+#     pre-deploy-checks:
+#       uses: ./infrastructure/ci/pre-deploy-checks.yml
+#       with:
+#         environment: staging
+#       secrets: inherit
+#
+#     deploy-staging:
+#       needs: pre-deploy-checks
+#       ...
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: 'Target environment (dev, staging, production)'
+        required: true
+        type: string
+      emergency_bypass:
+        description: 'Skip the blocking gate if a dependency is unhealthy'
+        required: false
+        type: boolean
+        default: false
+      emergency_reason:
+        description: 'Required justification when emergency_bypass is true'
+        required: false
+        type: string
+        default: ''
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment (dev, staging, production)'
+        required: true
+        type: choice
+        options: [dev, staging, production]
+      emergency_bypass:
+        description: 'Skip the blocking gate if a dependency is unhealthy'
+        required: false
+        type: boolean
+        default: false
+      emergency_reason:
+        description: 'Required justification when emergency_bypass is true'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  check-dependencies:
+    name: Check Infrastructure Dependencies (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate emergency bypass input
+        if: ${{ inputs.emergency_bypass && inputs.emergency_reason == '' }}
+        run: |
+          echo "emergency_bypass is true but emergency_reason was not provided."
+          echo "A reason is required so the bypass is auditable. Aborting."
+          exit 1
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y jq postgresql-client
+
+      - name: Run dependency health checks
+        id: health-checks
+        env:
+          DATABASE_HOST: ${{ secrets.DATABASE_HOST }}
+          DATABASE_PORT: ${{ secrets.DATABASE_PORT }}
+          DATABASE_NAME: ${{ secrets.DATABASE_NAME }}
+          DATABASE_USER: ${{ secrets.DATABASE_USER }}
+          DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+          SOROBAN_RPC_URL: ${{ vars.SOROBAN_RPC_URL }}
+          IPFS_GATEWAY: ${{ vars.IPFS_GATEWAY }}
+          PINATA_API_KEY: ${{ secrets.PINATA_API_KEY }}
+          PINATA_SECRET_KEY: ${{ secrets.PINATA_SECRET_KEY }}
+          EMERGENCY_BYPASS: ${{ inputs.emergency_bypass }}
+          EMERGENCY_REASON: ${{ inputs.emergency_reason }}
+        run: |
+          bash infrastructure/scripts/check-dependencies.sh
+
+      - name: Upload dependency health report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-health-${{ inputs.environment }}
+          path: infrastructure/ci/reports/dependency-health-*.json
+          retention-days: 30
+
+      - name: Notify on block
+        if: failure()
+        run: |
+          echo "Deploy to ${{ inputs.environment }} blocked: one or more infrastructure dependencies are unhealthy."
+          echo "See the dependency-health report artifact for details."
+          echo "To bypass for a genuine emergency, re-run with emergency_bypass=true and a emergency_reason."

--- a/infrastructure/docs/dependency-map.md
+++ b/infrastructure/docs/dependency-map.md
@@ -1,0 +1,63 @@
+# Infrastructure Dependency Map
+
+This document lists every external dependency GistPin needs at runtime, how
+each one is checked before a deploy, and what happens when a check fails.
+
+The checks below are implemented in
+[`infrastructure/scripts/check-dependencies.sh`](../scripts/check-dependencies.sh)
+and run as a gate in
+[`infrastructure/ci/pre-deploy-checks.yml`](./pre-deploy-checks.yml) before
+`deploy-dev.yml`, `deploy-staging.yml`, and `deploy-production.yml`.
+
+## Dependencies
+
+| Dependency | Used for | Critical | Check | Env vars |
+|---|---|---|---|---|
+| Postgres/PostGIS | Primary data store for gists, geospatial queries | Yes | TCP reachability (`pg_isready`, falls back to `/dev/tcp`) plus a real `SELECT 1` query | `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_NAME`, `DATABASE_USER`, `DATABASE_PASSWORD` |
+| Soroban RPC (Stellar) | Reading/submitting gist registry contract transactions | Yes | JSON-RPC `getHealth` call, expects `"status":"healthy"` | `SOROBAN_RPC_URL` |
+| IPFS gateway (Pinata) | Serving pinned gist content | No | HTTP reachability check against the gateway root | `IPFS_GATEWAY` |
+| Pinata pinning API | Pinning new gist content to IPFS | No | `testAuthentication` call with the configured API key/secret. Skipped entirely when keys are blank, since dev falls back to mock CIDs | `PINATA_API_KEY`, `PINATA_SECRET_KEY` |
+
+"Critical" dependencies block a deploy on failure. Non-critical dependencies
+are still checked and reported, but a failure there degrades functionality
+(e.g. new content can't be pinned) rather than making the app fully
+unavailable, so they don't block by themselves.
+
+## Blocking behavior
+
+`check-dependencies.sh` exits non-zero if any **critical** dependency is
+unhealthy, and the `pre-deploy-checks.yml` job fails, which blocks the
+downstream deploy job via `needs:`. Non-critical failures are recorded in
+the report but do not change the exit code.
+
+Every run writes a timestamped JSON report to
+`infrastructure/ci/reports/dependency-health-<timestamp>.json` and uploads
+it as a workflow artifact so failures can be diagnosed after the fact
+without re-running the pipeline.
+
+## Emergency bypass
+
+Sometimes a deploy needs to go out despite a check that's failing for a
+known, already-mitigated reason (e.g. a flaky health probe during a
+provider incident that's been confirmed manually). The bypass:
+
+- Requires **both** `emergency_bypass: true` and a non-empty
+  `emergency_reason` -- the workflow refuses to run without a reason.
+- Still runs every check and writes the report, so the unhealthy state is
+  on record even though it didn't block.
+- Logs a `WARN` line with the reason so it shows up clearly in the job log
+  and in the report's `emergency_reason` field.
+
+Bypass is meant for genuine incidents, not for routinely skipping the gate.
+If a check is flaky or wrong, fix the check -- don't reach for the bypass.
+
+## Adding a new dependency
+
+1. Add a `check_<name>()` function to `check-dependencies.sh` following the
+   existing pattern (log start, run the check, call `record` with
+   `name|status|critical|detail`).
+2. Call it from `main()`.
+3. Add a row to the table above.
+4. If the CI job needs a new secret or variable to reach it, add it to
+   `pre-deploy-checks.yml`'s `env:` block for the `Run dependency health
+   checks` step.

--- a/infrastructure/scripts/check-dependencies.sh
+++ b/infrastructure/scripts/check-dependencies.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Pre-deploy infrastructure dependency health checks.
+#
+# Verifies that every external dependency GistPin needs at runtime is
+# reachable before a deploy is allowed to proceed. Intended to run as a
+# gate in infrastructure/ci/pre-deploy-checks.yml, but is safe to run
+# locally too.
+#
+# Checks:
+#   - Database (Postgres/PostGIS) reachability + a real query
+#   - Soroban RPC (Stellar) availability via its getHealth method
+#   - IPFS gateway / Pinata pinning API availability
+#
+# Exit code:
+#   0  all critical checks passed (or EMERGENCY_BYPASS was used)
+#   1  one or more critical checks failed and no bypass was given
+#
+# Emergency bypass:
+#   EMERGENCY_BYPASS=true EMERGENCY_REASON="incident-1234, DB flaky but confirmed up manually" \
+#     ./infrastructure/scripts/check-dependencies.sh
+#   Bypass still runs every check and writes the report -- it only changes
+#   whether a failed check blocks the exit code. EMERGENCY_REASON is
+#   required and gets embedded in the report for audit purposes.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+# --- Config (env-overridable, matches Backend/.env.example) -----------------
+DATABASE_HOST="${DATABASE_HOST:-localhost}"
+DATABASE_PORT="${DATABASE_PORT:-5432}"
+DATABASE_NAME="${DATABASE_NAME:-gistpin}"
+DATABASE_USER="${DATABASE_USER:-gistpin}"
+DATABASE_PASSWORD="${DATABASE_PASSWORD:-}"
+
+SOROBAN_RPC_URL="${SOROBAN_RPC_URL:-https://soroban-testnet.stellar.org}"
+
+IPFS_GATEWAY="${IPFS_GATEWAY:-https://gateway.pinata.cloud/ipfs}"
+PINATA_API_KEY="${PINATA_API_KEY:-}"
+PINATA_SECRET_KEY="${PINATA_SECRET_KEY:-}"
+
+TIMEOUT="${TIMEOUT:-10}"
+REPORT_DIR="${REPORT_DIR:-infrastructure/ci/reports}"
+
+EMERGENCY_BYPASS="${EMERGENCY_BYPASS:-false}"
+EMERGENCY_REASON="${EMERGENCY_REASON:-}"
+
+log()  { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+warn() { log "WARN: $*"; }
+fail() { log "FAIL: $*"; }
+
+mkdir -p "${REPORT_DIR}"
+TIMESTAMP="$(date -u +%Y%m%d-%H%M%S)"
+REPORT_FILE="${REPORT_DIR}/dependency-health-${TIMESTAMP}.json"
+
+RESULTS=()   # each entry: name|status|critical|detail
+OVERALL_OK=true
+
+record() {
+  local name="$1" status="$2" critical="$3" detail="$4"
+  RESULTS+=("${name}|${status}|${critical}|${detail}")
+  if [[ "${status}" != "ok" && "${critical}" == "true" ]]; then
+    OVERALL_OK=false
+  fi
+}
+
+# --- Checks -------------------------------------------------------------
+
+check_database() {
+  log "Checking database reachability at ${DATABASE_HOST}:${DATABASE_PORT}..."
+
+  if command -v pg_isready >/dev/null 2>&1; then
+    if ! pg_isready -h "${DATABASE_HOST}" -p "${DATABASE_PORT}" -t "${TIMEOUT}" >/dev/null 2>&1; then
+      fail "Database not reachable at ${DATABASE_HOST}:${DATABASE_PORT}"
+      record "database" "error" "true" "pg_isready failed against ${DATABASE_HOST}:${DATABASE_PORT}"
+      return
+    fi
+  elif ! timeout "${TIMEOUT}" bash -c "echo > /dev/tcp/${DATABASE_HOST}/${DATABASE_PORT}" 2>/dev/null; then
+    fail "Database not reachable at ${DATABASE_HOST}:${DATABASE_PORT}"
+    record "database" "error" "true" "TCP connect failed to ${DATABASE_HOST}:${DATABASE_PORT}"
+    return
+  fi
+
+  if command -v psql >/dev/null 2>&1; then
+    local result
+    result=$(PGPASSWORD="${DATABASE_PASSWORD}" psql -h "${DATABASE_HOST}" -p "${DATABASE_PORT}" \
+      -U "${DATABASE_USER}" -d "${DATABASE_NAME}" -tAc "SELECT 1" 2>&1 || true)
+    if [[ "${result}" != "1" ]]; then
+      fail "Database query check failed: ${result}"
+      record "database" "error" "true" "SELECT 1 did not return 1: ${result}"
+      return
+    fi
+  else
+    warn "psql not available, skipping query-level check"
+  fi
+
+  log "Database OK"
+  record "database" "ok" "true" "reachable and query check passed"
+}
+
+check_soroban_rpc() {
+  log "Checking Soroban RPC at ${SOROBAN_RPC_URL}..."
+
+  local response
+  response=$(curl -s -m "${TIMEOUT}" -X POST "${SOROBAN_RPC_URL}" \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}' 2>&1 || true)
+
+  if echo "${response}" | grep -q '"status"[[:space:]]*:[[:space:]]*"healthy"'; then
+    log "Soroban RPC OK"
+    record "soroban_rpc" "ok" "true" "getHealth returned healthy"
+  else
+    fail "Soroban RPC did not report healthy: ${response}"
+    record "soroban_rpc" "error" "true" "unexpected getHealth response: ${response}"
+  fi
+}
+
+check_ipfs_gateway() {
+  log "Checking IPFS gateway at ${IPFS_GATEWAY}..."
+
+  local status
+  status=$(curl -s -o /dev/null -w '%{http_code}' -m "${TIMEOUT}" "${IPFS_GATEWAY}" 2>/dev/null || true)
+  status="${status:-000}"
+
+  # Gateway root commonly returns 4xx (no CID given) -- any real HTTP
+  # response means the gateway itself is up. 000 means unreachable.
+  if [[ "${status}" == "000" ]]; then
+    fail "IPFS gateway unreachable at ${IPFS_GATEWAY}"
+    record "ipfs_gateway" "error" "false" "no response from ${IPFS_GATEWAY}"
+  else
+    log "IPFS gateway OK (HTTP ${status})"
+    record "ipfs_gateway" "ok" "false" "responded with HTTP ${status}"
+  fi
+}
+
+check_pinata_api() {
+  if [[ -z "${PINATA_API_KEY}" || -z "${PINATA_SECRET_KEY}" ]]; then
+    log "Pinata API keys not configured, skipping (dev uses mock CIDs)"
+    record "pinata_api" "skipped" "false" "PINATA_API_KEY/PINATA_SECRET_KEY not set"
+    return
+  fi
+
+  log "Checking Pinata API authentication..."
+  local status
+  status=$(curl -s -o /dev/null -w '%{http_code}' -m "${TIMEOUT}" \
+    -H "pinata_api_key: ${PINATA_API_KEY}" \
+    -H "pinata_secret_api_key: ${PINATA_SECRET_KEY}" \
+    "https://api.pinata.cloud/data/testAuthentication" 2>/dev/null || true)
+  status="${status:-000}"
+
+  if [[ "${status}" == "200" ]]; then
+    log "Pinata API OK"
+    record "pinata_api" "ok" "false" "testAuthentication returned HTTP 200"
+  else
+    fail "Pinata API auth check failed (HTTP ${status})"
+    record "pinata_api" "error" "false" "testAuthentication returned HTTP ${status}"
+  fi
+}
+
+# --- Report ---------------------------------------------------------------
+
+write_report() {
+  local entries_json="[]"
+  local entry
+  for entry in "${RESULTS[@]}"; do
+    IFS='|' read -r name status critical detail <<< "${entry}"
+    entries_json=$(echo "${entries_json}" | jq \
+      --arg name "${name}" --arg status "${status}" \
+      --argjson critical "${critical}" --arg detail "${detail}" \
+      '. + [{name: $name, status: $status, critical: $critical, detail: $detail}]')
+  done
+
+  jq -n \
+    --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --argjson overall_ok "${OVERALL_OK}" \
+    --argjson bypassed "${EMERGENCY_BYPASS}" \
+    --arg bypass_reason "${EMERGENCY_REASON}" \
+    --argjson checks "${entries_json}" \
+    '{timestamp: $timestamp, overall_ok: $overall_ok, emergency_bypass: $bypassed, emergency_reason: $bypass_reason, checks: $checks}' \
+    > "${REPORT_FILE}"
+
+  log "Report written to ${REPORT_FILE}"
+}
+
+main() {
+  log "Starting pre-deploy dependency health checks..."
+
+  if ! command -v jq >/dev/null 2>&1; then
+    fail "jq is required to run this script"
+    exit 1
+  fi
+
+  check_database
+  check_soroban_rpc
+  check_ipfs_gateway
+  check_pinata_api
+
+  write_report
+
+  if [[ "${OVERALL_OK}" == "true" ]]; then
+    log "All critical dependencies healthy. Deploy may proceed."
+    exit 0
+  fi
+
+  fail "One or more critical dependencies are unhealthy."
+
+  if [[ "${EMERGENCY_BYPASS}" == "true" ]]; then
+    if [[ -z "${EMERGENCY_REASON}" ]]; then
+      fail "EMERGENCY_BYPASS set but EMERGENCY_REASON is empty. Refusing to bypass without a reason."
+      exit 1
+    fi
+    warn "EMERGENCY_BYPASS active -- proceeding despite unhealthy dependencies."
+    warn "Reason on record: ${EMERGENCY_REASON}"
+    exit 0
+  fi
+
+  fail "Blocking deploy. Re-run with EMERGENCY_BYPASS=true and EMERGENCY_REASON=\"...\" only for genuine emergencies."
+  exit 1
+}
+
+main "$@"


### PR DESCRIPTION
- Add check-dependencies.sh: checks Postgres/PostGIS reachability + a real query, Soroban RPC via getHealth, and the IPFS/Pinata gateway + pinning API (skipped when keys are unset, matching existing dev behavior). Writes a timestamped JSON report and supports EMERGENCY_BYPASS + a required EMERGENCY_REASON for genuine incidents.
- Add pre-deploy-checks.yml: reusable workflow_call gate that runs the script, uploads the report as an artifact, and blocks the downstream deploy job on unhealthy critical dependencies.
- Add dependency-map.md documenting each dependency, its criticality, how it's checked, and the bypass procedure.
- Ignore infrastructure/ci/reports/ (generated run artifacts).

Verified locally: blocked-deploy path, healthy-critical-with-bypass path, valid-bypass-with-reason path, and refused-bypass-without-reason path all exercised against real network calls and a real closed DB port.

Closes #754