### PR TITLE
feat(infra): init container dependency ordering, runbook executor, Slack plan notifications, and Istio traffic mirroring

### DIFF
--- a/infrastructure/ci/slack-plan-notify.yml
+++ b/infrastructure/ci/slack-plan-notify.yml
@@ -1,0 +1,48 @@
+name: Slack Terraform Plan Notification
+
+on:
+  workflow_call:
+    inputs:
+      plan_file:
+        required: true
+        type: string
+      pr_url:
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  notify:
+    name: Post plan diff to Slack
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download plan artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.plan_file }}
+          path: /tmp/plan
+
+      - name: Get cost estimate (infracost)
+        id: cost
+        continue-on-error: true
+        run: |
+          if command -v infracost &>/dev/null; then
+            COST=$(infracost diff --path infrastructure/terraform --format json \
+              | jq -r '.diffTotalMonthlyCost // "N/A"')
+          else
+            COST="N/A"
+          fi
+          echo "estimate=${COST}" >> "$GITHUB_OUTPUT"
+
+      - name: Send Slack notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          PR_URL: ${{ inputs.pr_url || github.event.pull_request.html_url }}
+          COST_ESTIMATE: ${{ steps.cost.outputs.estimate }}
+          SLACK_CHANNEL: ${{ vars.INFRA_SLACK_CHANNEL || '#infra-deploys' }}
+        run: |
+          chmod +x infrastructure/scripts/notify-plan.sh
+          bash infrastructure/scripts/notify-plan.sh \
+            --plan-file /tmp/plan/plan.txt

--- a/infrastructure/k8s/init-containers/db-ready.yaml
+++ b/infrastructure/k8s/init-containers/db-ready.yaml
@@ -1,0 +1,133 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-with-init
+  namespace: gistpin
+  labels:
+    app: gistpin-backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: gistpin-backend
+  template:
+    metadata:
+      labels:
+        app: gistpin-backend
+    spec:
+      initContainers:
+        # 1. Wait for PostgreSQL to accept connections
+        - name: wait-for-db
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for PostgreSQL at ${DB_HOST}:${DB_PORT}..."
+              ATTEMPTS=0
+              until nc -z "${DB_HOST:-postgres-service}" "${DB_PORT:-5432}"; do
+                ATTEMPTS=$((ATTEMPTS + 1))
+                if [ "${ATTEMPTS}" -ge 30 ]; then
+                  echo "ERROR: PostgreSQL not ready after 30 attempts. Aborting."
+                  exit 1
+                fi
+                echo "  attempt ${ATTEMPTS}/30 — retrying in 5s..."
+                sleep 5
+              done
+              echo "PostgreSQL is ready."
+          env:
+            - name: DB_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: backend-config
+                  key: DB_HOST
+            - name: DB_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: backend-config
+                  key: DB_PORT
+                  optional: true
+
+        # 2. Wait for Soroban RPC endpoint
+        - name: wait-for-soroban-rpc
+          image: curlimages/curl:8.7.1
+          command:
+            - sh
+            - -c
+            - |
+              RPC_URL="${SOROBAN_RPC_URL:-http://soroban-rpc:8000}"
+              echo "Waiting for Soroban RPC at ${RPC_URL}..."
+              ATTEMPTS=0
+              until curl -sf "${RPC_URL}/health" -o /dev/null; do
+                ATTEMPTS=$((ATTEMPTS + 1))
+                if [ "${ATTEMPTS}" -ge 20 ]; then
+                  echo "ERROR: Soroban RPC not ready after 20 attempts."
+                  exit 1
+                fi
+                echo "  attempt ${ATTEMPTS}/20 — retrying in 5s..."
+                sleep 5
+              done
+              echo "Soroban RPC is ready."
+          env:
+            - name: SOROBAN_RPC_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: backend-config
+                  key: SOROBAN_RPC_URL
+                  optional: true
+
+        # 3. Wait for IPFS gateway
+        - name: wait-for-ipfs
+          image: curlimages/curl:8.7.1
+          command:
+            - sh
+            - -c
+            - |
+              IPFS_URL="${IPFS_GATEWAY_URL:-http://ipfs-gateway:8080}"
+              echo "Waiting for IPFS gateway at ${IPFS_URL}..."
+              ATTEMPTS=0
+              until curl -sf "${IPFS_URL}/api/v0/version" -o /dev/null; do
+                ATTEMPTS=$((ATTEMPTS + 1))
+                if [ "${ATTEMPTS}" -ge 15 ]; then
+                  echo "WARN: IPFS gateway not ready — continuing anyway (non-critical)."
+                  exit 0
+                fi
+                sleep 5
+              done
+              echo "IPFS gateway is ready."
+          env:
+            - name: IPFS_GATEWAY_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: backend-config
+                  key: IPFS_GATEWAY_URL
+                  optional: true
+
+      containers:
+        - name: backend
+          image: ghcr.io/pinspace-org/gistpin-backend:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          envFrom:
+            - configMapRef:
+                name: backend-config
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/infrastructure/k8s/istio/traffic-mirror.yaml
+++ b/infrastructure/k8s/istio/traffic-mirror.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: gistpin-backend-mirror
+  namespace: gistpin
+spec:
+  hosts:
+    - gistpin-backend
+  http:
+    - match:
+        - uri:
+            prefix: /
+      route:
+        - destination:
+            host: gistpin-backend
+            port:
+              number: 3000
+          weight: 100
+      # Mirror 20% of production traffic to staging for realistic load testing.
+      # Responses from the mirror are discarded — no writes propagate.
+      mirror:
+        host: gistpin-backend-staging
+        port:
+          number: 3000
+      mirrorPercentage:
+        value: 20.0

--- a/infrastructure/runbooks/as-code/restart-backend.yaml
+++ b/infrastructure/runbooks/as-code/restart-backend.yaml
@@ -1,0 +1,26 @@
+title: Restart GistPin Backend
+description: Rolling restart of the backend deployment
+severity: low
+
+steps:
+  - name: Check current pod status
+    command: kubectl get pods -n gistpin -l app=gistpin-backend
+    requires_approval: false
+
+  - name: Confirm rollout health
+    command: kubectl rollout status deployment/backend-deployment -n gistpin --timeout=60s
+    requires_approval: false
+
+  - name: Trigger rolling restart
+    command: kubectl rollout restart deployment/backend-deployment -n gistpin
+    requires_approval: true
+    rollback: kubectl rollout undo deployment/backend-deployment -n gistpin
+
+  - name: Wait for rollout to complete
+    command: kubectl rollout status deployment/backend-deployment -n gistpin --timeout=120s
+    requires_approval: false
+    rollback: kubectl rollout undo deployment/backend-deployment -n gistpin
+
+  - name: Verify pods healthy
+    command: kubectl get pods -n gistpin -l app=gistpin-backend --field-selector=status.phase=Running
+    requires_approval: false

--- a/infrastructure/scripts/notify-plan.sh
+++ b/infrastructure/scripts/notify-plan.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# notify-plan.sh — parse terraform plan output and post summary to Slack
+# Usage: ./notify-plan.sh --plan-file plan.txt --channel "#infra-deploys"
+set -euo pipefail
+
+PLAN_FILE=""
+SLACK_CHANNEL="${SLACK_CHANNEL:-#infra-deploys}"
+SLACK_WEBHOOK="${SLACK_WEBHOOK_URL:-}"
+PR_URL="${PR_URL:-}"
+COST_ESTIMATE="${COST_ESTIMATE:-N/A}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --plan-file)  PLAN_FILE="$2"; shift 2 ;;
+    --channel)    SLACK_CHANNEL="$2"; shift 2 ;;
+    *) echo "Unknown: $1"; exit 1 ;;
+  esac
+done
+
+[[ -z "${PLAN_FILE}" || ! -f "${PLAN_FILE}" ]] && { echo "ERROR: --plan-file required"; exit 1; }
+[[ -z "${SLACK_WEBHOOK}" ]] && { echo "ERROR: SLACK_WEBHOOK_URL not set"; exit 1; }
+
+# Parse plan summary line
+SUMMARY=$(grep -E "^Plan:|No changes\." "${PLAN_FILE}" | tail -1 || echo "No summary found")
+ADD=$(echo "${SUMMARY}"    | grep -oP '\d+(?= to add)'    || echo "0")
+CHANGE=$(echo "${SUMMARY}" | grep -oP '\d+(?= to change)' || echo "0")
+DESTROY=$(echo "${SUMMARY}"| grep -oP '\d+(?= to destroy)'|| echo "0")
+
+# Choose emoji based on severity
+if [[ "${DESTROY}" -gt 0 ]]; then
+  ICON=":rotating_light:"
+  COLOR="danger"
+elif [[ "${CHANGE}" -gt 0 || "${ADD}" -gt 0 ]]; then
+  ICON=":terraform:"
+  COLOR="warning"
+else
+  ICON=":white_check_mark:"
+  COLOR="good"
+fi
+
+PAYLOAD=$(cat <<JSON
+{
+  "channel": "${SLACK_CHANNEL}",
+  "attachments": [{
+    "color": "${COLOR}",
+    "title": "${ICON} Terraform Plan Summary",
+    "title_link": "${PR_URL}",
+    "fields": [
+      {"title": "Add",     "value": "${ADD}",            "short": true},
+      {"title": "Change",  "value": "${CHANGE}",         "short": true},
+      {"title": "Destroy", "value": "${DESTROY}",        "short": true},
+      {"title": "Est. cost delta", "value": "${COST_ESTIMATE}", "short": true}
+    ],
+    "footer": "GistPin Infra | $(date -u +%Y-%m-%dT%H:%MZ)",
+    "actions": [
+      {"type": "button", "text": "View PR", "url": "${PR_URL}"},
+      {"type": "button", "text": "Approve", "url": "${PR_URL}#approve"},
+      {"type": "button", "text": "Reject",  "url": "${PR_URL}#close", "style": "danger"}
+    ]
+  }]
+}
+JSON
+)
+
+curl -sf -X POST -H 'Content-type: application/json' \
+  --data "${PAYLOAD}" "${SLACK_WEBHOOK}"
+echo "Slack notification sent."

--- a/infrastructure/scripts/runbook-executor.sh
+++ b/infrastructure/scripts/runbook-executor.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# runbook-executor.sh — execute runbook steps with optional human approval gates
+# Usage: ./runbook-executor.sh --runbook runbooks/as-code/restart-backend.yaml [--dry-run]
+set -euo pipefail
+
+RUNBOOK_FILE=""
+DRY_RUN=false
+AUDIT_LOG="/tmp/runbook-audit-$(date +%Y%m%d-%H%M%S).log"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --runbook)  RUNBOOK_FILE="$2"; shift 2 ;;
+    --dry-run)  DRY_RUN=true; shift ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+[[ -z "${RUNBOOK_FILE}" ]] && { echo "ERROR: --runbook required"; exit 1; }
+[[ -f "${RUNBOOK_FILE}" ]] || { echo "ERROR: runbook not found: ${RUNBOOK_FILE}"; exit 1; }
+
+log() { echo "[$(date -u +%T)] $*" | tee -a "${AUDIT_LOG}"; }
+
+log "=== Runbook Executor ==="
+log "Runbook: ${RUNBOOK_FILE}"
+log "Dry-run: ${DRY_RUN}"
+log "Audit log: ${AUDIT_LOG}"
+echo ""
+
+# Parse runbook YAML (requires yq or python3)
+if command -v yq &>/dev/null; then
+  TITLE=$(yq '.title' "${RUNBOOK_FILE}" 2>/dev/null || echo "unknown")
+  STEP_COUNT=$(yq '.steps | length' "${RUNBOOK_FILE}" 2>/dev/null || echo "0")
+else
+  TITLE=$(python3 -c "import yaml,sys; d=yaml.safe_load(open('${RUNBOOK_FILE}')); print(d.get('title','unknown'))" 2>/dev/null || echo "unknown")
+  STEP_COUNT=$(python3 -c "import yaml,sys; d=yaml.safe_load(open('${RUNBOOK_FILE}')); print(len(d.get('steps',[])))" 2>/dev/null || echo "0")
+fi
+
+log "Title: ${TITLE} | Steps: ${STEP_COUNT}"
+echo ""
+
+for i in $(seq 0 $((STEP_COUNT - 1))); do
+  if command -v yq &>/dev/null; then
+    NAME=$(yq ".steps[${i}].name" "${RUNBOOK_FILE}")
+    CMD=$(yq ".steps[${i}].command" "${RUNBOOK_FILE}")
+    REQUIRES_APPROVAL=$(yq ".steps[${i}].requires_approval // \"false\"" "${RUNBOOK_FILE}")
+    ROLLBACK_CMD=$(yq ".steps[${i}].rollback // \"\"" "${RUNBOOK_FILE}")
+  else
+    NAME=$(python3 -c "import yaml; d=yaml.safe_load(open('${RUNBOOK_FILE}')); print(d['steps'][${i}].get('name','step-${i}'))")
+    CMD=$(python3 -c "import yaml; d=yaml.safe_load(open('${RUNBOOK_FILE}')); print(d['steps'][${i}].get('command','echo no-op'))")
+    REQUIRES_APPROVAL=$(python3 -c "import yaml; d=yaml.safe_load(open('${RUNBOOK_FILE}')); print(str(d['steps'][${i}].get('requires_approval',False)).lower())")
+    ROLLBACK_CMD=$(python3 -c "import yaml; d=yaml.safe_load(open('${RUNBOOK_FILE}')); print(d['steps'][${i}].get('rollback',''))" 2>/dev/null || echo "")
+  fi
+
+  log "Step $((i+1))/${STEP_COUNT}: ${NAME}"
+
+  # Human approval gate
+  if [[ "${REQUIRES_APPROVAL}" == "true" && "${DRY_RUN}" != "true" ]]; then
+    read -rp "  Approve step '${NAME}'? [yes/no/rollback]: " answer
+    case "${answer}" in
+      yes) log "  Approved." ;;
+      rollback)
+        log "  Rolling back previous steps..."
+        [[ -n "${ROLLBACK_CMD}" ]] && eval "${ROLLBACK_CMD}" && log "  Rollback complete."
+        exit 1
+        ;;
+      *) log "  Skipped by user."; continue ;;
+    esac
+  fi
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "  [DRY-RUN] Would run: ${CMD}"
+  else
+    log "  Running: ${CMD}"
+    if ! eval "${CMD}"; then
+      log "  FAILED. Attempting rollback..."
+      [[ -n "${ROLLBACK_CMD}" ]] && eval "${ROLLBACK_CMD}" && log "  Rollback complete."
+      exit 1
+    fi
+    log "  OK."
+  fi
+done
+
+log ""
+log "=== Runbook completed successfully ==="


### PR DESCRIPTION
Adds startup dependency enforcement, incident automation, deployment observability, and realistic load testing capabilities.

## Changes

### Kubernetes Init Container Dependency Ordering (#774)
- `k8s/init-containers/db-ready.yaml`: three init containers enforcing strict startup order — PostgreSQL readiness (TCP probe, 30 retries × 5s), Soroban RPC readiness (HTTP /health, 20 retries), IPFS gateway check (non-blocking, 15 retries before continuing)

### Automated Runbook Executor (#775)
- `scripts/runbook-executor.sh`: executes YAML runbook steps sequentially with human approval gates, automatic rollback on failure, and timestamped audit log
- `runbooks/as-code/restart-backend.yaml`: example runbook for rolling backend restart with approval gate and rollback command

### Terraform Plan Notifications to Slack (#776)
- `scripts/notify-plan.sh`: parses `terraform plan` output for add/change/destroy counts, includes cost estimate, and posts a formatted Slack message with Approve/Reject action buttons
- `ci/slack-plan-notify.yml`: reusable workflow downloading the plan artifact, running infracost for cost delta, and calling the notify script

### Istio Traffic Mirroring for Testing (#777)
- `k8s/istio/traffic-mirror.yaml`: Istio `VirtualService` mirroring 20% of live production traffic to the staging backend; mirror responses are discarded so no writes or side-effects propagate to staging

Closes #774
Closes #775
Closes #776
Closes #777