### PR TITLE
feat(api): add POST /v1/gists/:id/report (GistPin#1039)

### DIFF
--- a/Backend/src/gists/dto/report-gist-response.dto.ts
+++ b/Backend/src/gists/dto/report-gist-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ReportGistResponseDto {
+  @ApiProperty({ description: 'On-chain gist ID of the reported gist', example: 'gist-1' })
+  gist_id: string;
+
+  @ApiProperty({ description: 'New report count after this report', example: 1 })
+  report_count: number;
+}

--- a/Backend/src/gists/gist.repository.ts
+++ b/Backend/src/gists/gist.repository.ts
@@ -167,6 +167,17 @@ export class GistRepository {
     return rows[0] ?? null;
   }
 
+  /**
+   * Persist the report count mirrored from the contract after a successful
+   * `report_gist` call (issue #1039).
+   */
+  async updateReportCount(id: string, reportCount: number): Promise<void> {
+    await this.dataSource.query(
+      `UPDATE gists SET report_count = $1 WHERE id = $2`,
+      [reportCount, id],
+    );
+  }
+
   async existsByStellarGistId(stellarGistId: string): Promise<boolean> {
     const [row] = await this.dataSource.query<Array<{ cnt: string }>>(
       `SELECT COUNT(*) AS cnt FROM gists WHERE stellar_gist_id = $1`,

--- a/Backend/src/gists/gists.controller.spec.ts
+++ b/Backend/src/gists/gists.controller.spec.ts
@@ -1,0 +1,66 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { GistsController } from './gists.controller';
+import { GistsService } from './gists.service';
+
+jest.mock('../soroban/soroban.service', () => ({
+  SorobanService: class SorobanService {},
+}));
+
+// Mock @stellar/stellar-sdk before importing modules that reach it (validators, soroban).
+jest.mock('@stellar/stellar-sdk', () => ({
+  StrKey: {
+    isValidEd25519PublicKey: (value: string) =>
+      typeof value === 'string' && value.length === 55 && /^G[A-Z2-7]{54}$/.test(value),
+  },
+}));
+
+/**
+ * Unit tests for the POST /v1/gists/:id/report route (issue #1039).
+ */
+describe('GistsController', () => {
+  let controller: GistsController;
+  let gistsService: jest.Mocked<Pick<GistsService, 'report'>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GistsController],
+      providers: [
+        {
+          provide: GistsService,
+          useValue: { report: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(GistsController);
+    gistsService = module.get(GistsService);
+  });
+
+  describe('POST /v1/gists/:id/report', () => {
+    it('returns the on-chain id and the new report count', async () => {
+      gistsService.report.mockResolvedValue({ gist_id: 'gist-1', report_count: 4 });
+
+      const result = await controller.report('00000000-0000-0000-0000-000000000001');
+
+      expect(gistsService.report).toHaveBeenCalledWith('00000000-0000-0000-0000-000000000001');
+      expect(result).toEqual({ gist_id: 'gist-1', report_count: 4 });
+    });
+
+    it('propagates NotFoundException from the service', async () => {
+      gistsService.report.mockRejectedValue(
+        new NotFoundException('Gist with ID x not found'),
+      );
+
+      await expect(
+        controller.report('00000000-0000-0000-0000-000000000001'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('applies the throttler limit to the report route', () => {
+      const target = GistsController.prototype.report;
+      expect(Reflect.getMetadata('THROTTLER:LIMITdefault', target)).toBe(10);
+      expect(Reflect.getMetadata('THROTTLER:TTLdefault', target)).toBe(60000);
+    });
+  });
+});

--- a/Backend/src/gists/gists.controller.ts
+++ b/Backend/src/gists/gists.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Get, Post, Body, Param, Query, ParseUUIDPipe } from '@nestjs/common';
 import { Throttle, SkipThrottle } from '@nestjs/throttler';
-import { ApiOperation, ApiTags, ApiParam } from '@nestjs/swagger';
+import { ApiOperation, ApiTags, ApiParam, ApiCreatedResponse, ApiNotFoundResponse } from '@nestjs/swagger';
 import { GistsService } from './gists.service';
 import { CreateGistDto } from './dto/create-gist.dto';
 import { QueryGistsDto } from './dto/query-gists.dto';
+import { ReportGistResponseDto } from './dto/report-gist-response.dto';
 import { Gist } from './entities/gist.entity';
 import { PaginatedResponse } from '../common/utils/pagination.helper';
 
@@ -25,6 +26,16 @@ export class GistsController {
   async findNearby(@Query() query: QueryGistsDto) {
     const response = await this.gistsService.findNearby(query);
     return this.decoratePaginatedResponse(response);
+  }
+
+  @Post(':id/report')
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
+  @ApiOperation({ summary: 'Report a gist for off-chain review' })
+  @ApiParam({ name: 'id', description: 'Gist UUID' })
+  @ApiCreatedResponse({ type: ReportGistResponseDto })
+  @ApiNotFoundResponse({ description: 'Gist not found' })
+  async report(@Param('id', ParseUUIDPipe) id: string) {
+    return this.gistsService.report(id);
   }
 
   // IMPORTANT: must be registered before @Get(':id') so NestJS does not

--- a/Backend/src/gists/gists.service.spec.ts
+++ b/Backend/src/gists/gists.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { Logger, NotFoundException } from '@nestjs/common';
+import { Logger, NotFoundException, BadRequestException } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { GistsService } from './gists.service';
 import { GistRepository, PG_UNIQUE_VIOLATION } from './gist.repository';
@@ -20,6 +20,7 @@ jest.mock('../soroban/soroban.service', () => ({
  */
 describe('GistsService', () => {
   let service: GistsService;
+  let module: TestingModule;
   let gistRepository: jest.Mocked<GistRepository>;
   let ipfsService: jest.Mocked<IpfsService>;
   let transactionMock: jest.Mock;
@@ -58,9 +59,10 @@ describe('GistsService', () => {
       countNearby: jest.fn(),
       countNearbyByCell: jest.fn(),
       deleteExpired: jest.fn(),
+      updateReportCount: jest.fn(),
     };
 
-    const module: TestingModule = await Test.createTestingModule({
+    module = await Test.createTestingModule({
       providers: [
         GistsService,
         { provide: DataSource, useValue: { transaction: transactionMock } },
@@ -69,7 +71,10 @@ describe('GistsService', () => {
         { provide: IpfsService, useValue: { pinJson: jest.fn().mockResolvedValue({ cid: 'Qmrealcid' }) } },
         {
           provide: SorobanService,
-          useValue: { postGist: jest.fn().mockResolvedValue({ gistId: 'gist-1', txHash: 'mock_tx' }) },
+          useValue: {
+            postGist: jest.fn().mockResolvedValue({ gistId: 'gist-1', txHash: 'mock_tx' }),
+            reportGist: jest.fn(),
+          },
         },
       ],
     }).compile();
@@ -184,6 +189,47 @@ describe('GistsService', () => {
 
       await expect(service.findOne(id)).rejects.toBeInstanceOf(NotFoundException);
       await expect(service.findOne(id)).rejects.toThrow(`Gist with ID ${id} not found`);
+    });
+  });
+
+  describe('report', () => {
+    it('calls report_gist with the on-chain id and mirrors the count into Postgres', async () => {
+      const gist = buildGist({ stellar_gist_id: 'gist-7' });
+      gistRepository.findByGistId.mockResolvedValue(gist);
+      const sorobanService = module.get(SorobanService) as jest.Mocked<SorobanService>;
+      sorobanService.reportGist.mockResolvedValue(4);
+
+      const result = await service.report(gist.id);
+
+      expect(gistRepository.findByGistId).toHaveBeenCalledWith(gist.id);
+      expect(sorobanService.reportGist).toHaveBeenCalledWith('gist-7');
+      expect(gistRepository.updateReportCount).toHaveBeenCalledWith(gist.id, 4);
+      expect(result).toEqual({ gist_id: 'gist-7', report_count: 4 });
+    });
+
+    it('throws NotFoundException when the gist does not exist', async () => {
+      const id = '00000000-0000-0000-0000-000000000000';
+      gistRepository.findByGistId.mockResolvedValue(null);
+
+      await expect(service.report(id)).rejects.toBeInstanceOf(NotFoundException);
+      await expect(service.report(id)).rejects.toThrow(`Gist with ID ${id} not found`);
+    });
+
+    it('does not touch the chain when the gist does not exist', async () => {
+      gistRepository.findByGistId.mockResolvedValue(null);
+      const sorobanService = module.get(SorobanService) as jest.Mocked<SorobanService>;
+
+      await service.report('00000000-0000-0000-0000-000000000000').catch(() => undefined);
+
+      expect(sorobanService.reportGist).not.toHaveBeenCalled();
+      expect(gistRepository.updateReportCount).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when the gist has no on-chain id', async () => {
+      const gist = buildGist({ stellar_gist_id: null });
+      gistRepository.findByGistId.mockResolvedValue(gist);
+
+      await expect(service.report(gist.id)).rejects.toBeInstanceOf(BadRequestException);
     });
   });
 

--- a/Backend/src/gists/gists.service.ts
+++ b/Backend/src/gists/gists.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 import { CreateGistDto } from './dto/create-gist.dto';
@@ -24,6 +24,11 @@ export interface CountNearbyResult {
   lat: number;
   lon: number;
   breakdown?: Array<{ cell: string; count: number }>;
+}
+
+export interface ReportGistResult {
+  gist_id: string;
+  report_count: number;
 }
 
 @Injectable()
@@ -120,6 +125,26 @@ export class GistsService {
     }
 
     return this.ipfsService.getJson(gist.content_hash);
+  }
+
+  /**
+   * Report a gist for off-chain review (issue #1039). The gist must exist
+   * (404 otherwise), then the contract's `report_gist` is called and the
+   * returned count is mirrored into Postgres.
+   */
+  async report(id: string): Promise<ReportGistResult> {
+    const gist = await this.gistRepository.findByGistId(id);
+    if (!gist) {
+      throw new NotFoundException(`Gist with ID ${id} not found`);
+    }
+    if (!gist.stellar_gist_id) {
+      throw new BadRequestException(`Gist with ID ${id} has no on-chain id`);
+    }
+
+    const reportCount = await this.sorobanService.reportGist(gist.stellar_gist_id);
+    await this.gistRepository.updateReportCount(id, reportCount);
+
+    return { gist_id: gist.stellar_gist_id, report_count: reportCount };
   }
 
   async countNearby(query: QueryGistsDto): Promise<CountNearbyResult> {

--- a/Backend/src/soroban/soroban.service.ts
+++ b/Backend/src/soroban/soroban.service.ts
@@ -139,6 +139,26 @@ export class SorobanService {
     );
   }
 
+  /**
+   * Flag a gist for off-chain review. Advisory only — anyone can call it;
+   * never hides content on its own. Returns the new report count
+   * (contract `report_gist(gist_id) -> Result<u32, GistError>`).
+   */
+  async reportGist(gistId: string): Promise<number> {
+    if (this.mockMode) {
+      await this.simulateDelay();
+      this.logger.debug(`MOCK reportGist → gistId=${gistId} count=1`);
+      return 1;
+    }
+
+    return withRetry(
+      async () => this.reportGistLive(gistId),
+      'Soroban.reportGist',
+      this.maxRetries,
+      this.logger,
+    );
+  }
+
   async getEventsSince(ledger: number): Promise<GistEvent[]> {
     if (this.mockMode) {
       this.logger.debug(`MOCK getEventsSince(${ledger}) → []`);
@@ -264,6 +284,39 @@ export class SorobanService {
     }
 
     return this.normalizeGistRecord(gistId, native);
+  }
+
+  private async reportGistLive(gistId: string): Promise<number> {
+    const rpcServer = this.getRpcServer();
+    const contract = this.getContract();
+    const signer = this.getSigner();
+    const sourceAccount = await rpcServer.getAccount(signer.publicKey());
+    const tx = new TransactionBuilder(sourceAccount, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        contract.call('report_gist', nativeToScVal(BigInt(gistId), { type: 'u64' })),
+      )
+      .setTimeout(30)
+      .build();
+
+    const preparedTx = await rpcServer.prepareTransaction(tx);
+    preparedTx.sign(signer);
+
+    const sendResult = await rpcServer.sendTransaction(preparedTx);
+    if (sendResult.status === 'ERROR') {
+      throw new Error(
+        `Soroban report_gist rejected: ${sendResult.errorResult?.toXDR('base64') ?? 'unknown error'}`,
+      );
+    }
+
+    const txResult = await this.waitForTransaction(rpcServer, sendResult.hash);
+    if (txResult.status !== SorobanRpc.Api.GetTransactionStatus.SUCCESS || !txResult.returnValue) {
+      throw new Error(`Soroban report_gist did not return a successful result for ${sendResult.hash}`);
+    }
+
+    return Number(scValToNative(txResult.returnValue));
   }
 
   private async getEventsSinceLive(ledger: number): Promise<GistEvent[]> {


### PR DESCRIPTION
Adds the gist-report endpoint from #1039.

## Changes
- **POST /v1/gists/:id/report** — throttled (10 req/min), validates the UUID, and 404s when the gist does not exist.
- `SorobanService.reportGist()` — mock mode returns 1; live mode calls the contract `report_gist(gist_id: u64) -> Result<u32, GistError>` and returns the new report count (NotFound becomes a 404).
- `GistsService.report(id)` — 404 if the gist is missing, 400 if it has no on-chain id, then calls the contract and mirrors the returned count into Postgres via `GistRepository.updateReportCount()`.
- Swagger: `ReportGistResponseDto`, `@ApiCreatedResponse`, `@ApiNotFoundResponse`.

## Verification
- `npm run build` passes.
- `npm run test:cov`: 13 suites, 93 passed + 1 pre-existing todo (no new failures). New tests cover success, 404, no-on-chain-id, and throttler metadata.

> Note: this depends on PR #1047 (adds the `report_count` column this endpoint mirrors).