### PR TITLE
feat(database): add hidden column and exclude hidden gists from queries (closes #1037)

### DIFF
--- a/Backend/src/database/migrations/AddGistHiddenColumn1750000000003.ts
+++ b/Backend/src/database/migrations/AddGistHiddenColumn1750000000003.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddGistHiddenColumn1750000000003 implements MigrationInterface {
+  name = 'AddGistHiddenColumn1750000000003';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "gists"
+        ADD COLUMN IF NOT EXISTS "hidden" BOOLEAN NOT NULL DEFAULT false
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_gists_hidden"
+        ON "gists" ("hidden")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_gists_hidden"`);
+    await queryRunner.query(`ALTER TABLE "gists" DROP COLUMN IF EXISTS "hidden"`);
+  }
+}

--- a/Backend/src/gists/entities/gist.entity.ts
+++ b/Backend/src/gists/entities/gist.entity.ts
@@ -40,4 +40,7 @@ export class Gist {
 
   @Column({ type: 'timestamptz' })
   expires_at: Date;
+
+  @Column({ type: 'boolean', default: false })
+  hidden: boolean;
 }

--- a/Backend/src/gists/gist.repository.integration-spec.ts
+++ b/Backend/src/gists/gist.repository.integration-spec.ts
@@ -149,6 +149,18 @@ describe('GistRepository (integration)', () => {
       const result = await repository.findByGistId('00000000-0000-0000-0000-000000000000');
       expect(result).toBeNull();
     });
+
+    it('should return null for a hidden gist ID', async () => {
+      const created = await repository.create({
+        content: 'hidden findById test',
+        lat: 9.0579,
+        lon: 7.4951,
+        hidden: true,
+      });
+
+      const found = await repository.findByGistId(created.id);
+      expect(found).toBeNull();
+    });
   });
 
   describe('findByStellarGistId', () => {
@@ -294,6 +306,27 @@ describe('GistRepository (integration)', () => {
       }
     });
 
+    it('should exclude hidden gists from findNearby', async () => {
+      const hiddenContent = `hidden-nearby-${Date.now()}`;
+      await repository.create({
+        content: hiddenContent,
+        lat: 9.058,
+        lon: 7.495,
+        location_cell: 's1t7d8c',
+        hidden: true,
+      });
+
+      const result = await repository.findNearby({
+        lat: 9.0579,
+        lon: 7.4951,
+        radiusMeters: 500,
+        limit: 50,
+      });
+
+      const found = result.data.find((g) => g.content === hiddenContent);
+      expect(found).toBeUndefined();
+    });
+
     it('should return empty result when authorAddress matches no gists in radius', async () => {
       await repository.create({
         content: 'far-away alice',
@@ -409,6 +442,20 @@ describe('GistRepository (integration)', () => {
     it('should return 0 when no gists are in radius', async () => {
       const count = await repository.countNearby(51.5074, -0.1278, 100);
       expect(count).toBe(0);
+    });
+
+    it('should exclude hidden gists from countNearby', async () => {
+      const beforeCount = await repository.countNearby(9.0579, 7.4951, 500);
+      await repository.create({
+        content: `hidden-count-${Date.now()}`,
+        lat: 9.058,
+        lon: 7.495,
+        location_cell: 's1t7d8c',
+        hidden: true,
+      });
+
+      const afterCount = await repository.countNearby(9.0579, 7.4951, 500);
+      expect(afterCount).toBe(beforeCount);
     });
   });
 

--- a/Backend/src/gists/gist.repository.ts
+++ b/Backend/src/gists/gist.repository.ts
@@ -26,6 +26,7 @@ export interface CreateGistData {
   tx_hash?: string;
   author_address?: string;
   expires_at?: Date;
+  hidden?: boolean;
 }
 
 @Injectable()
@@ -43,6 +44,7 @@ export class GistRepository {
       tx_hash = null,
       author_address = null,
       expires_at,
+      hidden = false,
     } = data;
 
     const expiresAt = expires_at ?? new Date(Date.now() + 24 * 60 * 60 * 1000);
@@ -52,20 +54,20 @@ export class GistRepository {
       `
       INSERT INTO gists (
         content, location, location_cell,
-        content_hash, stellar_gist_id, tx_hash, author_address, expires_at
+        content_hash, stellar_gist_id, tx_hash, author_address, expires_at, hidden
       )
       VALUES (
         $1,
         ST_SetSRID(ST_MakePoint($2, $3), 4326)::geography,
-        $4, $5, $6, $7, $8, $9
+        $4, $5, $6, $7, $8, $9, $10
       )
       RETURNING
         id, content, location_cell, content_hash,
-        stellar_gist_id, tx_hash, author_address, created_at, expires_at,
+        stellar_gist_id, tx_hash, author_address, created_at, expires_at, hidden,
         ST_X(location::geometry) AS lon,
         ST_Y(location::geometry) AS lat
       `,
-      [content, lon, lat, location_cell, content_hash, stellar_gist_id, tx_hash, author_address, expiresAt],
+      [content, lon, lat, location_cell, content_hash, stellar_gist_id, tx_hash, author_address, expiresAt, hidden],
     );
 
     return result[0];
@@ -78,6 +80,7 @@ export class GistRepository {
     const clauses: string[] = [];
 
     clauses.push(`g.expires_at > NOW()`);
+    clauses.push(`g.hidden = false`);
 
     if (cursor) {
       const decoded = PaginationHelper.decodeCursor(cursor) ?? cursor;
@@ -104,6 +107,7 @@ export class GistRepository {
         g.author_address,
         g.created_at,
         g.expires_at,
+        g.hidden,
         ST_X(g.location::geometry)                              AS lon,
         ST_Y(g.location::geometry)                              AS lat,
         ST_Distance(
@@ -117,6 +121,7 @@ export class GistRepository {
         $3
       )
       AND g.expires_at > NOW()
+      AND g.hidden = false
       ${extraWhere}
       ORDER BY distance_meters ASC, g.created_at DESC
       LIMIT $4
@@ -137,12 +142,13 @@ export class GistRepository {
       `
       SELECT
         id, content, location_cell, content_hash,
-        stellar_gist_id, tx_hash, author_address, created_at, expires_at,
+        stellar_gist_id, tx_hash, author_address, created_at, expires_at, hidden,
         ST_X(location::geometry) AS lon,
         ST_Y(location::geometry) AS lat
       FROM gists
       WHERE id = $1
         AND expires_at > NOW()
+        AND hidden = false
       LIMIT 1
       `,
       [id],
@@ -155,7 +161,7 @@ export class GistRepository {
       `
       SELECT
         id, content, location_cell, content_hash,
-        stellar_gist_id, tx_hash, author_address, created_at, expires_at,
+        stellar_gist_id, tx_hash, author_address, created_at, expires_at, hidden,
         ST_X(location::geometry) AS lon,
         ST_Y(location::geometry) AS lat
       FROM gists
@@ -190,7 +196,7 @@ export class GistRepository {
          location::geography,
          ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography,
          $3
-       ) AND expires_at > NOW()`,
+       ) AND expires_at > NOW() AND hidden = false`,
       [lon, lat, radiusMeters],
     );
     return parseInt(row.count, 10);
@@ -206,7 +212,7 @@ export class GistRepository {
          location::geography,
          ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography,
          $3
-       ) AND expires_at > NOW()
+       ) AND expires_at > NOW() AND hidden = false
        GROUP BY location_cell ORDER BY count DESC`,
       [lon, lat, radiusMeters],
     );

--- a/Backend/src/gists/gists.service.spec.ts
+++ b/Backend/src/gists/gists.service.spec.ts
@@ -35,6 +35,7 @@ describe('GistsService', () => {
     location: null,
     created_at: new Date('2026-01-01T00:00:00Z'),
     expires_at: new Date('2026-01-02T00:00:00Z'),
+    hidden: false,
     ...overrides,
   });
 


### PR DESCRIPTION
## Overview
Closes #1037.

Adds a `hidden boolean NOT NULL DEFAULT false` column via a TypeORM migration and updates PostGIS / SQL queries in `GistRepository` to exclude hidden gists alongside existing expiry checks.

## Changes
1. **Migration (`AddGistHiddenColumn1750000000003.ts`)**:
   - Adds `hidden` boolean column (default `false`) to `gists` table.
   - Creates index `idx_gists_hidden` on `gists (hidden)`.
2. **Entity (`Gist.ts`)**:
   - Added `@Column({ type: 'boolean', default: false }) hidden: boolean;` field.
3. **Repository (`GistRepository.ts`)**:
   - Included `hidden` in `create`, `findNearby`, `findByGistId`, `countNearby`, and `countNearbyByCell`.
   - Updated WHERE clauses to filter `AND g.hidden = false` so hidden gists are excluded from listings, proximity searches, counts, and direct lookups by UUID.
4. **Tests**:
   - Added tests in `gist.repository.integration-spec.ts` asserting hidden gists are excluded from `findNearby`, `countNearby`, and `findByGistId`.
   - All unit and build tests compile and pass.

## Verification
- Unit test suite: `npm test` passed (12 suites passed, 86 tests passed).
- Build check: `npm run build` completed cleanly without errors.
