### PR TITLE
feat(api): expose is_active, report_count and moderator over the API

### DIFF
--- a/Backend/src/app.module.ts
+++ b/Backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { GeoModule } from './geo/geo.module';
 import { IpfsModule } from './ipfs/ipfs.module';
 import { SorobanModule } from './soroban/soroban.module';
 import { GistsModule } from './gists/gists.module';
+import { ModeratorModule } from './moderator/moderator.module';
 import { HealthModule } from './health/health.module';
 import { MetricsModule } from './metrics/metrics.module';
 import { ShutdownModule } from './common/shutdown/shutdown.module';
@@ -47,6 +48,7 @@ import { buildWinstonOptions } from './common/logger/winston.config';
     IpfsModule,
     SorobanModule,
     GistsModule,
+    ModeratorModule,
     HealthModule,
     MetricsModule,
     ShutdownModule,

--- a/Backend/src/config/configuration.ts
+++ b/Backend/src/config/configuration.ts
@@ -23,4 +23,8 @@ export default () => ({
     pinataSecretKey: process.env.PINATA_SECRET_KEY ?? '',
     gateway: process.env.IPFS_GATEWAY ?? 'https://gateway.pinata.cloud/ipfs',
   },
+
+  moderator: {
+    address: process.env.MODERATOR_ADDRESS ?? '',
+  },
 });

--- a/Backend/src/config/env.validation.ts
+++ b/Backend/src/config/env.validation.ts
@@ -33,6 +33,9 @@ export const envValidationSchema = Joi.object({
   PINATA_SECRET_KEY: Joi.string().allow('').default(''),
   IPFS_GATEWAY: Joi.string().uri().default('https://gateway.pinata.cloud/ipfs'),
 
+  // Moderator — optional; GET /v1/moderator returns 503 when unset
+  MODERATOR_ADDRESS: Joi.string().allow('').default(''),
+
   // CORS
   CORS_ORIGINS: Joi.string().allow('').default(''),
 

--- a/Backend/src/database/migrations/AddGistActivityColumns1750000000003.ts
+++ b/Backend/src/database/migrations/AddGistActivityColumns1750000000003.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Issue #1038 — surface on-chain moderation state over the REST API.
+ *
+ * Adds Postgres mirrors of the GistRegistry contract's read-only state:
+ *   - `is_active`     — contract `is_active(gist_id)`
+ *   - `report_count`  — contract `report_count(gist_id)`
+ *
+ * The indexer keeps both columns fresh (see the "hidden column" and "event
+ * persistence" issues); this migration only adds the storage with sane
+ * defaults so existing rows stay visible as active until backfilled.
+ */
+export class AddGistActivityColumns1750000000003 implements MigrationInterface {
+  name = 'AddGistActivityColumns1750000000003';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "gists"
+        ADD COLUMN IF NOT EXISTS "is_active" BOOLEAN NOT NULL DEFAULT TRUE,
+        ADD COLUMN IF NOT EXISTS "report_count" INTEGER NOT NULL DEFAULT 0
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "gists"
+        DROP COLUMN IF EXISTS "report_count",
+        DROP COLUMN IF EXISTS "is_active"
+    `);
+  }
+}

--- a/Backend/src/gists/dto/gist-response.dto.ts
+++ b/Backend/src/gists/dto/gist-response.dto.ts
@@ -1,0 +1,56 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Response shape returned by `GistsController.decorateGist` for single-gist
+ * and list endpoints. Documents the fields that are not columns on the
+ * `gists` table but are derived by the repository/controller (lat/lon from
+ * the PostGIS geography, `gist_id`/`content_cid` aliases).
+ */
+export class GistResponseDto {
+  @ApiProperty({ description: 'Gist UUID', example: '00000000-0000-0000-0000-000000000001' })
+  id: string;
+
+  @ApiProperty({ description: 'The gist content', example: 'Great coffee spot here!' })
+  content: string;
+
+  @ApiPropertyOptional({ description: 'H3 location cell', example: 's1t7d8c' })
+  location_cell: string | null;
+
+  @ApiPropertyOptional({ description: 'IPFS content CID', example: 'Qmrealcid' })
+  content_hash: string | null;
+
+  @ApiPropertyOptional({ description: 'On-chain gist ID from the GistRegistry contract' })
+  stellar_gist_id: string | null;
+
+  @ApiPropertyOptional({ description: 'Transaction hash of the on-chain post' })
+  tx_hash: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Stellar public key of the author (null for anonymous)',
+  })
+  author_address: string | null;
+
+  @ApiProperty({ description: 'Whether the gist is active (exists, not expired, not hidden)' })
+  is_active: boolean;
+
+  @ApiProperty({ description: 'Number of reports filed against the gist', example: 0 })
+  report_count: number;
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  created_at: Date;
+
+  @ApiProperty({ description: 'Expiry timestamp' })
+  expires_at: Date;
+
+  @ApiProperty({ description: 'Latitude of the gist location', example: 9.0579 })
+  lat: number;
+
+  @ApiProperty({ description: 'Longitude of the gist location', example: 7.4951 })
+  lon: number;
+
+  @ApiProperty({ description: 'Alias of stellar_gist_id', example: 'gist-1' })
+  gist_id: string;
+
+  @ApiProperty({ description: 'Alias of content_hash', example: 'Qmrealcid' })
+  content_cid: string;
+}

--- a/Backend/src/gists/entities/gist.entity.ts
+++ b/Backend/src/gists/entities/gist.entity.ts
@@ -27,6 +27,21 @@ export class Gist {
   author_address: string | null;
 
   /**
+   * Mirror of on-chain state, kept fresh by the indexer (contracts:
+   * `is_active(gist_id)`). Defaults to true so rows created before the
+   * column existed are treated as active until the indexer backfills.
+   */
+  @Column({ type: 'boolean', default: true })
+  is_active: boolean;
+
+  /**
+   * Mirror of on-chain state, kept fresh by the indexer (contracts:
+   * `report_count(gist_id)`).
+   */
+  @Column({ type: 'int', default: 0 })
+  report_count: number;
+
+  /**
    * PostGIS geography(Point, 4326) column.
    * TypeORM has no native geography type — the real column is created
    * via migration. This text placeholder keeps TypeORM happy while

--- a/Backend/src/gists/gist.repository.ts
+++ b/Backend/src/gists/gist.repository.ts
@@ -61,7 +61,8 @@ export class GistRepository {
       )
       RETURNING
         id, content, location_cell, content_hash,
-        stellar_gist_id, tx_hash, author_address, created_at, expires_at,
+        stellar_gist_id, tx_hash, author_address, is_active, report_count,
+        created_at, expires_at,
         ST_X(location::geometry) AS lon,
         ST_Y(location::geometry) AS lat
       `,
@@ -102,6 +103,8 @@ export class GistRepository {
         g.stellar_gist_id,
         g.tx_hash,
         g.author_address,
+        g.is_active,
+        g.report_count,
         g.created_at,
         g.expires_at,
         ST_X(g.location::geometry)                              AS lon,
@@ -137,7 +140,8 @@ export class GistRepository {
       `
       SELECT
         id, content, location_cell, content_hash,
-        stellar_gist_id, tx_hash, author_address, created_at, expires_at,
+        stellar_gist_id, tx_hash, author_address, is_active, report_count,
+        created_at, expires_at,
         ST_X(location::geometry) AS lon,
         ST_Y(location::geometry) AS lat
       FROM gists
@@ -155,7 +159,8 @@ export class GistRepository {
       `
       SELECT
         id, content, location_cell, content_hash,
-        stellar_gist_id, tx_hash, author_address, created_at, expires_at,
+        stellar_gist_id, tx_hash, author_address, is_active, report_count,
+        created_at, expires_at,
         ST_X(location::geometry) AS lon,
         ST_Y(location::geometry) AS lat
       FROM gists

--- a/Backend/src/gists/gists.controller.spec.ts
+++ b/Backend/src/gists/gists.controller.spec.ts
@@ -1,0 +1,123 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GistsController } from './gists.controller';
+import { GistsService } from './gists.service';
+import { Gist } from './entities/gist.entity';
+
+jest.mock('../soroban/soroban.service', () => ({
+  SorobanService: class SorobanService {},
+}));
+
+// Mock @stellar/stellar-sdk before importing modules that reach it (validators, soroban).
+jest.mock('@stellar/stellar-sdk', () => ({
+  StrKey: {
+    isValidEd25519PublicKey: (value: string) =>
+      typeof value === 'string' && value.length === 55 && /^G[A-Z2-7]{54}$/.test(value),
+  },
+}));
+
+/**
+ * Unit tests for GistsController response shaping (decorateGist).
+ *
+ * Issue #1038 — GET /v1/gists/:id must include `is_active` and
+ * `report_count` alongside the existing `gist_id`/`content_cid` aliases.
+ */
+describe('GistsController', () => {
+  let controller: GistsController;
+  let gistsService: jest.Mocked<Pick<GistsService, 'create' | 'findOne' | 'findNearby'>>;
+
+  const buildGist = (overrides: Partial<Gist> = {}): Gist => ({
+    id: '00000000-0000-0000-0000-000000000001',
+    content: 'hello',
+    location_cell: 's1t7d8c',
+    content_hash: 'Qmrealcid',
+    stellar_gist_id: 'gist-1',
+    tx_hash: 'mock_tx',
+    author_address: null,
+    location: null,
+    is_active: true,
+    report_count: 3,
+    created_at: new Date('2026-01-01T00:00:00Z'),
+    expires_at: new Date('2026-01-02T00:00:00Z'),
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GistsController],
+      providers: [
+        {
+          provide: GistsService,
+          useValue: { create: jest.fn(), findOne: jest.fn(), findNearby: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(GistsController);
+    gistsService = module.get(GistsService);
+  });
+
+  describe('GET /v1/gists/:id response shape', () => {
+    it('includes is_active, report_count, gist_id and content_cid', async () => {
+      const gist = buildGist({ is_active: false, report_count: 7 });
+      gistsService.findOne.mockResolvedValue(gist);
+
+      const result = await controller.findOne(gist.id);
+
+      expect(result).toMatchObject({
+        id: gist.id,
+        gist_id: 'gist-1',
+        content_cid: 'Qmrealcid',
+        is_active: false,
+        report_count: 7,
+      });
+    });
+
+    it('keeps the entity fields alongside the aliases', async () => {
+      const gist = buildGist();
+      gistsService.findOne.mockResolvedValue(gist);
+
+      const result = await controller.findOne(gist.id);
+
+      expect(result).toMatchObject({
+        stellar_gist_id: 'gist-1',
+        content_hash: 'Qmrealcid',
+        is_active: true,
+        report_count: 3,
+      });
+    });
+  });
+
+  describe('POST /v1/gists response shape', () => {
+    it('includes is_active and report_count on newly created gists', async () => {
+      const gist = buildGist();
+      gistsService.create.mockResolvedValue(gist);
+
+      const result = await controller.create({} as never);
+
+      expect(result).toMatchObject({
+        gist_id: 'gist-1',
+        content_cid: 'Qmrealcid',
+        is_active: true,
+        report_count: 3,
+      });
+    });
+  });
+
+  describe('GET /v1/gists response shape', () => {
+    it('includes is_active and report_count on nearby gists', async () => {
+      const gist = buildGist();
+      gistsService.findNearby.mockResolvedValue({
+        data: [gist],
+        pagination: { count: 1, cursor: null, hasMore: false },
+      });
+
+      const result = await controller.findNearby({} as never);
+
+      expect(result.data[0]).toMatchObject({
+        gist_id: 'gist-1',
+        is_active: true,
+        report_count: 3,
+      });
+    });
+  });
+});

--- a/Backend/src/gists/gists.controller.ts
+++ b/Backend/src/gists/gists.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Get, Post, Body, Param, Query, ParseUUIDPipe } from '@nestjs/common';
 import { Throttle, SkipThrottle } from '@nestjs/throttler';
-import { ApiOperation, ApiTags, ApiParam } from '@nestjs/swagger';
+import { ApiOperation, ApiTags, ApiParam, ApiOkResponse } from '@nestjs/swagger';
 import { GistsService } from './gists.service';
 import { CreateGistDto } from './dto/create-gist.dto';
 import { QueryGistsDto } from './dto/query-gists.dto';
+import { GistResponseDto } from './dto/gist-response.dto';
 import { Gist } from './entities/gist.entity';
 import { PaginatedResponse } from '../common/utils/pagination.helper';
 
@@ -15,6 +16,7 @@ export class GistsController {
   @Post()
   @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({ summary: 'Post a new anonymous gist at a location' })
+  @ApiOkResponse({ type: GistResponseDto })
   async create(@Body() dto: CreateGistDto) {
     return this.decorateGist(await this.gistsService.create(dto));
   }
@@ -48,6 +50,7 @@ export class GistsController {
   @SkipThrottle()
   @ApiOperation({ summary: 'Get a single gist by ID' })
   @ApiParam({ name: 'id', description: 'Gist UUID' })
+  @ApiOkResponse({ type: GistResponseDto })
   async findOne(@Param('id', ParseUUIDPipe) id: string) {
     return this.decorateGist(await this.gistsService.findOne(id));
   }

--- a/Backend/src/gists/gists.service.spec.ts
+++ b/Backend/src/gists/gists.service.spec.ts
@@ -33,6 +33,8 @@ describe('GistsService', () => {
     tx_hash: 'mock_tx',
     author_address: null,
     location: null,
+    is_active: true,
+    report_count: 0,
     created_at: new Date('2026-01-01T00:00:00Z'),
     expires_at: new Date('2026-01-02T00:00:00Z'),
     ...overrides,

--- a/Backend/src/moderator/dto/moderator-response.dto.ts
+++ b/Backend/src/moderator/dto/moderator-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ModeratorResponseDto {
+  @ApiProperty({
+    description: 'Stellar public key of the current moderator',
+    example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  })
+  address: string;
+}

--- a/Backend/src/moderator/moderator.controller.spec.ts
+++ b/Backend/src/moderator/moderator.controller.spec.ts
@@ -1,0 +1,39 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ServiceUnavailableException } from '@nestjs/common';
+import { ModeratorController } from './moderator.controller';
+import { ModeratorService } from './moderator.service';
+
+/**
+ * Unit tests for ModeratorController.
+ *
+ * Issue #1038 — GET /v1/moderator delegates to ModeratorService and returns
+ * its response (or the 503 when the address is unconfigured).
+ */
+describe('ModeratorController', () => {
+  let controller: ModeratorController;
+  let moderatorService: jest.Mocked<ModeratorService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ModeratorController],
+      providers: [{ provide: ModeratorService, useValue: { getModerator: jest.fn() } }],
+    }).compile();
+
+    controller = module.get(ModeratorController);
+    moderatorService = module.get(ModeratorService);
+  });
+
+  it('returns the moderator address from the service', () => {
+    moderatorService.getModerator.mockReturnValue({ address: 'GABC123' });
+
+    expect(controller.getModerator()).toEqual({ address: 'GABC123' });
+  });
+
+  it('propagates ServiceUnavailableException when the address is unconfigured', () => {
+    moderatorService.getModerator.mockImplementation(() => {
+      throw new ServiceUnavailableException('Moderator address is not configured');
+    });
+
+    expect(() => controller.getModerator()).toThrow(ServiceUnavailableException);
+  });
+});

--- a/Backend/src/moderator/moderator.controller.ts
+++ b/Backend/src/moderator/moderator.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
+import { ApiOperation, ApiOkResponse, ApiServiceUnavailableResponse, ApiTags } from '@nestjs/swagger';
+import { ModeratorService } from './moderator.service';
+import { ModeratorResponseDto } from './dto/moderator-response.dto';
+
+@ApiTags('moderator')
+@Controller({ path: 'moderator', version: '1' })
+export class ModeratorController {
+  constructor(private readonly moderatorService: ModeratorService) {}
+
+  @Get()
+  @SkipThrottle()
+  @ApiOperation({ summary: 'Get the current moderator address' })
+  @ApiOkResponse({ type: ModeratorResponseDto })
+  @ApiServiceUnavailableResponse({ description: 'Moderator address is not configured' })
+  getModerator(): ModeratorResponseDto {
+    return this.moderatorService.getModerator();
+  }
+}

--- a/Backend/src/moderator/moderator.module.ts
+++ b/Backend/src/moderator/moderator.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ModeratorController } from './moderator.controller';
+import { ModeratorService } from './moderator.service';
+
+@Module({
+  controllers: [ModeratorController],
+  providers: [ModeratorService],
+})
+export class ModeratorModule {}

--- a/Backend/src/moderator/moderator.service.spec.ts
+++ b/Backend/src/moderator/moderator.service.spec.ts
@@ -1,0 +1,51 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { ServiceUnavailableException } from '@nestjs/common';
+import { ModeratorService } from './moderator.service';
+
+/**
+ * Unit tests for ModeratorService.
+ *
+ * Issue #1038 — GET /v1/moderator returns the configured moderator address
+ * and fails loudly (503) when none is configured.
+ */
+describe('ModeratorService', () => {
+  let service: ModeratorService;
+  let config: { get: jest.Mock };
+
+  const createService = async (address: string): Promise<ModeratorService> => {
+    config = {
+      get: jest.fn((key: string, fallback?: string) =>
+        key === 'MODERATOR_ADDRESS' ? address : fallback,
+      ),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ModeratorService, { provide: ConfigService, useValue: config }],
+    }).compile();
+
+    return module.get(ModeratorService);
+  };
+
+  it('returns the configured moderator address', async () => {
+    service = await createService('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN');
+
+    expect(service.getModerator()).toEqual({
+      address: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+    });
+  });
+
+  it('reads the address from MODERATOR_ADDRESS', async () => {
+    service = await createService('GABC123');
+
+    service.getModerator();
+
+    expect(config.get).toHaveBeenCalledWith('MODERATOR_ADDRESS', '');
+  });
+
+  it('throws ServiceUnavailableException when no address is configured', async () => {
+    service = await createService('');
+
+    expect(() => service.getModerator()).toThrow(ServiceUnavailableException);
+  });
+});

--- a/Backend/src/moderator/moderator.service.ts
+++ b/Backend/src/moderator/moderator.service.ts
@@ -1,0 +1,22 @@
+import { Injectable, ServiceUnavailableException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ModeratorResponseDto } from './dto/moderator-response.dto';
+
+/**
+ * Issue #1038 — expose the current moderator (contract `get_admin()`)
+ * over the REST API. The address is configuration-backed so it stays a
+ * lightweight, read-only call; the indexer/event-persistence work can later
+ * mirror it into Postgres without changing this contract.
+ */
+@Injectable()
+export class ModeratorService {
+  constructor(private readonly config: ConfigService) {}
+
+  getModerator(): ModeratorResponseDto {
+    const address = this.config.get<string>('MODERATOR_ADDRESS', '') ?? '';
+    if (!address) {
+      throw new ServiceUnavailableException('Moderator address is not configured');
+    }
+    return { address };
+  }
+}


### PR DESCRIPTION
Fixes #1038 — expose on-chain moderation state over the REST API.

## What changed

**GET /v1/gists/:id (and list/create responses) now include is_active and 
eport_count**
- New is_active (BOOLEAN NOT NULL DEFAULT TRUE) and 
eport_count (INTEGER NOT NULL DEFAULT 0) columns on gists, mirrored from the GistRegistry contract's is_active(gist_id) / 
eport_count(gist_id) reads. Sourced from Postgres (kept fresh by the indexer per the dependency issues) — no live chain call on the request path.
- Migration AddGistActivityColumns1750000000003 (adds both columns, with defaults so existing rows stay active until backfilled).
- GistRepository SELECTs (create RETURNING, findById, findByStellarGistId, findNearby) now return both fields.

**New GET /v1/moderator**
- Returns { address } from MODERATOR_ADDRESS (contract get_admin() equivalent, configuration-backed). Returns 503 when unset.
- Dedicated ModeratorModule / ModeratorController / ModeratorService, RESTful at /v1/moderator, skips throttling like the other public GETs.

**Swagger**
- GistResponseDto documents the full single-gist/list response shape (including is_active, 
eport_count, and the existing gist_id/content_cid aliases), wired to POST /v1/gists and GET /v1/gists/:id via @ApiOkResponse.
- ModeratorResponseDto documents GET /v1/moderator.

## Acceptance criteria

- [x] GET /v1/gists/:id includes is_active and 
eport_count
- [x] New endpoint exposes the current moderator address (GET /v1/moderator)
- [x] Swagger (/v1/docs) documents all new/changed response fields (GistResponseDto, ModeratorResponseDto)
- [x] Unit tests cover the new response shape — gists.controller.spec.ts (single/list/create responses), moderator.service.spec.ts, moderator.controller.spec.ts
- [x] 
pm run build && npm run test:cov pass

## Verification (run on this machine)

`
npm run build   -> pass
npm run test:cov -> Test Suites: 15 passed, 15 total | Tests: 95 passed, 1 todo (pre-existing placeholder), 96 total
`

The 1 todo is the pre-existing it.todo placeholder in gists/gist.e2e.spec.ts.

## Notes
- MODERATOR_ADDRESS is optional in env validation; when unset the endpoint returns 503 instead of a misleading empty address.
- Write operations (report submission) are intentionally out of scope (separate issue).