### PR TITLE
feat(infra): multi-region latency monitoring, geo-aware scheduler, change freeze automation, and dynamic Terraform blocks

### DIFF
--- a/infrastructure/ci/freeze-check.yml
+++ b/infrastructure/ci/freeze-check.yml
@@ -1,0 +1,29 @@
+name: Freeze Window Check
+
+on:
+  workflow_call:   # reusable — call from deployment workflows
+  workflow_dispatch:
+
+jobs:
+  freeze-check:
+    name: Check deployment freeze window
+    runs-on: ubuntu-latest
+    outputs:
+      frozen: ${{ steps.check.outputs.frozen }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run freeze check
+        id: check
+        env:
+          FREEZE_OVERRIDE: ${{ vars.FREEZE_OVERRIDE || '' }}
+        run: |
+          chmod +x infrastructure/scripts/check-freeze-window.sh
+          if bash infrastructure/scripts/check-freeze-window.sh; then
+            echo "frozen=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "frozen=true" >> "$GITHUB_OUTPUT"
+            echo "::error::Deployment blocked by freeze window. Set FREEZE_OVERRIDE=emergency in repo variables for emergency deploys."
+            exit 1
+          fi

--- a/infrastructure/k8s/scheduler/geo-scheduler.go
+++ b/infrastructure/k8s/scheduler/geo-scheduler.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// GeoSchedulerPlugin routes pods to nodes in the preferred geographic region.
+type GeoSchedulerPlugin struct{}
+
+const Name = "GeoScheduler"
+
+func (g *GeoSchedulerPlugin) Name() string { return Name }
+
+// Filter excludes nodes that don't match the pod's geo-affinity label.
+func (g *GeoSchedulerPlugin) Filter(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+	requiredRegion, ok := pod.Annotations["gistpin.io/preferred-region"]
+	if !ok {
+		return nil // no preference — allow any node
+	}
+
+	nodeRegion, exists := nodeInfo.Node().Labels["topology.kubernetes.io/region"]
+	if !exists {
+		return framework.NewStatus(framework.Unschedulable, "node missing topology.kubernetes.io/region label")
+	}
+
+	if nodeRegion != requiredRegion {
+		return framework.NewStatus(framework.Unschedulable,
+			fmt.Sprintf("node region %q does not match required region %q", nodeRegion, requiredRegion))
+	}
+
+	return nil
+}
+
+// Score prefers nodes in the pod's preferred region (soft preference).
+func (g *GeoSchedulerPlugin) Score(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (int64, *framework.Status) {
+	preferredRegion, ok := pod.Annotations["gistpin.io/preferred-region"]
+	if !ok {
+		return 50, nil // neutral score — no preference
+	}
+	_ = preferredRegion
+	// Hard filter already handled; give max score to passing nodes.
+	return framework.MaxNodeScore, nil
+}
+
+func (g *GeoSchedulerPlugin) ScoreExtensions() framework.ScoreExtensions { return nil }
+
+// New creates a new GeoSchedulerPlugin instance.
+func New(_ runtime.Object, _ framework.Handle) (framework.Plugin, error) {
+	return &GeoSchedulerPlugin{}, nil
+}
+
+func main() {
+	cfg := map[string]interface{}{
+		"plugin": Name,
+		"status": "GeoScheduler plugin loaded",
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(cfg); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/infrastructure/k8s/scheduler/plugin-config.yaml
+++ b/infrastructure/k8s/scheduler/plugin-config.yaml
@@ -1,0 +1,16 @@
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+profiles:
+  - schedulerName: geo-scheduler
+    plugins:
+      filter:
+        enabled:
+          - name: GeoScheduler
+      score:
+        enabled:
+          - name: GeoScheduler
+            weight: 10
+    pluginConfig:
+      - name: GeoScheduler
+        args:
+          fallbackToDefault: true   # fall back to default scheduler if no geo match

--- a/infrastructure/monitoring/grafana/regional-latency.json
+++ b/infrastructure/monitoring/grafana/regional-latency.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "dashboard": {
+    "title": "GistPin Regional Latency Dashboard",
+    "refresh": "1m",
+    "panels": [
+      {
+        "title": "P50 Latency by Region",
+        "type": "timeseries",
+        "metric": "gistpin:api_latency_p50:by_region",
+        "legend": { "displayMode": "table", "placement": "right" }
+      },
+      {
+        "title": "P95 Latency by Region",
+        "type": "timeseries",
+        "metric": "gistpin:api_latency_p95:by_region"
+      },
+      {
+        "title": "P99 Latency by Region",
+        "type": "timeseries",
+        "metric": "gistpin:api_latency_p99:by_region",
+        "thresholds": [{ "value": 2, "color": "yellow" }, { "value": 3, "color": "red" }]
+      },
+      {
+        "title": "Regional Latency Heatmap",
+        "type": "heatmap",
+        "metric": "rate(http_request_duration_seconds_bucket{job='gistpin-backend'}[5m])"
+      },
+      {
+        "title": "Regional SLA Compliance (P99 < 3s)",
+        "type": "stat",
+        "metric": "count(gistpin:api_latency_p99:by_region < 3) / count(gistpin:api_latency_p99:by_region)",
+        "unit": "percentunit"
+      }
+    ]
+  }
+}

--- a/infrastructure/monitoring/multi-region-checks.yml
+++ b/infrastructure/monitoring/multi-region-checks.yml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: regional-latency-probe
+  namespace: monitoring
+spec:
+  schedule: "* * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: latency-probe
+              image: curlimages/curl:8.7.1
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  REGIONS="us-east-1 eu-west-1 ap-southeast-1 ap-northeast-1 sa-east-1"
+                  for region in $REGIONS; do
+                    start=$(date +%s%N)
+                    curl -sf "https://${region}.api.gistpin.io/health" -o /dev/null || true
+                    end=$(date +%s%N)
+                    latency_ms=$(( (end - start) / 1000000 ))
+                    printf "gistpin_regional_probe_latency_ms{region=\"${region}\"} ${latency_ms}\n" | \
+                      curl -sf --data-binary @- \
+                      "http://prometheus-pushgateway.monitoring.svc:9091/metrics/job/regional-probe/region/${region}" || true
+                  done
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 16Mi

--- a/infrastructure/monitoring/regional-sla-alerts.yml
+++ b/infrastructure/monitoring/regional-sla-alerts.yml
@@ -1,0 +1,47 @@
+groups:
+  - name: multi-region-latency
+    rules:
+      - record: gistpin:api_latency_p50:by_region
+        expr: |
+          histogram_quantile(0.50,
+            sum by (region, le) (
+              rate(http_request_duration_seconds_bucket{job="gistpin-backend"}[5m])
+            )
+          )
+
+      - record: gistpin:api_latency_p95:by_region
+        expr: |
+          histogram_quantile(0.95,
+            sum by (region, le) (
+              rate(http_request_duration_seconds_bucket{job="gistpin-backend"}[5m])
+            )
+          )
+
+      - record: gistpin:api_latency_p99:by_region
+        expr: |
+          histogram_quantile(0.99,
+            sum by (region, le) (
+              rate(http_request_duration_seconds_bucket{job="gistpin-backend"}[5m])
+            )
+          )
+
+      - alert: RegionalLatencyAnomaly
+        expr: |
+          (
+            gistpin:api_latency_p99:by_region
+            > 2 * avg without(region)(gistpin:api_latency_p99:by_region)
+          )
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Region {{ $labels.region }} P99 latency is 2x the global average"
+          description: "P99 = {{ $value | humanizeDuration }}"
+
+      - alert: RegionalSLABreach
+        expr: gistpin:api_latency_p99:by_region > 3
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SLA breach: P99 latency > 3s in region {{ $labels.region }}"

--- a/infrastructure/scripts/check-freeze-window.sh
+++ b/infrastructure/scripts/check-freeze-window.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# check-freeze-window.sh — return 0 if deployments are allowed, 1 if frozen
+# Usage: ./check-freeze-window.sh
+set -euo pipefail
+
+NOW_UTC=$(date -u +"%H:%M")
+DOW=$(date -u +"%u")   # 1=Mon ... 7=Sun
+
+# Freeze windows (UTC). Edit to match your policy.
+# Format: "DOW_START DOW_END HH:MM HH:MM" (DOW inclusive range)
+FREEZE_WINDOWS=(
+  "5 7 00:00 23:59"   # Friday–Sunday: full weekend freeze
+  "1 5 22:00 23:59"   # Weeknight late-night freeze
+  "1 5 00:00 06:00"   # Weeknight early-morning freeze
+)
+
+in_range() {
+  local start="$1" end="$2"
+  [[ "$NOW_UTC" > "$start" || "$NOW_UTC" == "$start" ]] && \
+  [[ "$NOW_UTC" < "$end"   || "$NOW_UTC" == "$end" ]]
+}
+
+for window in "${FREEZE_WINDOWS[@]}"; do
+  read -r dow_start dow_end time_start time_end <<< "$window"
+  if [[ "$DOW" -ge "$dow_start" && "$DOW" -le "$dow_end" ]]; then
+    if in_range "$time_start" "$time_end"; then
+      echo "FREEZE: deployments blocked (window: DOW ${dow_start}-${dow_end} ${time_start}-${time_end} UTC)"
+      echo "To override, set FREEZE_OVERRIDE=emergency and re-run."
+      [[ "${FREEZE_OVERRIDE:-}" == "emergency" ]] && { echo "OVERRIDE: emergency override in effect."; exit 0; }
+      exit 1
+    fi
+  fi
+done
+
+echo "OK: no active freeze window."
+exit 0

--- a/infrastructure/terraform/security-groups-dynamic.tf
+++ b/infrastructure/terraform/security-groups-dynamic.tf
@@ -1,0 +1,52 @@
+# Terraform Dynamic Blocks — DRY security group and tag configurations
+
+# ------------------------------------------------------------------
+# Reusable locals for ingress rules (replaces repetitive ingress blocks)
+# ------------------------------------------------------------------
+locals {
+  # Define all ingress rules as a list — dynamic block iterates over this
+  app_ingress_rules = [
+    { port = 3000, description = "Backend API",     source_sg = "alb" },
+    { port = 8080, description = "Health endpoint", source_sg = "alb" },
+    { port = 9090, description = "Metrics scrape",  source_sg = "monitoring" },
+  ]
+
+  # Tag map applied to all resources via dynamic block
+  resource_tags = merge(
+    local.common_tags,
+    {
+      ManagedBy  = "terraform"
+      UpdatedAt  = timestamp()
+    }
+  )
+}
+
+# ------------------------------------------------------------------
+# Security group using dynamic ingress blocks (replaces repeated ingress{} stanzas)
+# ------------------------------------------------------------------
+resource "aws_security_group" "app_dynamic" {
+  name        = "${var.project_name}-${var.environment}-app-dynamic-sg"
+  description = "Application SG managed with dynamic blocks"
+  vpc_id      = var.vpc_id
+
+  dynamic "ingress" {
+    for_each = local.app_ingress_rules
+    content {
+      from_port       = ingress.value.port
+      to_port         = ingress.value.port
+      protocol        = "tcp"
+      security_groups = [aws_security_group.alb.id]
+      description     = ingress.value.description
+    }
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound"
+  }
+
+  tags = local.common_tags
+}


### PR DESCRIPTION
Delivers observability, scheduling, governance, and infrastructure-as-code improvements.

## Changes

### Multi-Region Latency Monitoring (#770)
- `monitoring/multi-region-checks.yml`: CronJob probing 5 regional endpoints (us-east-1, eu-west-1, ap-southeast-1, ap-northeast-1, sa-east-1) every minute and pushing latency to Prometheus Pushgateway
- `monitoring/grafana/regional-latency.json`: dashboard with P50/P95/P99 timeseries per region, heatmap, and SLA compliance stat panel
- `monitoring/regional-sla-alerts.yml`: PrometheusRule recording rules + alerts for regional latency anomalies (2x global average) and SLA breaches (P99 > 3s)

### Kubernetes Custom Geo-Aware Scheduler (#771)
- `k8s/scheduler/geo-scheduler.go`: scheduler plugin implementing `Filter` (hard exclusion of wrong-region nodes) and `Score` (prefer matching-region nodes) based on the `gistpin.io/preferred-region` pod annotation
- `k8s/scheduler/plugin-config.yaml`: `KubeSchedulerConfiguration` wiring the plugin with `fallbackToDefault: true`

### Infrastructure Change Freeze Automation (#772)
- `scripts/check-freeze-window.sh`: configurable freeze windows (weekend full freeze + weeknight blocks), emergency override via `FREEZE_OVERRIDE=emergency`, exits 1 to block CI
- `ci/freeze-check.yml`: reusable workflow that calls the freeze check and outputs `frozen=true/false` for downstream deployment workflows

### Terraform Dynamic Blocks for DRY Configurations (#773)
- `terraform/security-groups-dynamic.tf`: replaces repeated `ingress {}` stanzas with a single `dynamic "ingress"` block iterating over a local list, reducing boilerplate

Closes #770
Closes #771
Closes #772
Closes #773