### PR TITLE
ci: add CI workflows for contracts test and frontend build (closes #1043)

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,47 @@
+name: Contracts CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'contracts/**'
+  pull_request:
+    paths:
+      - 'contracts/**'
+
+jobs:
+  test:
+    name: Run Contract Tests and Build
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: contracts
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            contracts/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('contracts/Cargo.lock', 'contracts/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Run contract tests
+        run: cargo test
+
+      - name: Build wasm contract
+        run: cargo build --target wasm32-unknown-unknown --release

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,0 +1,36 @@
+name: Frontend Build Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Frontend/**'
+  pull_request:
+    paths:
+      - 'Frontend/**'
+
+jobs:
+  build:
+    name: Run Frontend Build Check
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: Frontend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: Frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build


### PR DESCRIPTION
## Description
Closes #1043

This PR introduces two dedicated, lightweight GitHub Actions workflows following the patterns established in :

1. :
   - Triggers on push/pull_request affecting .
   - Sets up stable Rust toolchain with  target.
   - Caches Cargo dependencies.
   - Executes  and .

2. :
   - Triggers on push/pull_request affecting .
   - Sets up Node.js 20 with npm cache.
   - Runs  and .

## Acceptance Criteria Verification
- [x] Path filters ensure  only runs on changes to  and  only runs on changes to .
- [x] Contracts workflow validates unit/integration tests and wasm compilation.
- [x] Frontend workflow validates dependencies installation and production build.
