### PR TITLE
fix(security): guarantee backend-submitted posts are always anonymous on-chain (closes #1040)

### DIFF
--- a/Backend/README.md
+++ b/Backend/README.md
@@ -168,12 +168,15 @@ Content-Type: application/json
 
 `authorAddress` is optional — anonymous posting is fully supported.
 
+> **Wallet-Direct Model & On-Chain Anonymity (Issue #1040):**
+> GistPin backend submissions to the Soroban smart contract are **always anonymous** (`author = None`). The `authorAddress` in the request body is preserved solely in Postgres as an off-chain display/filter hint (e.g. for `GET /v1/gists?authorAddress=...`). Signed, on-chain attributed posts will happen directly from the client wallet in a future Wave, as only the caller's wallet can satisfy `require_auth()` for their address on-chain.
+
 **What happens internally:**
 1. Validate + sanitise input
 2. Pin content to IPFS → receive CID
 3. Derive `locationCell` from `(lat, lon)` via geohash
-4. Submit `post_gist(author, locationCell, contentHash)` to Soroban
-5. Persist the record in Postgres
+4. Submit `post_gist(None, locationCell, contentHash)` anonymously to Soroban
+5. Persist the record (with optional off-chain `author_address` hint) in Postgres
 6. Return the created gist
 
 ---

--- a/Backend/src/gists/dto/create-gist.dto.ts
+++ b/Backend/src/gists/dto/create-gist.dto.ts
@@ -21,7 +21,8 @@ export class CreateGistDto {
   lon: number;
 
   @ApiPropertyOptional({
-    description: 'Optional Stellar public key of the author (Ed25519, starts with G, 56 chars)',
+    description:
+      'Optional Stellar public key of the author (Ed25519, starts with G, 56 chars). Note: Used strictly as an off-chain display/filter hint. On-chain posts submitted via the backend are always anonymous.',
     example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
   })
   @IsOptional()

--- a/Backend/src/gists/gists.service.spec.ts
+++ b/Backend/src/gists/gists.service.spec.ts
@@ -90,7 +90,7 @@ describe('GistsService', () => {
   // create
   // ──────────────────────────────────────────────────────────────────────────
   describe('create', () => {
-    it('sanitizes, encodes, pins IPFS, posts Soroban, and inserts in a transaction', async () => {
+    it('sanitizes, encodes, pins IPFS, posts Soroban anonymously, and inserts in a transaction', async () => {
       const created = buildGist();
       gistRepository.create.mockResolvedValue(created);
 
@@ -110,6 +110,17 @@ describe('GistsService', () => {
       });
       expect(managerArg).toEqual({});
       expect(result).toBe(created);
+    });
+
+    // Issue #1040 — backend-submitted posts are always anonymous on-chain
+    it('always passes undefined/None author to sorobanService.postGist even if authorAddress is supplied', async () => {
+      const sorobanService = (service as any).sorobanService;
+      gistRepository.create.mockResolvedValue(buildGist());
+
+      await service.create(buildDto({ authorAddress: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN' }));
+
+      expect(sorobanService.postGist).toHaveBeenCalledTimes(1);
+      expect(sorobanService.postGist).toHaveBeenCalledWith('s1t7d8c', 'Qmrealcid', undefined);
     });
 
     // Issue #604 — expires_at is set based on ttlHours

--- a/Backend/src/gists/gists.service.ts
+++ b/Backend/src/gists/gists.service.ts
@@ -53,7 +53,9 @@ export class GistsService {
     });
 
     const author = dto.authorAddress;
-    const { gistId, txHash } = await this.sorobanService.postGist(locationCell, cid, author);
+    // Issue #1040: Guarantee backend-submitted posts are always anonymous on-chain (author = undefined / None).
+    // Client-supplied authorAddress is strictly an off-chain display/filter hint.
+    const { gistId, txHash } = await this.sorobanService.postGist(locationCell, cid, undefined);
 
     this.logger.log(`Gist posted → cell=${locationCell} cid=${cid} gistId=${gistId}`);
 


### PR DESCRIPTION
## Description
Closes #1040.

This PR implements the security guarantee that all backend-submitted posts to the Soroban on-chain `GistRegistry` contract are provably anonymous (`author = None`).

### Context & Changes
1. **On-Chain Anonymity Guarantee (`gists.service.ts`)**:
   - In `GistsService.create()`, `this.sorobanService.postGist(locationCell, cid, undefined)` is now explicitly invoked with `undefined` for `author` instead of passing client-supplied `dto.authorAddress`.
   - The caller's `authorAddress` is preserved strictly in Postgres as an off-chain display/filter hint.
2. **DTO & Schema Documentation (`create-gist.dto.ts`)**:
   - Updated `@ApiPropertyOptional` description to clearly document that `authorAddress` is an off-chain hint and all backend-relayed on-chain posts remain anonymous.
3. **Documentation (`Backend/README.md`)**:
   - Added documentation explaining the wallet-direct model: signed posts that require on-chain authorization will be submitted directly via user wallets in future Waves, while backend-relayed submissions remain strictly anonymous.
4. **Regression Tests (`gists.service.spec.ts`)**:
   - Added a dedicated test asserting that submitting a request with `authorAddress` never passes the author address to `sorobanService.postGist` (always passes `undefined`).

### Acceptance Criteria Checklist
- [x] The backend's `post_gist` calls are provably always anonymous (`author = None`) — regardless of request body contents.
- [x] A regression test asserts this (mock `SorobanService` and assert call arguments).
- [x] `Backend/README.md` documents the wallet-direct model.
- [x] `npm run build` and `npm run test` pass with 100% success across all test suites.
