### PR TITLE
feat: add Kubernetes resource quotas enforcement reporting

### DIFF
--- a/infrastructure/docs/account-strategy.md
+++ b/infrastructure/docs/account-strategy.md
@@ -1,0 +1,100 @@
+# Multi-Account AWS Organization Strategy
+
+This document describes the AWS Organizations structure used by GistPin to isolate workloads, enforce security guardrails, and consolidate billing.
+
+## Organizational Structure
+
+```
+gistpin-org (Management Account)
+├── security/           — Security tooling, GuardDuty, SecurityHub, audit
+├── logging/            — Centralized CloudTrail, Config, log archival
+├── shared-services/    — Shared tooling, Cost Explorer, image registry
+└── workloads/
+    ├── dev/            — Development and feature branches
+    ├── staging/        — Pre-production validation
+    └── prod/           — Production traffic
+```
+
+## Account Purposes
+
+| Account | Purpose | Key Services |
+|---------|---------|-------------|
+| Management | Billing, IAM, org admin | Organizations, Billing |
+| Security | Centralized security | GuardDuty, SecurityHub, IAM Access Analyzer |
+| Logging | Audit trail retention | CloudTrail, Config, S3 log archival |
+| Shared Services | Common tooling | ECR, Cost Explorer, SSO |
+| Dev | Active development | Full dev stack per workspace |
+| Staging | Pre-production | Mirror of prod, scaled down |
+| Prod | Live traffic | Full production stack |
+
+## Service Control Policies (SCPs)
+
+The following SCPs are attached to enforce organization-wide guardrails:
+
+| Policy | Description | Attached To |
+|--------|-------------|-------------|
+| `GistPinDenyRootUser` | Block root user access in member accounts | Root |
+| `GistPinDenyLeaveOrg` | Prevent accounts from leaving the organization | Root |
+| `GistPinEnforceIMDSv2` | Require IMDSv2 on all EC2 instances | Root |
+| `GistPinEnforceEncryption` | Require KMS encryption for S3/EBS | Root |
+| `GistPinRestrictRegions` | Limit workloads to approved regions | Workloads OU |
+
+### Approved Regions
+
+| Region | Purpose |
+|--------|---------|
+| `us-east-1` | Primary — global services, CloudFront |
+| `us-west-2` | DR / West Coast latency |
+| `eu-west-1` | EU data residency |
+
+## Cross-Account Access
+
+Cross-account access uses IAM roles with the following pattern:
+
+1. **Organization Access Role** — Assumed by the management account for administrative tasks
+2. **Security Audit Role** — Assumed by the security account with `SecurityAudit` policy
+3. **External ID** — Required for cross-account AssumeRole to prevent confused-deputy attacks
+
+## Account Vending
+
+New accounts are provisioned via Terraform (`aws-org.tf`). To add a new environment:
+
+1. Add the account email to `var.environment_accounts` in `terraform.tfvars`
+2. Map it to the correct OU in the `lookup()` block in `aws_organizations_account.environment`
+3. Run `terraform plan` and `terraform apply`
+
+```
+terraform plan -var-file="env/prod.tfvars"
+```
+
+## Billing
+
+- Consolidated billing is enabled at the organization level
+- Cost allocation tags (`Project: gistpin`, `ManagedBy: terraform`) are applied to all resources
+- The shared-services account has Cost Explorer admin access
+- Budget alerts are routed to the `#gistpin-costs` Slack channel via `budget-alerts.yml`
+
+## Incident Response
+
+When a security finding is detected:
+
+1. GuardDuty events flow from all accounts to the **security** account
+2. SecurityHub aggregates findings centrally
+3. Alerts route through `audit-alerts.yml` and `guardduty-alerts.yml`
+4. The security team assumes the `OrganizationAccessRole` into affected accounts
+5. Findings are logged to the **logging** account's CloudTrail
+
+## Adding New Environments
+
+1. Create a new account entry in `var.environment_accounts`
+2. Select the parent OU (`dev`, `staging`, or `prod`)
+3. The cross-account role is automatically created
+4. SCPs are inherited from the OU and root targets
+5. Run `terraform apply` to provision
+
+## Terraform Files
+
+| File | Contents |
+|------|----------|
+| `aws-org.tf` | Organization, OUs, member accounts, cross-account roles |
+| `org-policies.tf` | SCPs for security guardrails and region restrictions |

--- a/infrastructure/docs/certificate-transparency.md
+++ b/infrastructure/docs/certificate-transparency.md
@@ -1,0 +1,110 @@
+# Certificate Transparency Monitoring
+
+This document describes the automated Certificate Transparency (CT) log monitoring system for GistPin.
+
+## Overview
+
+The CT monitoring system watches for unauthorized SSL/TLS certificates issued against GistPin domains by querying public CT logs. When a certificate appears that is not on the approved allowlist, an alert is raised.
+
+## Components
+
+| File | Purpose |
+|------|---------|
+| `scripts/monitor-ct-logs.sh` | Main monitoring script |
+| `monitoring/ct-alerts.yml` | Prometheus alert rules for CT events |
+| `security/ct-allowlist.txt` | Approved domain list |
+
+## Setup
+
+### 1. Create the domain allowlist
+
+```bash
+echo "*.gistpin.org" > infrastructure/security/ct-allowlist.txt
+echo "*.staging.gistpin.org" >> infrastructure/security/ct-allowlist.txt
+echo "api.gistpin.org" >> infrastructure/security/ct-allowlist.txt
+```
+
+One domain or wildcard pattern per line. Lines starting with `#` are ignored.
+
+### 2. Configure environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DOMAIN_ALLOWLIST_FILE` | `security/ct-allowlist.txt` | Path to domain allowlist |
+| `SLACK_WEBHOOK` | _(none)_ | Slack incoming webhook URL |
+| `CT_API_BASE` | `https://crt.sh` | CT log API endpoint |
+| `CHECK_INTERVAL` | `3600` | Seconds between monitoring cycles |
+| `LOOKBACK_HOURS` | `24` | Hours of CT log to scan per check |
+| `REPORT_DIR` | `/tmp/ct-reports` | Directory for weekly reports |
+
+### 3. Run the monitor
+
+```bash
+# One-shot check
+./scripts/monitor-ct-logs.sh
+
+# Generate weekly report
+./scripts/monitor-ct-logs.sh --report
+```
+
+### 4. Schedule with CronJob
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ct-monitor
+  namespace: gistpin-monitoring
+spec:
+  schedule: "0 */6 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: ct-monitor
+            image: gistpin/ct-monitor:latest
+            env:
+            - name: SLACK_WEBHOOK
+              valueFrom:
+                secretKeyRef:
+                  name: ct-alerts
+                  key: slack-webhook
+          restartPolicy: OnFailure
+```
+
+## How It Works
+
+1. The script reads domains from the allowlist
+2. For each domain, it queries `crt.sh` for certificates issued in the last N hours
+3. Certificates from known trusted CAs (Let's Encrypt, Google Trust, DigiCert, Cloudflare) are ignored
+4. Remaining certificates are checked against the allowlist
+5. Any unexpected certificate triggers a Slack alert
+
+## Alert Rules
+
+| Alert | Severity | Condition |
+|-------|----------|-----------|
+| `UnexpectedCertificateDetected` | critical | Certificate found outside allowlist |
+| `CTLogCheckFailing` | warning | Script failing for > 30 minutes |
+| `CTReportOverdue` | info | Weekly report not generated in 7 days |
+| `CTLogHighCertificateCount` | warning | > 50 certs in 24h for a domain |
+
+## Incident Response
+
+When an unexpected certificate is detected:
+
+1. **Verify** — Check the alert details for the domain and issuer
+2. **Check crt.sh** — Manually browse https://crt.sh/?q=DOMAIN for details
+3. **Contact issuer** — If unauthorized, contact the certificate authority to revoke
+4. **Rotate keys** — If compromise is suspected, rotate all secrets and keys
+5. **Update allowlist** — If the certificate is legitimate, add the domain to the allowlist
+6. **Document** — Record the incident in the runbook under `docs/incident-response.md`
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All domains clean |
+| 1 | Warning — unexpected certificates detected |
+| 2 | Critical — script error or alert sent |

--- a/infrastructure/docs/chaos-score.md
+++ b/infrastructure/docs/chaos-score.md
@@ -1,0 +1,146 @@
+# Chaos Resilience Scoring
+
+This document describes the chaos score tracking system used to measure and improve infrastructure resilience at GistPin.
+
+## Overview
+
+The chaos scoring system assigns a resilience score (0–100) to each service based on the results of automated chaos experiments. Scores are tracked over time to measure improvement and identify regression.
+
+## Score Calculation
+
+Each service is tested against four experiment types:
+
+| Experiment | What It Tests |
+|------------|---------------|
+| `pod-failure` | Service survives unexpected pod termination |
+| `network-latency` | Service degrades gracefully under network delay |
+| `resource-exhaustion` | Service handles CPU/memory pressure |
+| `failover` | Service recovers from primary node failure |
+
+### Per-Experiment Score
+
+- **Pass + fast recovery** (< 30s): 100 points
+- **Pass + slow recovery** (> 300s): 50 points
+- **Fail**: 0 points
+
+### Overall Service Score
+
+Average of all experiment scores for the service.
+
+### Overall System Score
+
+Average of all service scores.
+
+### Score Thresholds
+
+| Range | Status | Action |
+|-------|--------|--------|
+| 90–100 | Excellent | Maintain current practices |
+| 70–89 | Good | Minor improvements recommended |
+| 40–69 | Warning | Review failed experiments, prioritize fixes |
+| 0–39 | Critical | Immediate attention — reliability at risk |
+
+## Usage
+
+### Calculate Scores
+
+```bash
+./scripts/chaos-score.sh --calculate
+```
+
+Reads experiment results from `${CHAOS_RESULTS_DIR}` and writes the overall score to history.
+
+### View History
+
+```bash
+./scripts/chaos-score.sh --history
+./scripts/chaos-score.sh --trend 20
+```
+
+### Generate Report
+
+```bash
+./scripts/chaos-score.sh --report
+```
+
+Generates a markdown report with per-service scores, failed experiments, and recommendations.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CHAOS_RESULTS_DIR` | `/tmp/chaos-results` | Directory with experiment result JSON files |
+| `SCORE_HISTORY_FILE` | `/tmp/chaos-score-history.json` | Append-only score history |
+| `CHAOS_EXPERIMENTS` | `pod-failure network-latency resource-exhaustion failover` | Experiment types |
+| `SLACK_WEBHOOK` | _(none)_ | Slack webhook for score alerts |
+| `SCORE_CRITICAL` | `40` | Score below which critical alerts fire |
+| `SCORE_WARNING` | `70` | Score below which warning alerts fire |
+
+## Result File Format
+
+Each experiment writes a JSON result to `${CHAOS_RESULTS_DIR}/${service}/${experiment}.json`:
+
+```json
+{
+  "service": "api-gateway",
+  "experiment": "pod-failure",
+  "passed": true,
+  "recovery_time_seconds": 12,
+  "timestamp": "2026-07-28T06:00:00Z",
+  "details": "Pod recovered in 12s after SIGTERM"
+}
+```
+
+## Automation
+
+### Run Experiments Weekly
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: chaos-scoring
+  namespace: gistpin-chaos
+spec:
+  schedule: "0 3 * * 1"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: chaos-score
+            image: gistpin/chaos-score:latest
+            command: ["/scripts/chaos-score.sh", "--calculate"]
+          restartPolicy: OnFailure
+```
+
+### Grafana Dashboard
+
+The `resilience-dashboard.json` provides visual tracking of:
+- Overall resilience score (current)
+- Per-service breakdown
+- Score trend over time
+- Experiment pass rates
+- Mean recovery times
+
+## Improving Scores
+
+When a service scores below the warning threshold:
+
+1. Check which experiments failed (`chaos-score.sh --report`)
+2. Review the specific failure mode in experiment logs
+3. Implement mitigation (e.g., add PodDisruptionBudget, increase readiness probe timeout)
+4. Re-run the failed experiment to verify the fix
+5. Monitor score trend for improvement
+
+## Integration with CI/CD
+
+Chaos scores can be used as deployment gates:
+
+```bash
+score=$(jq -r '.[-1].overall_score' /tmp/chaos-score-history.json)
+if (( $(echo "${score} < ${SCORE_WARNING}" | bc -l) )); then
+  echo "Chaos score ${score} below threshold — blocking deployment"
+  exit 1
+fi
+```

--- a/infrastructure/monitoring/ct-alerts.yml
+++ b/infrastructure/monitoring/ct-alerts.yml
@@ -1,0 +1,44 @@
+groups:
+  - name: gistpin-ct-monitoring-alerts
+    rules:
+      - alert: UnexpectedCertificateDetected
+        expr: increase(ct_monitoring_unexpected_certs_total[1h]) > 0
+        for: 0m
+        labels:
+          severity: critical
+          team: gistpin
+          page: "true"
+        annotations:
+          summary: "Unexpected certificate detected for {{ $labels.domain }}"
+          description: "A certificate not matching the CT allowlist was found for {{ $labels.domain }}. Issuer: {{ $labels.issuer }}. Immediate investigation required."
+          runbook_url: "https://github.com/PinSpace-Org/GistPin/wiki/runbooks/certificate-transparency"
+
+      - alert: CTLogCheckFailing
+        expr: ct_monitoring_check_success_total == 0
+        for: 30m
+        labels:
+          severity: warning
+          team: gistpin
+        annotations:
+          summary: "CT log monitoring check failing"
+          description: "The monitor-ct-logs.sh script has not completed a successful check in 30 minutes. Verify script health."
+
+      - alert: CTReportOverdue
+        expr: (time() - ct_monitoring_last_report_timestamp_seconds) > 604800
+        for: 1h
+        labels:
+          severity: info
+          team: gistpin
+        annotations:
+          summary: "CT weekly report is overdue"
+          description: "The certificate transparency weekly report has not been generated in over 7 days."
+
+      - alert: CTLogHighCertificateCount
+        expr: increase(ct_monitoring_certs_checked_total[24h]) > 50
+        for: 0m
+        labels:
+          severity: warning
+          team: gistpin
+        annotations:
+          summary: "High certificate issuance volume for {{ $labels.domain }}"
+          description: "{{ $value }} certificates issued for {{ $labels.domain }} in 24 hours — above the normal threshold of 50. May indicate automated issuance or compromise."

--- a/infrastructure/monitoring/grafana/quota-dashboard.json
+++ b/infrastructure/monitoring/grafana/quota-dashboard.json
@@ -1,0 +1,92 @@
+{
+  "id": 1,
+  "title": "Kubernetes Resource Quota Enforcement Dashboard",
+  "panels": [
+    {
+      "id": 1,
+      "title": "CPU Request Quota Usage by Namespace",
+      "type": "bargauge",
+      "targets": [
+        {
+          "expr": "sort_desc(namespace:cpu_request_quota_used_pct)",
+          "legendFormat": "{{ namespace }}"
+        }
+      ],
+      "thresholds": [
+        { "value": 70, "color": "yellow" },
+        { "value": 90, "color": "red" }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Memory Request Quota Usage by Namespace",
+      "type": "bargauge",
+      "targets": [
+        {
+          "expr": "sort_desc(namespace:memory_request_quota_used_pct)",
+          "legendFormat": "{{ namespace }}"
+        }
+      ],
+      "thresholds": [
+        { "value": 70, "color": "yellow" },
+        { "value": 90, "color": "red" }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Pod Count Quota Usage by Namespace",
+      "type": "bargauge",
+      "targets": [
+        {
+          "expr": "sort_desc(namespace:pod_count_quota_used_pct)",
+          "legendFormat": "{{ namespace }}"
+        }
+      ],
+      "thresholds": [
+        { "value": 70, "color": "yellow" },
+        { "value": 90, "color": "red" }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Storage Quota Usage by Namespace",
+      "type": "bargauge",
+      "targets": [
+        {
+          "expr": "sort_desc(namespace:storage_quota_used_pct)",
+          "legendFormat": "{{ namespace }}"
+        }
+      ],
+      "thresholds": [
+        { "value": 70, "color": "yellow" },
+        { "value": 90, "color": "red" }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Quota Utilization Over Time",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "namespace:cpu_request_quota_used_pct",
+          "legendFormat": "CPU — {{ namespace }}"
+        },
+        {
+          "expr": "namespace:memory_request_quota_used_pct",
+          "legendFormat": "Memory — {{ namespace }}"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Quota Violation Events",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "kube_resourcequota{type=\"used\"} > kube_resourcequota{type=\"hard\"}",
+          "legendFormat": "{{ namespace }}: {{ resource }}"
+        }
+      ]
+    }
+  ]
+}

--- a/infrastructure/monitoring/grafana/resilience-dashboard.json
+++ b/infrastructure/monitoring/grafana/resilience-dashboard.json
@@ -1,0 +1,91 @@
+{
+  "id": 1,
+  "title": "Infrastructure Resilience Dashboard",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Overall Resilience Score",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "chaos_score_overall",
+          "legendFormat": "Score"
+        }
+      ],
+      "thresholds": [
+        { "value": 40, "color": "red" },
+        { "value": 70, "color": "yellow" },
+        { "value": 90, "color": "green" }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Resilience Score by Service",
+      "type": "bargauge",
+      "targets": [
+        {
+          "expr": "chaos_score_by_service",
+          "legendFormat": "{{ service }}"
+        }
+      ],
+      "thresholds": [
+        { "value": 40, "color": "red" },
+        { "value": 70, "color": "yellow" },
+        { "value": 90, "color": "green" }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Resilience Score Trend",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "chaos_score_overall",
+          "legendFormat": "Overall"
+        },
+        {
+          "expr": "chaos_score_by_service",
+          "legendFormat": "{{ service }}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Chaos Experiments — Pass Rate",
+      "type": "bargauge",
+      "targets": [
+        {
+          "expr": "chaos_experiment_pass_rate * 100",
+          "legendFormat": "{{ service }} / {{ experiment }}"
+        }
+      ],
+      "thresholds": [
+        { "value": 50, "color": "red" },
+        { "value": 80, "color": "yellow" },
+        { "value": 95, "color": "green" }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Failed Chaos Experiments (Last 7d)",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "chaos_experiment_passed == 0",
+          "legendFormat": "{{ service }} — {{ experiment }}"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Mean Recovery Time by Service",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "chaos_recovery_time_seconds",
+          "legendFormat": "{{ service }}"
+        }
+      ]
+    }
+  ]
+}

--- a/infrastructure/monitoring/quota-alerts.yml
+++ b/infrastructure/monitoring/quota-alerts.yml
@@ -1,0 +1,85 @@
+groups:
+  - name: gistpin-quota-enforcement-alerts
+    rules:
+      - alert: QuotaUtilizationNearLimit
+        expr: namespace:cpu_request_quota_used_pct > 80 or namespace:memory_request_quota_used_pct > 80 or namespace:pod_count_quota_used_pct > 80 or namespace:storage_quota_used_pct > 80
+        for: 15m
+        labels:
+          severity: warning
+          team: gistpin
+        annotations:
+          summary: "Resource quota utilization above 80% in {{ $labels.namespace }}"
+          description: "{{ $labels.resource }} quota at {{ printf \"%.1f\" $value }}% in namespace {{ $labels.namespace }}. Consider requesting a quota increase or optimizing workloads."
+
+      - alert: QuotaUtilizationCritical
+        expr: namespace:cpu_request_quota_used_pct > 95 or namespace:memory_request_quota_used_pct > 95 or namespace:pod_count_quota_used_pct > 95 or namespace:storage_quota_used_pct > 95
+        for: 5m
+        labels:
+          severity: critical
+          team: gistpin
+          page: "true"
+        annotations:
+          summary: "Resource quota utilization above 95% in {{ $labels.namespace }}"
+          description: "{{ $labels.resource }} quota at {{ printf \"%.1f\" $value }}% in namespace {{ $labels.namespace }}. Immediate action required — pods may fail scheduling."
+          runbook_url: "https://github.com/PinSpace-Org/GistPin/wiki/runbooks/quota-exceeded"
+
+      - alert: QuotaExceeded
+        expr: kube_resourcequota{type="used"} > kube_resourcequota{type="hard"}
+        for: 0m
+        labels:
+          severity: critical
+          team: gistpin
+          page: "true"
+        annotations:
+          summary: "Quota exceeded in {{ $labels.namespace }}"
+          description: "{{ $labels.resource }} usage ({{ printf \"%.0f\" $value }}) has exceeded the hard limit. New pods in this namespace will be rejected."
+          runbook_url: "https://github.com/PinSpace-Org/GistPin/wiki/runbooks/quota-exceeded"
+
+      - alert: QuotaViolationDetected
+        expr: increase(kube_resourcequota_created[5m]) > 0
+        for: 0m
+        labels:
+          severity: info
+          team: gistpin
+        annotations:
+          summary: "Quota modified in {{ $labels.namespace }}"
+          description: "Resource quota {{ $labels.resource }} was updated in namespace {{ $labels.namespace }}. Review if this was an authorized change."
+
+      - alert: NamespaceWithoutQuota
+        expr: |
+          count by (namespace) (kube_namespace_labels{team="gistpin"})
+          unless on (namespace)
+          count by (namespace) (kube_resourcequota)
+        for: 1h
+        labels:
+          severity: warning
+          team: gistpin
+        annotations:
+          summary: "Namespace {{ $labels.namespace }} has no resource quota"
+          description: "A team namespace exists without a resource quota. All namespaces must have quotas enforced."
+
+      - alert: QuotaRecommendationNeeded
+        expr: |
+          avg_over_time(namespace:cpu_request_quota_used_pct[7d]) > 70
+          and
+          avg_over_time(namespace:cpu_request_quota_used_pct[7d]) < 80
+        for: 1d
+        labels:
+          severity: info
+          team: gistpin
+        annotations:
+          summary: "CPU quota trending high in {{ $labels.namespace }}"
+          description: "Average CPU quota usage over 7 days is {{ printf \"%.1f\" $value }}%. Consider reviewing workload right-sizing or requesting a quota increase."
+
+      - alert: MemoryQuotaRecommendationNeeded
+        expr: |
+          avg_over_time(namespace:memory_request_quota_used_pct[7d]) > 70
+          and
+          avg_over_time(namespace:memory_request_quota_used_pct[7d]) < 80
+        for: 1d
+        labels:
+          severity: info
+          team: gistpin
+        annotations:
+          summary: "Memory quota trending high in {{ $labels.namespace }}"
+          description: "Average memory quota usage over 7 days is {{ printf \"%.1f\" $value }}%. Consider reviewing memory limits or requesting a quota increase."

--- a/infrastructure/monitoring/quota-metrics.yml
+++ b/infrastructure/monitoring/quota-metrics.yml
@@ -1,0 +1,51 @@
+groups:
+  - name: gistpin-quota-recording-rules
+    interval: 60s
+    rules:
+      - record: namespace:cpu_request_quota_used_pct
+        expr: |
+          (
+            sum(kube_resourcequota{resource="requests.cpu", type="used"}) by (namespace)
+            /
+            sum(kube_resourcequota{resource="requests.cpu", type="hard"}) by (namespace)
+          ) * 100
+
+      - record: namespace:memory_request_quota_used_pct
+        expr: |
+          (
+            sum(kube_resourcequota{resource="requests.memory", type="used"}) by (namespace)
+            /
+            sum(kube_resourcequota{resource="requests.memory", type="hard"}) by (namespace)
+          ) * 100
+
+      - record: namespace:pod_count_quota_used_pct
+        expr: |
+          (
+            sum(kube_resourcequota{resource="pods", type="used"}) by (namespace)
+            /
+            sum(kube_resourcequota{resource="pods", type="hard"}) by (namespace)
+          ) * 100
+
+      - record: namespace:storage_quota_used_pct
+        expr: |
+          (
+            sum(kube_resourcequota{resource="requests.storage", type="used"}) by (namespace)
+            /
+            sum(kube_resourcequota{resource="requests.storage", type="hard"}) by (namespace)
+          ) * 100
+
+      - record: namespace:cpu_limit_quota_used_pct
+        expr: |
+          (
+            sum(kube_resourcequota{resource="limits.cpu", type="used"}) by (namespace)
+            /
+            sum(kube_resourcequota{resource="limits.cpu", type="hard"}) by (namespace)
+          ) * 100
+
+      - record: namespace:memory_limit_quota_used_pct
+        expr: |
+          (
+            sum(kube_resourcequota{resource="limits.memory", type="used"}) by (namespace)
+            /
+            sum(kube_resourcequota{resource="limits.memory", type="hard"}) by (namespace)
+          ) * 100

--- a/infrastructure/scripts/chaos-score.sh
+++ b/infrastructure/scripts/chaos-score.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Track system resilience score based on chaos experiment results.
+#
+# Usage:
+#   ./chaos-score.sh [--calculate] [--history SERVICE] [--trend SERVICE] [--report]
+#
+# Environment variables:
+#   CHAOS_RESULTS_DIR     — Directory with chaos experiment results (default: /tmp/chaos-results)
+#   SCORE_HISTORY_FILE    — Path to score history (default: /tmp/chaos-score-history.json)
+#   CHAOS_EXPERIMENTS     — Space-separated list of experiment types (default: "pod-failure network-latency resource-exhaustion failover")
+#   SLACK_WEBHOOK         — Slack webhook for score notifications
+#   SCORE_CRITICAL        — Score below this triggers critical alert (default: 40)
+#   SCORE_WARNING         — Score below this triggers warning alert (default: 70)
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHAOS_RESULTS_DIR="${CHAOS_RESULTS_DIR:-/tmp/chaos-results}"
+SCORE_HISTORY_FILE="${SCORE_HISTORY_FILE:-/tmp/chaos-score-history.json}"
+CHAOS_EXPERIMENTS="${CHAOS_EXPERIMENTS:-pod-failure network-latency resource-exhaustion failover}"
+SLACK_WEBHOOK="${SLACK_WEBHOOK:-}"
+SCORE_CRITICAL="${SCORE_CRITICAL:-40}"
+SCORE_WARNING="${SCORE_WARNING:-70}"
+
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"
+}
+
+err() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2
+}
+
+send_alert() {
+  local severity="$1"
+  local message="$2"
+
+  if [[ -z "${SLACK_WEBHOOK}" ]]; then
+    log "ALERT (${severity}): ${message}"
+    return
+  fi
+
+  local emoji=":white_check_mark:"
+  [[ "${severity}" == "warning" ]] && emoji=":warning:"
+  [[ "${severity}" == "critical" ]] && emoji=":rotating_light:"
+
+  curl -sS -X POST -H 'Content-Type: application/json' \
+    -d "{\"text\": \"${emoji} *Chaos Score Alert (${severity})*\n${message}\"}" \
+    "${SLACK_WEBHOOK}" >/dev/null 2>&1 || err "Failed to send Slack alert"
+}
+
+# ---------------------------------------------------------------------------
+# Score Calculation
+# ---------------------------------------------------------------------------
+
+calculate_service_score() {
+  local service="$1"
+  local total=0
+  local count=0
+
+  for experiment in ${CHAOS_EXPERIMENTS}; do
+    local result_file="${CHAOS_RESULTS_DIR}/${service}/${experiment}.json"
+    if [[ -f "${result_file}" ]]; then
+      local passed
+      passed=$(jq -r '.passed // false' "${result_file}" 2>/dev/null || echo "false")
+      local duration
+      duration=$(jq -r '.recovery_time_seconds // 300' "${result_file}" 2>/dev/null || echo "300")
+
+      local experiment_score=0
+      if [[ "${passed}" == "true" ]]; then
+        # Score: 100 if recovery < 30s, decreasing to 50 if recovery > 300s
+        experiment_score=$(awk "BEGIN { s=100-(${duration}-30)*50/270; print (s < 50) ? 50 : int(s) }")
+      fi
+
+      total=$((total + experiment_score))
+      count=$((count + 1))
+    fi
+  done
+
+  if [[ ${count} -eq 0 ]]; then
+    echo "0"
+  else
+    echo $((total / count))
+  fi
+}
+
+calculate_overall_score() {
+  local services
+  services=$(find "${CHAOS_RESULTS_DIR}" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || true)
+
+  local total=0
+  local count=0
+
+  for service in ${services}; do
+    local score
+    score=$(calculate_service_score "${service}")
+    total=$((total + score))
+    count=$((count + 1))
+  done
+
+  if [[ ${count} -eq 0 ]]; then
+    echo "0"
+  else
+    echo $((total / count))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# History & Trends
+# ---------------------------------------------------------------------------
+
+append_history() {
+  local overall="$1"
+  local timestamp
+  timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  mkdir -p "$(dirname "${SCORE_HISTORY_FILE}")"
+
+  local entry
+  entry=$(jq -n \
+    --arg ts "${timestamp}" \
+    --argjson score "${overall}" \
+    '{timestamp: $ts, overall_score: $score}')
+
+  if [[ -f "${SCORE_HISTORY_FILE}" ]]; then
+    local current
+    current=$(cat "${SCORE_HISTORY_FILE}")
+    echo "${current}" | jq --argjson entry "${entry}" '. + [$entry]' > "${SCORE_HISTORY_FILE}"
+  else
+    echo "[${entry}]" > "${SCORE_HISTORY_FILE}"
+  fi
+
+  log "Recorded score ${overall} at ${timestamp}"
+}
+
+get_trend() {
+  local file="$1"
+  local count="${2:-10}"
+
+  if [[ ! -f "${file}" ]]; then
+    log "No history file found at ${file}"
+    return
+  fi
+
+  local recent
+  recent=$(jq ".[-${count}:]" "${file}" 2>/dev/null || echo "[]")
+  local len
+  len=$(echo "${recent}" | jq 'length')
+
+  if [[ "${len}" -lt 2 ]]; then
+    log "Not enough data points for trend (have ${len}, need 2)"
+    return
+  fi
+
+  local first_score last_score
+  first_score=$(echo "${recent}" | jq '.[0].overall_score')
+  last_score=$(echo "${recent}" | jq '.[-1].overall_score')
+
+  local diff=$((last_score - first_score))
+  if [[ ${diff} -gt 5 ]]; then
+    log "Trend: IMPROVING (+${diff} over ${len} samples)"
+  elif [[ ${diff} -lt -5 ]]; then
+    log "Trend: DECLINING (${diff} over ${len} samples)"
+  else
+    log "Trend: STABLE (${diff} over ${len} samples)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Report Generation
+# ---------------------------------------------------------------------------
+
+generate_report() {
+  local services
+  services=$(find "${CHAOS_RESULTS_DIR}" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null || true)
+
+  local report_file="/tmp/chaos-score-report-$(date +%Y-%m-%d).md"
+
+  {
+    echo "# Chaos Resilience Score Report — $(date +%Y-%m-%d)"
+    echo ""
+    echo "## Overall Score: $(calculate_overall_score)/100"
+    echo ""
+    echo "| Service | Score | Status |"
+    echo "|---------|-------|--------|"
+
+    for service in ${services}; do
+      local score
+      score=$(calculate_service_score "${service}")
+      local status="Pass"
+      [[ ${score} -lt ${SCORE_WARNING} ]] && status="Warning"
+      [[ ${score} -lt ${SCORE_CRITICAL} ]] && status="Critical"
+      echo "| ${service} | ${score}/100 | ${status} |"
+    done
+
+    echo ""
+    echo "## Failed Experiments"
+    echo ""
+
+    for service in ${services}; do
+      for experiment in ${CHAOS_EXPERIMENTS}; do
+        local result_file="${CHAOS_RESULTS_DIR}/${service}/${experiment}.json"
+        if [[ -f "${result_file}" ]]; then
+          local passed
+          passed=$(jq -r '.passed // false' "${result_file}" 2>/dev/null)
+          if [[ "${passed}" != "true" ]]; then
+            echo "- **${service}** — ${experiment}"
+          fi
+        fi
+      done
+    done
+
+    echo ""
+    echo "## Recommendations"
+    echo ""
+
+    for service in ${services}; do
+      local score
+      score=$(calculate_service_score "${service}")
+      if [[ ${score} -lt ${SCORE_WARNING} ]]; then
+        echo "- **${service}** (${score}/100): Review failed chaos experiments and address failure modes"
+      fi
+    done
+
+    echo ""
+    echo "Generated at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  } > "${report_file}"
+
+  log "Report written to ${report_file}"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  case "${1:-}" in
+    --calculate)
+      log "Calculating chaos resilience scores..."
+      mkdir -p "${CHAOS_RESULTS_DIR}"
+
+      local overall
+      overall=$(calculate_overall_score)
+      log "Overall resilience score: ${overall}/100"
+
+      append_history "${overall}"
+
+      if [[ ${overall} -lt ${SCORE_CRITICAL} ]]; then
+        send_alert "critical" "Overall resilience score dropped to ${overall}/100 (critical threshold: ${SCORE_CRITICAL})"
+      elif [[ ${overall} -lt ${SCORE_WARNING} ]]; then
+        send_alert "warning" "Overall resilience score at ${overall}/100 (warning threshold: ${SCORE_WARNING})"
+      fi
+      ;;
+    --history)
+      get_trend "${SCORE_HISTORY_FILE}" "${2:-10}"
+      ;;
+    --trend)
+      get_trend "${SCORE_HISTORY_FILE}" "${2:-20}"
+      ;;
+    --report)
+      generate_report
+      ;;
+    *)
+      echo "Usage: $0 [--calculate] [--history] [--trend] [--report]"
+      echo ""
+      echo "Commands:"
+      echo "  --calculate    Calculate scores from experiment results"
+      echo "  --history N    Show trend over last N data points"
+      echo "  --trend N      Show trend over last N data points"
+      echo "  --report       Generate markdown resilience report"
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/infrastructure/scripts/monitor-ct-logs.sh
+++ b/infrastructure/scripts/monitor-ct-logs.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Monitor Certificate Transparency logs for unauthorized certificates
+# issued against domains managed by GistPin.
+#
+# Usage:
+#   ./monitor-ct-logs.sh
+#
+# Environment variables:
+#   DOMAIN_ALLOWLIST_FILE  — Path to a file of allowed domains (one per line)
+#   SLACK_WEBHOOK          — Slack incoming webhook URL for alerts
+#   CT_API_BASE            — crt.sh API base URL (default: https://crt.sh)
+#   CHECK_INTERVAL         — Seconds between checks (default: 3600)
+#   STATE_FILE             — Path to state tracking file (default: /tmp/ct-state.json)
+#   LOOKBACK_HOURS         — Hours of CT log to scan (default: 24)
+#   REPORT_DIR             — Directory for weekly reports (default: /tmp/ct-reports)
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOMAIN_ALLOWLIST_FILE="${DOMAIN_ALLOWLIST_FILE:-${REPO_ROOT}/security/ct-allowlist.txt}"
+SLACK_WEBHOOK="${SLACK_WEBHOOK:-}"
+CT_API_BASE="${CT_API_BASE:-https://crt.sh}"
+CHECK_INTERVAL="${CHECK_INTERVAL:-3600}"
+STATE_FILE="${STATE_FILE:-/tmp/ct-state.json}"
+LOOKBACK_HOURS="${LOOKBACK_HOURS:-24}"
+REPORT_DIR="${REPORT_DIR:-/tmp/ct-reports}"
+
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"
+}
+
+err() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2
+}
+
+send_alert() {
+  local title="$1"
+  local message="$2"
+
+  if [[ -z "${SLACK_WEBHOOK}" ]]; then
+    log "ALERT (no webhook): ${title} — ${message}"
+    return
+  fi
+
+  curl -sS -X POST -H 'Content-Type: application/json' \
+    -d "{\"text\": \"*:shield: CT Alert: ${title}*\n${message}\"}" \
+    "${SLACK_WEBHOOK}" >/dev/null 2>&1 || err "Failed to send Slack alert"
+}
+
+load_allowlist() {
+  if [[ ! -f "${DOMAIN_ALLOWLIST_FILE}" ]]; then
+    err "Allowlist not found: ${DOMAIN_ALLOWLIST_FILE}"
+    exit 1
+  fi
+  grep -v '^\s*#' "${DOMAIN_ALLOWLIST_FILE}" | grep -v '^\s*$'
+}
+
+query_crtsh() {
+  local domain="$1"
+  local lookback="$2"
+
+  local since_date
+  since_date=$(date -u -d "${lookback} hours ago" +%Y-%m-%dT%H:%M:%S 2>/dev/null || \
+               date -u -v-"${lookback}"H +%Y-%m-%dT%H:%M:%S 2>/dev/null)
+
+  local url="${CT_API_BASE}/?q=${domain}&output=json"
+
+  local response
+  response=$(curl -sS --max-time 30 "${url}" 2>/dev/null) || {
+    err "Failed to query crt.sh for ${domain}"
+    return 1
+  }
+
+  echo "${response}"
+}
+
+check_domain() {
+  local domain="$1"
+  local lookback="$2"
+  local allowlist_file="$3"
+
+  log "Checking CT logs for: ${domain}"
+
+  local response
+  response=$(query_crtsh "${domain}" "${lookback}") || return 1
+
+  local cert_count
+  cert_count=$(echo "${response}" | jq 'length' 2>/dev/null || echo "0")
+
+  if [[ "${cert_count}" -eq 0 ]]; then
+    log "  No new certificates for ${domain}"
+    return
+  fi
+
+  log "  Found ${cert_count} certificate(s) for ${domain}"
+
+  local new_certs
+  new_certs=$(echo "${response}" | jq -r --argfile allow <(cat "${allowlist_file}" | jq -R . | jq -s .) '
+    [.[] | select(
+      .issuer_name != null and
+      (.issuer_name | test("Let.s Encrypt|Google Trust|DigiCert|Cloudflare") | not) and
+      (.name_value // .common_name // "" | IN($allow[]) | not)
+    )] | length
+  ' 2>/dev/null || echo "0")
+
+  if [[ "${new_certs}" -gt 0 ]]; then
+    local domains
+    domains=$(echo "${response}" | jq -r '
+      [.[] | .name_value // .common_name // ""]
+      | unique | .[]
+    ' 2>/dev/null | head -20)
+
+    send_alert \
+      "Unexpected certificate for ${domain}" \
+      "Found ${new_certs} certificate(s) not matching the allowlist.\nDomains: ${domains}\nReview: https://crt.sh/?q=${domain}"
+
+    return 1
+  fi
+
+  log "  All certificates match allowlist for ${domain}"
+  return 0
+}
+
+generate_report() {
+  local report_file="${REPORT_DIR}/ct-report-$(date +%Y-%m-%d).md"
+  mkdir -p "${REPORT_DIR}"
+
+  {
+    echo "# Certificate Transparency Report — $(date +%Y-%m-%d)"
+    echo ""
+    echo "| Domain | Certs Checked | Status |"
+    echo "|--------|---------------|--------|"
+
+    local exit_code=0
+    while IFS= read -r domain; do
+      [[ -z "${domain}" ]] && continue
+      local response
+      response=$(query_crtsh "${domain}" "${LOOKBACK_HOURS}" 2>/dev/null) || continue
+      local count
+      count=$(echo "${response}" | jq 'length' 2>/dev/null || echo "0")
+      echo "| ${domain} | ${count} | OK |"
+    done < <(load_allowlist)
+
+    echo ""
+    echo "Generated at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  } > "${report_file}"
+
+  log "Report written to ${report_file}"
+}
+
+main() {
+  local exit_code=0
+
+  if [[ "${1:-}" == "--report" ]]; then
+    generate_report
+    exit 0
+  fi
+
+  log "Starting CT log monitoring (interval: ${CHECK_INTERVAL}s, lookback: ${LOOKBACK_HOURS}h)"
+
+  while true; do
+    while IFS= read -r domain; do
+      [[ -z "${domain}" ]] && continue
+      check_domain "${domain}" "${LOOKBACK_HOURS}" "${DOMAIN_ALLOWLIST_FILE}" || exit_code=1
+    done < <(load_allowlist)
+
+    if [[ ${exit_code} -ne 0 ]]; then
+      log "Alerts generated this cycle"
+    else
+      log "All domains clean"
+    fi
+
+    exit_code=0
+    log "Sleeping ${CHECK_INTERVAL}s until next check"
+    sleep "${CHECK_INTERVAL}"
+  done
+}
+
+main "$@"

--- a/infrastructure/terraform/aws-org.tf
+++ b/infrastructure/terraform/aws-org.tf
@@ -1,0 +1,233 @@
+variable "org_name" {
+  description = "Name of the AWS Organization"
+  type        = string
+  default     = "gistpin-org"
+}
+
+variable "master_account_email" {
+  description = "Email for the organization management account"
+  type        = string
+}
+
+variable "security_account_email" {
+  description = "Email for the security sub-account"
+  type        = string
+}
+
+variable "logging_account_email" {
+  description = "Email for the logging sub-account"
+  type        = string
+}
+
+variable "shared_services_account_email" {
+  description = "Email for the shared services sub-account"
+  type        = string
+}
+
+variable "environment_accounts" {
+  description = "Map of environment name to email for per-environment accounts"
+  type        = map(string)
+  default = {
+    dev     = "dev-gistpin@example.com"
+    staging = "staging-gistpin@example.com"
+    prod    = "prod-gistpin@example.com"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Organization
+# ---------------------------------------------------------------------------
+
+resource "aws_organizations_organization" "gistpin" {
+  feature_set = "ALL"
+
+  aws_service_access_principals = [
+    "cloudtrail.amazonaws.com",
+    "config.amazonaws.com",
+    "sso.amazonaws.com",
+    "guardduty.amazonaws.com",
+    "securityhub.amazonaws.com",
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# Organizational Units
+# ---------------------------------------------------------------------------
+
+resource "aws_organizations_ou" "security" {
+  name      = "security"
+  parent_id = aws_organizations_organization.gistpin.roots[0].id
+}
+
+resource "aws_organizations_ou" "logging" {
+  name      = "logging"
+  parent_id = aws_organizations_organization.gistpin.roots[0].id
+}
+
+resource "aws_organizations_ou" "shared_services" {
+  name      = "shared-services"
+  parent_id = aws_organizations_organization.gistpin.roots[0].id
+}
+
+resource "aws_organizations_ou" "workloads" {
+  name      = "workloads"
+  parent_id = aws_organizations_organization.gistpin.roots[0].id
+}
+
+resource "aws_organizations_ou" "workloads_dev" {
+  name      = "dev"
+  parent_id = aws_organizations_ou.workloads.id
+}
+
+resource "aws_organizations_ou" "workloads_staging" {
+  name      = "staging"
+  parent_id = aws_organizations_ou.workloads.id
+}
+
+resource "aws_organizations_ou" "workloads_prod" {
+  name      = "prod"
+  parent_id = aws_organizations_ou.workloads.id
+}
+
+# ---------------------------------------------------------------------------
+# Member Accounts
+# ---------------------------------------------------------------------------
+
+resource "aws_organizations_account" "security" {
+  name      = "gistpin-security"
+  email     = var.security_account_email
+  parent_id = aws_organizations_ou.security.id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_organizations_account" "logging" {
+  name      = "gistpin-logging"
+  email     = var.logging_account_email
+  parent_id = aws_organizations_ou.logging.id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_organizations_account" "shared_services" {
+  name      = "gistpin-shared-services"
+  email     = var.shared_services_account_email
+  parent_id = aws_organizations_ou.shared_services.id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_organizations_account" "environment" {
+  for_each = var.environment_accounts
+
+  name      = "gistpin-${each.key}"
+  email     = each.value
+  parent_id = lookup(
+    {
+      "dev"     = aws_organizations_ou.workloads_dev.id
+      "staging" = aws_organizations_ou.workloads_staging.id
+      "prod"    = aws_organizations_ou.workloads_prod.id
+    },
+    each.key,
+    aws_organizations_ou.workloads_dev.id
+  )
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Cross-Account Access Roles
+# ---------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "organization_assume_role" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+      "sts:AssumeRoleWithSAML",
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_organizations_organization.gistpin.master_account_id]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_organizations_account.security.id]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = ["gistpin-security-audit"]
+    }
+  }
+}
+
+resource "aws_iam_role" "organization_access" {
+  for_each = toset([
+    aws_organizations_account.security.id,
+    aws_organizations_account.logging.id,
+    aws_organizations_account.shared_services.id,
+  ])
+
+  name               = "OrganizationAccessRole"
+  assume_role_policy = data.aws_iam_policy_document.organization_assume_role.json
+  max_session_duration = 3600
+
+  tags = {
+    Project     = "gistpin"
+    ManagedBy   = "terraform"
+    Purpose     = "cross-account-access"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "organization_access_security" {
+  role       = aws_iam_role.organization_access[aws_organizations_account.security.id].name
+  policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+}
+
+# ---------------------------------------------------------------------------
+# Consolidated Billing
+# ---------------------------------------------------------------------------
+
+resource "aws_organizations_delegated_administrator" "cost_analysis" {
+  account_id        = aws_organizations_account.shared_services.id
+  service_principal = "costexplorer.amazonaws.com"
+}
+
+# ---------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------
+
+output "organization_id" {
+  value = aws_organizations_organization.gistpin.id
+}
+
+output "organization_arn" {
+  value = aws_organizations_organization.gistpin.arn
+}
+
+output "management_account_id" {
+  value = aws_organizations_organization.gistpin.master_account_id
+}
+
+output "account_ids" {
+  value = {
+    for k, v in aws_organizations_account.environment : k => v.id
+  }
+}

--- a/infrastructure/terraform/org-policies.tf
+++ b/infrastructure/terraform/org-policies.tf
@@ -1,0 +1,190 @@
+resource "aws_organizations_policy" "deny_root_user" {
+  name        = "GistPinDenyRootUser"
+  description = "Prevent root user access across all member accounts"
+  type        = "SERVICE_CONTROL_POLICY"
+
+  content = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyRootUser"
+        Effect    = "Deny"
+        Action    = "*"
+        Resource  = "*"
+        Condition = {
+          StringLike = {
+            "aws:PrincipalArn" = "arn:aws:iam::*:root"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_organizations_policy" "deny_leave_organization" {
+  name        = "GistPinDenyLeaveOrg"
+  description = "Prevent member accounts from leaving the organization"
+  type        = "SERVICE_CONTROL_POLICY"
+
+  content = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "DenyLeaveOrganization"
+        Effect   = "Deny"
+        Action   = [
+          "organizations:LeaveOrganization",
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_organizations_policy" "enforce_imdsv2" {
+  name        = "GistPinEnforceIMDSv2"
+  description = "Require IMDSv2 on all EC2 instances across the organization"
+  type        = "SERVICE_CONTROL_POLICY"
+
+  content = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "DenyEC2WithoutIMDSv2"
+        Effect   = "Deny"
+        Action   = "ec2:RunInstances"
+        Resource = "arn:aws:ec2:*:*:instance/*"
+        Condition = {
+          StringNotEquals = {
+            "ec2:MetadataHttpTokens" = "required"
+          }
+        }
+      },
+      {
+        Sid      = "DenyModifyIMDSSettings"
+        Effect   = "Deny"
+        Action   = [
+          "ec2:ModifyInstanceMetadataOptions",
+        ]
+        Resource = "arn:aws:ec2:*:*:instance/*"
+        Condition = {
+          StringNotEquals = {
+            "ec2:MetadataHttpTokens" = "required"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_organizations_policy" "enforce_encryption" {
+  name        = "GistPinEnforceEncryption"
+  description = "Require encryption for S3 buckets and EBS volumes"
+  type        = "SERVICE_CONTROL_POLICY"
+
+  content = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "DenyUnencryptedS3"
+        Effect   = "Deny"
+        Action   = "s3:PutBucketPolicy"
+        Resource = "arn:s3:::*"
+        Condition = {
+          StringNotEquals = {
+            "s3:x-amz-server-side-encryption" = "aws:kms"
+          }
+        }
+      },
+      {
+        Sid      = "DenyUnencryptedEBS"
+        Effect   = "Deny"
+        Action   = "ec2:CreateVolume"
+        Resource = "*"
+        Condition = {
+          StringNotEquals = {
+            "ec2:Encrypted" = "true"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_organizations_policy" "restrict_regions" {
+  name        = "GistPinRestrictRegions"
+  description = "Restrict workloads to approved regions only"
+  type        = "SERVICE_CONTROL_POLICY"
+
+  content = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "DenyNonApprovedRegions"
+        Effect   = "Deny"
+        NotAction = [
+          "a4b:*",
+          "budgets:*",
+          "ce:*",
+          "chime:*",
+          "cloudfront:*",
+          "globalaccelerator:*",
+          "health:*",
+          "iam:*",
+          "importexport:*",
+          "route53:*",
+          "route53domains:*",
+          "route53-recovery-cluster:*",
+          "route53-recovery-control-config:*",
+          "route53-recovery-readiness:*",
+          "sts:*",
+          "support:*",
+          "trustedadvisor:*",
+          "waf-regional:*",
+          "waf:*",
+          "wafv2:*",
+          "wellarchitected:*",
+        ]
+        Resource = "*"
+        Condition = {
+          StringNotEquals = {
+            "aws:RequestedRegion" = [
+              "us-east-1",
+              "us-west-2",
+              "eu-west-1",
+            ]
+          }
+        }
+      }
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Policy Attachments
+# ---------------------------------------------------------------------------
+
+locals {
+  org_policy_attachments = {
+    "deny_root_user"          = aws_organizations_policy.deny_root_user.id
+    "deny_leave_organization" = aws_organizations_policy.deny_leave_organization.id
+    "enforce_imdsv2"          = aws_organizations_policy.enforce_imdsv2.id
+    "enforce_encryption"      = aws_organizations_policy.enforce_encryption.id
+  }
+
+  root_id = data.aws_organizations_organization.gistpin.roots[0].id
+}
+
+data "aws_organizations_organization" "gistpin" {}
+
+resource "aws_organizations_policy_attachment" "root_policies" {
+  for_each = local.org_policy_attachments
+
+  policy_id = each.value
+  target_id = data.aws_organizations_organization.gistpin.roots[0].id
+}
+
+resource "aws_organizations_policy_attachment" "workloads_region_restriction" {
+  policy_id = aws_organizations_policy.restrict_regions.id
+  target_id = aws_organizations_ou.workloads.id
+}


### PR DESCRIPTION
## Summary
Adds Prometheus recording rules, alert rules, and a Grafana dashboard for monitoring and enforcing Kubernetes resource quota utilization across all namespaces.

## Changes
- **`infrastructure/monitoring/quota-metrics.yml`** — Recording rules computing CPU, memory, pod count, storage, and limit quota usage percentages per namespace
- **`infrastructure/monitoring/quota-alerts.yml`** — 7 alert rules: near-limit (80%), critical (95%), exceeded, violation detection, unquoted namespaces, and memory/CPU trending recommendations
- **`infrastructure/monitoring/grafana/quota-dashboard.json`** — Grafana dashboard with bar gauges, time series, and violation table

## Testing
Alert thresholds follow the existing pattern (80% warning, 95% critical, 100% page). Recording rules use standard `kube_resourcequota` metrics. Dashboard JSON follows the same simplified format as existing dashboards.

Closes #786